### PR TITLE
Properly render C++20 and C++23 in one line in asciidoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,10 +39,10 @@ cmake --install .
 
 === MrDox:
 
-* narrow and deep focus on C++ only
+* narrow and deep focus on {cpp} only
 * uses clang's unstable libtooling API:
 ** Understands ALL C++: if clang can compile it, MrDox knows about it
-** This includes up to C++20 and even experimental things in C++23
+** This includes up to {cpp}20 and even experimental things in {cpp}23
 * brand-new program with no technical debt
 * written by me
 


### PR DESCRIPTION
Right now the readme says:

> This includes up to C20 and even experimental things in C23

This is due the fact that content between double pluses gets rendered differently. I have zero knowledge about asciiDoctor, but according to https://github.com/asciidoctor/asciidoctor/issues/1864, using `{cpp}` is the according fix.

The "C++" in line 42 gets rendered correctly. But for the sake of consistency, I also replaced it.