### PR TITLE
Multi-config CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,17 @@ jobs:
         include:
           - { name: "GCC 12 - C++20",    os: ubuntu-22.04, cc: gcc-12, cxx: g++-12, cxxstd: '20', install: g++-12 }
           - { name: "GCC 11 - C++20",    os: ubuntu-22.04, cc: gcc-11, cxx: g++-11, cxxstd: 20, install: g++-11 }
-          - { name: "GCC 10 - C++20",    os: ubuntu-22.04, cc: gcc-10, cxx: g++-10, cxxstd: 20, install: g++-10 }
-          - { name: "GCC 9  - C++20",    os: ubuntu-22.04, cc: gcc-9,  cxx: g++-9,  cxxstd: 20, install: g++-9 }
 
-          - { name: "Clang 14 - C++20",  os: ubuntu-22.04, cc: clang-14, cxx: clang++-14, cxxstd: 20, install: clang-14 }
-          - { name: "Clang 13 - C++20",  os: ubuntu-22.04, cc: clang-13, cxx: clang++-13, cxxstd: 20, install: clang-13 }
-          - { name: "Clang 12 - C++20",  os: ubuntu-22.04, cc: clang-12, cxx: clang++-12, cxxstd: 20, install: clang-12 }
+          # no <source_location>
+          # - { name: "GCC 10 - C++20",    os: ubuntu-22.04, cc: gcc-10, cxx: g++-10, cxxstd: 20, install: g++-10 }
+          # - { name: "GCC 9  - C++20",    os: ubuntu-22.04, cc: gcc-9,  cxx: g++-9,  cxxstd: 20, install: g++-9 }
+
+          - { name: "Clang 15 - C++20",  os: ubuntu-22.04, cc: clang-15, cxx: clang++-15, cxxstd: 20, install: clang-15 }
+
+          # no <source_location>
+          # - { name: "Clang 14 - C++20",  os: ubuntu-22.04, cc: clang-14, cxx: clang++-14, cxxstd: 20, install: clang-14 }
+          # - { name: "Clang 13 - C++20",  os: ubuntu-22.04, cc: clang-13, cxx: clang++-13, cxxstd: 20, install: clang-13 }
+          # - { name: "Clang 12 - C++20",  os: ubuntu-22.04, cc: clang-12, cxx: clang++-12, cxxstd: 20, install: clang-12 }
 
           # There's no LLVM container for MSVC yet
           # - { name: "MSVC 14.3 - C++20", os: windows-2022, cxxstd: '17,20', cmake_args: -G "Visual Studio 17 2022" -A x64, }
@@ -41,16 +46,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Environment
-        run: |
-          for dir in /usr/include/llvm /usr/local/include/llvm /usr/local/clang+llvm/include/llvm /usr/include/clang /usr/local/include/clang /usr/local/clang+llvm/include/clang
-          do
-          if [ -d "$dir" ]; then
-            find "$dir" -type f -name "*.h" -print
-          else
-            echo "$dir directory does not exist."
-          fi
-          done
+#      - name: Environment
+#        run: |
+#          for dir in /usr/include/llvm /usr/local/include/llvm /usr/local/clang+llvm/include/llvm /usr/include/clang /usr/local/include/clang /usr/local/clang+llvm/include/clang
+#          do
+#          if [ -d "$dir" ]; then
+#            find "$dir" -type f -name "*.h" -print
+#          else
+#            echo "$dir directory does not exist."
+#          fi
+#          done
 
       - name: Install packages
         if: ${{ matrix.install }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,8 @@
 #
 #-------------------------------------------------
 
-cmake_minimum_required(VERSION 3.25.2)
+cmake_minimum_required(VERSION 3.13)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-
-# VFALCO this is to link optimized llvm for debug builds
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL" CACHE STRING "")
-
 project(
     MrDox
     VERSION 1.0.0
@@ -28,39 +24,14 @@ project(
     LANGUAGES CXX C
 )
 
-#-------------------------------------------------
-#
-# Toolchain settings
-#
-#-------------------------------------------------
-
 set(BUILD_SHARED_LIBS OFF CACHE STRING "")
 set(CMAKE_CXX_EXTENSIONS OFF CACHE STRING "")
+# VFALCO this is to link optimized llvm for debug builds
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL" CACHE STRING "")
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON CACHE STRING "")
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL ON CACHE STRING "")
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO ON CACHE STRING "")
-
-# Windows, Win64
-if(WIN32)
-    add_definitions(
-        -D_WIN32_WINNT=0x0601
-        -D_CRT_SECURE_NO_WARNINGS
-        -D_SILENCE_CXX20_CISO646_REMOVED_WARNING
-    )
-endif()
-
-# cl.exe
-if(MSVC)
-    add_compile_options(
-        /permissive-    # strict C++
-        /W4             # enable all warnings
-        /MP             # multi-processor compilation
-        /EHsc           # C++ Exception handling
-    )
-    add_definitions(
-        -D_ITERATOR_DEBUG_LEVEL=0
-    )
-endif()
+option(MRDOX_BUILD_TESTS "Build tests" ON)
 
 #-------------------------------------------------
 #
@@ -77,32 +48,36 @@ add_definitions(${LLVM_DEFINITIONS})
 llvm_map_components_to_libnames(llvm_libs support core irreader)
 unset(CMAKE_FOLDER)
 
-if (LLVM_FOUND)
-    message(STATUS "LLVM found in ${LLVM_INCLUDE_DIRS}")
-endif ()
-if (Clang_FOUND)
-    message(STATUS "Clang found in ${CLANG_INCLUDE_DIRS}")
-endif ()
-
 #-------------------------------------------------
 #
 # Library
 #
 #-------------------------------------------------
 
-file(GLOB_RECURSE LIB_INCLUDES CONFIGURE_DEPENDS
-    include/*.hpp)
-
+file(GLOB_RECURSE LIB_INCLUDES CONFIGURE_DEPENDS include/*.hpp)
 file(GLOB_RECURSE LIB_SOURCES CONFIGURE_DEPENDS
     source/lib/*.h
     source/lib/*.hpp
     source/lib/*.cpp
     source/lib/*.natvis)
 
+add_library(mrdox_lib ${LIB_INCLUDES} ${LIB_SOURCES})
+target_compile_features(mrdox_lib PUBLIC cxx_std_20)
+target_include_directories(mrdox_lib PUBLIC
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>"
+    # VFALCO source/lib shouldn't be here it is a hack
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/source/lib>")
+
+# LLVM
+target_link_libraries(mrdox_lib PUBLIC ${llvm_libs})
+target_include_directories(mrdox_lib SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS})
+
+# Clang
 if (CLANG_SIMPLE_LIBS)
-    set(clang_libs LLVM clang clang-cpp)
+    target_link_libraries(mrdox_lib PUBLIC LLVM clang clang-cpp)
 else()
-    set(clang_libs
+    target_link_libraries(mrdox_lib
+        PUBLIC
         clangAST
         clangBasic
         clangFrontend
@@ -111,22 +86,33 @@ else()
         clangToolingCore
         clangToolingInclusions)
 endif()
+target_include_directories(mrdox_lib SYSTEM PUBLIC ${CLANG_INCLUDE_DIRS})
 
-add_library(mrdox_lib ${LIB_INCLUDES} ${LIB_SOURCES})
-target_compile_features(mrdox_lib PUBLIC cxx_std_20)
-target_include_directories(mrdox_lib PUBLIC
-    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>"
-    # VFALCO source/lib shouldn't be here it is a hack
-    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/source/lib>"
-    ${LLVM_INCLUDE_DIRS}
-    ${CLANG_INCLUDE_DIRS}
-    PRIVATE
-    "${PROJECT_SOURCE_DIR}/source/lib")
-
-target_link_libraries(mrdox_lib
-    PUBLIC
-    ${llvm_libs}
-    ${clang_libs})
+# Windows, Win64
+if (WIN32)
+    target_compile_definitions(
+        mrdox_lib
+        PUBLIC
+        -D_WIN32_WINNT=0x0601
+        -D_CRT_SECURE_NO_WARNINGS
+        -D_SILENCE_CXX20_CISO646_REMOVED_WARNING
+    )
+    get_target_property(LLVM_CONFIGURATION_TYPE LLVMCore IMPORTED_CONFIGURATIONS)
+    if (LLVM_CONFIGURATION_TYPE STREQUAL RELWITHDEBINFO)
+        target_compile_definitions(mrdox_lib PUBLIC -D_ITERATOR_DEBUG_LEVEL=0)
+        target_compile_options(mrdox_lib PUBLIC /MD)
+    endif()
+    if(MSVC)
+        target_compile_options(
+            mrdox_lib
+            PUBLIC
+            /permissive-    # strict C++
+            /W4             # enable all warnings
+            /MP             # multi-processor compilation
+            /EHsc           # C++ Exception handling
+        )
+    endif()
+endif ()
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES CMakeLists.txt)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include PREFIX "" FILES ${LIB_INCLUDES})
@@ -138,16 +124,10 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/source/lib PREFIX "source" FILES $
 #
 #-------------------------------------------------
 
-file(GLOB_RECURSE TOOL_SOURCES CONFIGURE_DEPENDS
-    source/tool/*.cpp
-    source/tool/*.hpp)
-
+file(GLOB_RECURSE TOOL_SOURCES CONFIGURE_DEPENDS source/tool/*.cpp source/tool/*.hpp)
 add_executable(mrdox ${TOOL_SOURCES})
 target_link_libraries(mrdox PRIVATE mrdox_lib)
-
-target_include_directories(mrdox
-    PRIVATE
-    ${PROJECT_SOURCE_DIR}/source/tool)
+target_include_directories(mrdox PRIVATE source/tool)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES CMakeLists.txt)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/source/tool PREFIX "" FILES ${TOOL_SOURCES})
@@ -158,16 +138,16 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/source/tool PREFIX "" FILES ${TOOL
 #
 #-------------------------------------------------
 
-file(GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS
-    source/tests/*.cpp
-    source/tests/*.hpp)
-enable_testing()
-add_executable(mrdox_tests ${TEST_SOURCES})
-target_link_libraries(mrdox_tests PRIVATE mrdox_lib ${llvm_libs})
-target_include_directories(mrdox_tests PRIVATE ${PROJECT_SOURCE_DIR}/source/tests)
-add_test(NAME mrdox_tests COMMAND mrdox_tests "${CMAKE_CURRENT_SOURCE_DIR}/testfiles")
-add_test(NAME mrdox_tests_bare COMMAND mrdox_tests "${CMAKE_CURRENT_SOURCE_DIR}/testfiles/bare")
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES CMakeLists.txt)
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/source/tests PREFIX "" FILES ${TEST_SOURCES})
+if (MRDOX_BUILD_TESTS)
+    file(GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS source/tests/*.cpp source/tests/*.hpp)
+    enable_testing()
+    add_executable(mrdox_tests ${TEST_SOURCES})
+    target_link_libraries(mrdox_tests PRIVATE mrdox_lib ${llvm_libs})
+    target_include_directories(mrdox_tests PRIVATE ${PROJECT_SOURCE_DIR}/source/tests)
+    add_test(NAME mrdox_tests COMMAND mrdox_tests "${CMAKE_CURRENT_SOURCE_DIR}/testfiles")
+    add_test(NAME mrdox_tests_bare COMMAND mrdox_tests "${CMAKE_CURRENT_SOURCE_DIR}/testfiles/bare")
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES CMakeLists.txt)
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/source/tests PREFIX "" FILES ${TEST_SOURCES})
+endif()
 
 #-------------------------------------------------

--- a/CMakeSettings.json.in
+++ b/CMakeSettings.json.in
@@ -1,0 +1,36 @@
+{
+  "configurations": [
+    {
+      "name": "Debug",
+      "generator": "Visual Studio 17 2022 Win64",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}/cmake-build-${name}-msvc",
+      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=\"C:\\Users\\vinnie\\src\\llvm-install\"",
+      "buildCommandArgs": ""
+    },
+    {
+      "name": "DebugWithRel",
+      "generator": "Visual Studio 17 2022 Win64",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}/cmake-build-${name}-msvc",
+      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=\"C:\\Users\\vinnie\\src\\llvm-install\\RelWithDebInfo\"",
+      "buildCommandArgs": ""
+    },
+    {
+      "name": "RelWithDebInfo",
+      "generator": "Visual Studio 17 2022 Win64",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${workspaceRoot}/cmake-build-${name}-msvc",
+      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=\"C:\\Users\\vinnie\\src\\llvm-install\\RelWithDebInfo\"",
+      "buildCommandArgs": ""
+    },
+    {
+      "name": "Release",
+      "generator": "Visual Studio 17 2022 Win64",
+      "configurationType": "Release",
+      "buildRoot": "${workspaceRoot}/cmake-build-${name}-msvc",
+      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=\"C:\\Users\\vinnie\\src\\llvm-install\\Release\"",
+      "buildCommandArgs": ""
+    }
+  ]
+}

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
-# Mr. Dox
+= Mr. Dox
 
-## Install
+== Install
 
 This library depends on a recent version of LLVM.
 Here are the instructions to install LVVM with the settings required by this project.
@@ -28,17 +28,21 @@ cmake --build . -j <threads>
 cmake --install .
 ----
 
+== Comparison
+
 === Doxygen:
+
 * tries to work for many languages
 * use the inferior libclang API
 * old program with lots of technical debt
 * not written by me
 
 === MrDox:
+
 * narrow and deep focus on C++ only
 * uses clang's unstable libtooling API:
 ** Understands ALL C++: if clang can compile it, MrDox knows about it
 ** This includes up to C++20 and even experimental things in C++23
-* brand new program with no technical debt
+* brand-new program with no technical debt
 * written by me
 

--- a/include/mrdox/Corpus.hpp
+++ b/include/mrdox/Corpus.hpp
@@ -118,8 +118,8 @@ public:
 
     /** Build the intermediate representation of the code being documented.
     */
-    static
     [[nodiscard]]
+    static
     std::unique_ptr<Corpus>
     build(
         tooling::ToolExecutor& ex,

--- a/source/lib/Error.cpp
+++ b/source/lib/Error.cpp
@@ -43,13 +43,13 @@ public:
     }
 
     std::error_code
-    convertToErrorCode() const
+    convertToErrorCode() const override
     {
         return llvm::inconvertibleErrorCode();
     }
 
     void const*
-    dynamicClassID() const
+    dynamicClassID() const override
     {
         return this;
     }


### PR DESCRIPTION
Changes in this PR:

- `ci.yml`: remove GCC <=10 and Clang <=14 because `<source_location>` is not available so the library doesn't support them anymore. All tests are passing again.
- `CMakeLists.txt`:
    - `D_ITERATOR_DEBUG_LEVEL` matches the value of LLVM for multi-configurations. LLVM already uses the default debug level for MSVC, so this wouldn't be necessary in the general case. But a Debug build depending on LLVM compiled with RelWithDebInfo breaks it because the defaults are different. This change will check whatever debug level LLVM is using and apply it to the MrDox library.
    - Minimum version required is set to 3.13 since the most recent feature we use is from 3.13. Setting the `minimum_required` to the latest version instead of the real _minimum_ value required creates unnecessary errors and makes CI slower since now we need to needlessly install a more recent version of CMake. 
    - Returns with the `MRDOX_BUILD_TESTS` option. The convention everyone uses for its default value is [`BUILD_TESTING`](https://cmake.org/cmake/help/latest/module/CTest.html) but I just set it to `ON` so the VS workflow is not broken. This means, of course, anyone building it will build the tests unless they know we changed that convention.
    - Global options were moved to target options so they won't leak to targets where we don't want or can't have them.
- `Corpus.hpp` and `Error.cpp`: fixed small errors that broke GCC.
- `CMakeSettings.json.in`: see below

The current MSVC workflow described in `NOTES.adoc` creates a single multiconfig solution from CMake:

```mermaid
flowchart LR
    CMake[CMakeLists.txt] -->|configure| S[VS Solution]
    S -->|builds| Debug
    S -->|builds| DebugWithRel
    S -->|builds| RelWithDebInfo
    S -->|builds| ...
```

The main problem with that is LLVM-Config.cmake, like most libraries, does not support being imported into multi-config solutions with redirection of targets to the corresponding build type. Thus, all MrDox targets will attempt to link to the same LLVM configuration, which will either fail for conflicting definitions or at least not achieve what we wanted.

A trivial solution is to generate multiple solutions linking to different LLVM configurations and ignore any other potential configurations in the generated solution:

```mermaid
flowchart LR
    CMake[CMakeLists.txt] -->|configure with LLVM Debug| S1[VS Solution - Debug] -->|builds| Debug
    S1 -->|ignore| D1[...]
    CMake[CMakeLists.txt] -->|configure with LLVM RelWithDebInfo| S2[VS Solution - DebugWithRel] -->|builds| DebugWithRel
    S2 -->|ignore| D2[...]
    CMake[CMakeLists.txt] -->|configure with LLVM RelWithDebInfo| S3[VS Solution - RelWithDebInfo] -->|builds| RelWithDebInfo
    S3 -->|ignore| D3[...]
    CMake[CMakeLists.txt] -->|configure with LLVM ...| S4[VS Solution - ...] -->|builds| ...
    S4 -->|ignore| D4[...]
  
```

This works fine and the change in `CMakeLists.txt` to infer the proper debug level should also work fine. 

Some might consider this unnecessarily complex and it makes the workflow a little painful. Another solution is describing these effectively single-configuration solutions in a CMakeSettings.json file in VS and opening the CMake folder directly in VS, which will just do everything for us.

```mermaid
flowchart LR
    CMake[CMakeLists.txt] -->|VS configures it as in CMakeSettings.json and builds| Debug
    CMake[CMakeLists.txt] -->|VS configures it as in CMakeSettings.json and builds| DebugWithRel
    CMake[CMakeLists.txt] -->|VS configures it as in CMakeSettings.json and builds| RelWithDebInfo
    CMake[CMakeLists.txt] -->|VS configures it as in CMakeSettings.json and builds| ...

```

`CMakeSettings.json` describes exactly where each configuration should look for LLVM and will end up doing the same thing under the hood since they are all still using the Visual Studio 17 2022 generator. `CMakeSettings.json.in` includes a template to build the targets with multiple LLVM configurations in VS. It also allows for more configuration variants than a single solution.

`CMakeSettings.json.in` was left as a template to avoid breaking the current workflow. Renaming it `CMakeSettings.json` and adjusting `cmakeCommandArgs` to the correct `llvm-install` should already work. Other options that can be used in this file are [here](https://learn.microsoft.com/en-us/cpp/build/cmakesettings-reference?view=msvc-170).

`CMakeSettings.json` is part of the first VS push towards CMake. There's actually a second push where they [recommend](https://learn.microsoft.com/en-us/cpp/build/customize-cmake-settings?view=msvc-170) to customize the CMake via [`CMakePresets.json`](https://learn.microsoft.com/en-us/cpp/build/cmake-presets-json-reference?view=msvc-170) files. `CMakePresets.json` is more powerful and works outside VS, but it requires some investigation and we don't need any of its functionality at the moment.
