### PR TITLE
Add generate.py to generate enum declarations into tests/py/dcl.enum/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ temp/
 test/
 tests/**/*.adoc
 tests/**/*.bad.xml
+tests/py/

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -1,0 +1,35 @@
+import exrex
+import os
+
+def ToplevelFolder():
+    scriptPath = os.path.realpath(__file__)
+    parentDirectory = os.path.dirname(scriptPath)
+    return os.path.join(parentDirectory, "py")
+
+def EnumDeclarationsFolder():
+    return os.path.join(ToplevelFolder(), "dcl.enum")
+
+
+def GenerateEnumDeclarations():
+    #https://eel.is/c++draft/enum
+    enum_base = "(|: short|: unsigned int|: const long|: const volatile long long|: decltype\(0\))"
+    enumerator_initializer = "(| = 0| = true \? 1,2 : 3| = \!\+\[\]\(\)\{\})"
+    enumerators = " (|(A" + enumerator_initializer + "|A" + enumerator_initializer + ", B " + enumerator_initializer + "),?) "
+    regex = "enum (|EnumName|class EnumName|struct EnumName) " + enum_base + " (\{" + enumerators + "\})? ;"
+    generator = exrex.generate(regex)
+    first = next(generator) #The first entry is "enum    ;", which is not valid. Therefore, we skip it.
+    if first != "enum    ;":
+        raise Exception("We are expecting that the first value is 'enum    ;', which should be skipped. But our expectation is not met. The first value is '" + first + "'.")
+    return generator
+
+
+def GenerateIndexedCppFiles(parentDirectory, fileContents):
+    os.makedirs(parentDirectory, exist_ok=True)
+    for index, aDeclaration in enumerate(fileContents):
+        fileName = str(index) + ".cpp"
+        filePath = os.path.join(parentDirectory, fileName)
+        with open(filePath, "w") as f:
+            f.write(aDeclaration)
+
+
+GenerateIndexedCppFiles(EnumDeclarationsFolder(), GenerateEnumDeclarations())

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -13,7 +13,7 @@ def EnumDeclarationsFolder():
 def GenerateEnumDeclarations():
     #https://eel.is/c++draft/enum
     enum_base = "(|: short|: unsigned int|: const long|: const volatile long long|: decltype\(0\))"
-    enumerator_initializer = "(| = 0| = true \? 1,2 : 3| = \!\+\[\]\(\)\{\})"
+    enumerator_initializer = "(| = 0| = true \? 1,2 : 3)"
     enumerators = " (|(A" + enumerator_initializer + "|A" + enumerator_initializer + ", B " + enumerator_initializer + "),?) "
     regex = "enum (|EnumName|class EnumName|struct EnumName) " + enum_base + " (\{" + enumerators + "\})? ;"
     generator = exrex.generate(regex)

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -17,10 +17,16 @@ def GenerateEnumDeclarations():
     enumerators = " (|(A" + enumerator_initializer + "|A" + enumerator_initializer + ", B " + enumerator_initializer + "),?) "
     regex = "enum (|EnumName|class EnumName|struct EnumName) " + enum_base + " (\{" + enumerators + "\})? ;"
     generator = exrex.generate(regex)
-    first = next(generator) #The first entry is "enum    ;", which is not valid. Therefore, we skip it.
-    if first != "enum    ;":
-        raise Exception("We are expecting that the first value is 'enum    ;', which should be skipped. But our expectation is not met. The first value is '" + first + "'.")
-    return generator
+    declarations = list(generator)
+    # Unfortunately, the regex produces some invalid declarations. We remove them by hand as of now.
+    for invalidDeclaration in ["enum    ;", "enum  : short  ;", "enum  : unsigned int  ;",
+                               "enum  : const long  ;", "enum  : const volatile long long  ;",
+                               "enum  : decltype(0)  ;", "enum EnumName   ;"]:
+        try:
+            declarations.remove(invalidDeclaration)
+        except ValueError:
+            print("The invalid declaration \"" + invalidDeclaration + "\" gets no longer generated, so it can be removed from the list of invalid declarations.")
+    return declarations
 
 
 def GenerateIndexedCppFiles(parentDirectory, fileContents):

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -13,7 +13,7 @@ def EnumDeclarationsFolder():
 def GenerateEnumDeclarations():
     #https://eel.is/c++draft/enum
     enum_base = "(|: short|: unsigned int|: const long|: const volatile long long|: decltype\(0\))"
-    enumerator_initializer = "(| = 0| = true \? 1,2 : 3)"
+    enumerator_initializer = "(| = 0| = true \? 1,2 : 3| = \!\+\[\]\(\)\{\})"
     enumerators = " (|(A" + enumerator_initializer + "|A" + enumerator_initializer + ", B " + enumerator_initializer + "),?) "
     regex = "enum (|EnumName|class EnumName|struct EnumName) " + enum_base + " (\{" + enumerators + "\})? ;"
     generator = exrex.generate(regex)


### PR DESCRIPTION
As we discussed it in [cpplang.slack](https://cpplang.slack.com/archives/C21PKDHSL/p1682283694044249), here is the script to generate C++ declarations. So far it only generates enum declarations. The files will be written to _file-dir_/tests/py/dcl.enum/*.cpp, where _file-dir_ is the directory of the script generate.py. The script uses the python module [exrex](https://github.com/asciimoo/exrex), so please make sure to install it.

Feel free to add a code review or require other changes. In the meantime, I will look into further declarations and how to generate them.