### PR TITLE
Add explicit specifier

### DIFF
--- a/include/mrdox/Metadata/Function.hpp
+++ b/include/mrdox/Metadata/Function.hpp
@@ -81,7 +81,9 @@ enum class FnFlags1 : std::uint32_t
     nodiscardSpelling       = 0x00000002 +
                               0x00000004 +
                               0x00000008 +
-                              0x00000010
+                              0x00000010,
+
+    isExplicit              = 0x00000020
 };
 
 // TODO: Expand to allow for documenting templating and default args.

--- a/source/api/AST/Serializer.cpp
+++ b/source/api/AST/Serializer.cpp
@@ -1002,6 +1002,19 @@ getFunctionSpecs(
         //MF->isMoveAssignmentOperator()
         //MF->isOverloadedOperator();
         //MF->isStaticOverloadedOperator();
+
+        if(auto const Ctor = dyn_cast<CXXConstructorDecl>(MF))
+        {
+            I.specs1.set<FnFlags1::isExplicit>(Ctor->getExplicitSpecifier().isSpecified());
+        }
+        else if(auto const Conv = dyn_cast<CXXConversionDecl>(MF))
+        {
+            I.specs1.set<FnFlags1::isExplicit>(Conv->getExplicitSpecifier().isSpecified());
+        }
+    }
+    else if(auto const DG = dyn_cast<CXXDeductionGuideDecl>(D))
+    {
+        I.specs1.set<FnFlags1::isExplicit>(DG->getExplicitSpecifier().isSpecified());
     }
 
     if(auto attr = D->getAttr<WarnUnusedResultAttr>())

--- a/source/api/_XML/XMLWriter.cpp
+++ b/source/api/_XML/XMLWriter.cpp
@@ -220,6 +220,8 @@ visit(
 
         if(I.specs1.get<FnFlags1::isNodiscard>())
             os << "<nodiscard/>";
+        if(I.specs1.get<FnFlags1::isExplicit>())
+            os << "<explicit/>";
 
         // ConstexprSpecKind
         auto CSK = I.specs0.get<

--- a/test-files/old-tests/explicit-conv-operator.cpp
+++ b/test-files/old-tests/explicit-conv-operator.cpp
@@ -1,0 +1,18 @@
+//Test conversion operators that can be "explicit", "explicit(true)", "explicit(false)" and "explicit(EXPR)"
+
+struct Explicit {
+    explicit operator bool();
+};
+
+struct ExplicitFalse {
+    explicit(false) operator bool();
+};
+
+struct ExplicitTrue {
+    explicit(true) operator bool();
+};
+
+template<bool B>
+struct ExplicitExpression {
+    explicit(B) operator bool();
+};

--- a/test-files/old-tests/explicit-conv-operator.xml
+++ b/test-files/old-tests/explicit-conv-operator.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mrdox SYSTEM "mrdox.dtd">
+<mrdox>
+<namespace name="">
+  <struct name="ExplicitFalse" id="Lt5u3k14Z7EBxY7Ike3h9qkJ0fo=">
+    <file path="explicit-conv-operator.cpp" line="7" class="def"/>
+    <function name="operator bool" access="public" id="hJXOxv26Y9uxUYMMVZRsp3Wps4A=">
+      <file path="explicit-conv-operator.cpp" line="8"/>
+      <explicit/>
+      <return name="_Bool"/>
+    </function>
+  </struct>
+  <struct name="Explicit" id="bonobNKGOblPVcRjxpiPan4nYnc=">
+    <file path="explicit-conv-operator.cpp" line="3" class="def"/>
+    <function name="operator bool" access="public" id="64zY8rVu+TzEUayzMrnV65i9nFc=">
+      <file path="explicit-conv-operator.cpp" line="4"/>
+      <explicit/>
+      <return name="_Bool"/>
+    </function>
+  </struct>
+  <struct name="ExplicitTrue" id="htdCGapMsdazR1XkXoanrOCkvDE=">
+    <file path="explicit-conv-operator.cpp" line="11" class="def"/>
+    <function name="operator bool" access="public" id="9tpZWv9eJGfWj37jmTdNTg+gp14=">
+      <file path="explicit-conv-operator.cpp" line="12"/>
+      <explicit/>
+      <return name="_Bool"/>
+    </function>
+  </struct>
+  <struct name="ExplicitExpression" id="ztb0u1Q4SVBUQ0roTOM7MFlUt/o=">
+    <file path="explicit-conv-operator.cpp" line="16" class="def"/>
+    <function name="operator bool" access="public" id="q6N8XkMK9WWWGKNQnlx/o2E1EYc=">
+      <file path="explicit-conv-operator.cpp" line="17"/>
+      <explicit/>
+      <return name="_Bool"/>
+    </function>
+  </struct>
+</namespace>
+</mrdox>

--- a/test-files/old-tests/explicit-ctor.cpp
+++ b/test-files/old-tests/explicit-ctor.cpp
@@ -1,0 +1,30 @@
+//Test constructors that can be "explicit", "explicit(true)", "explicit(false)" and "explicit(EXPR)"
+
+struct Explicit {
+    explicit Explicit();
+    explicit Explicit(const Explicit&);
+    explicit Explicit(Explicit&&) noexcept;
+    explicit Explicit(int, int);
+};
+
+struct ExplicitTrue {
+    explicit(true) ExplicitTrue();
+    explicit(true) ExplicitTrue(const ExplicitTrue&);
+    explicit(true) ExplicitTrue(ExplicitTrue&&) noexcept;
+    explicit(true) ExplicitTrue(int, int);
+};
+
+struct ExplicitFalse {
+    explicit(false) ExplicitFalse();
+    explicit(false) ExplicitFalse(const ExplicitFalse&);
+    explicit(false) ExplicitFalse(ExplicitFalse&&) noexcept;
+    explicit(false) ExplicitFalse(int, int);
+};
+
+template<bool B>
+struct ExplicitExpression {
+    explicit(B) ExplicitExpression();
+    explicit(B) ExplicitExpression(const ExplicitExpression&);
+    explicit(B) ExplicitExpression(ExplicitExpression&&) noexcept;
+    explicit(B) ExplicitExpression(int, int);
+};

--- a/test-files/old-tests/explicit-ctor.xml
+++ b/test-files/old-tests/explicit-ctor.xml
@@ -2,85 +2,96 @@
 <!DOCTYPE mrdox SYSTEM "mrdox.dtd">
 <mrdox>
 <namespace name="">
-  <struct name="ExplFalse" id="HgTptXdtBz1kXtdw8hy0HEpqWm4=">
-    <file path="explicit-ctor.cpp" line="18" class="def"/>
-    <function name="ExplFalse" access="public" id="B1pPQYLa0V0HcSU7YaiAwg7Kmw4=">
-      <file path="explicit-ctor.cpp" line="22"/>
+  <struct name="ExplicitFalse" id="Lt5u3k14Z7EBxY7Ike3h9qkJ0fo=">
+    <file path="explicit-ctor.cpp" line="17" class="def"/>
+    <function name="ExplicitFalse" access="public" id="GVN7KvqFotNClBLUnxR3nnPlH7Y=">
+      <file path="explicit-ctor.cpp" line="18"/>
+      <explicit/>
+    </function>
+    <function name="ExplicitFalse" access="public" id="T0aRgSzz7xtFbPWKv3q57ueIYlI=">
+      <file path="explicit-ctor.cpp" line="21"/>
       <explicit/>
       <param type="int"/>
       <param type="int"/>
     </function>
-    <function name="ExplFalse" access="public" id="2VXMpLH6oHAGQRbo2Opm8XyfpSo=">
+    <function name="ExplicitFalse" access="public" id="gsl+2i8v8v4Lifq3SZ5sFhSfseQ=">
       <file path="explicit-ctor.cpp" line="19"/>
       <explicit/>
+      <param type="const ExplicitFalse &amp;"/>
     </function>
-    <function name="ExplFalse" access="public" id="3mZDVfGXWS6nJDf3gdaHHSqnv3k=">
-      <file path="explicit-ctor.cpp" line="21"/>
-      <explicit/><noexcept/>
-      <param type="ExplFalse &amp;&amp;"/>
-    </function>
-    <function name="ExplFalse" access="public" id="4r43v4bPb6rG6JnImJaFWp+RPCo=">
+    <function name="ExplicitFalse" access="public" id="qXjKOO0FQ3p2vTehkEQl2kIKpFs=">
       <file path="explicit-ctor.cpp" line="20"/>
-      <explicit/>
-      <param type="const ExplFalse &amp;"/>
+      <explicit/><noexcept/>
+      <param type="ExplicitFalse &amp;&amp;"/>
     </function>
   </struct>
-  <struct name="Expl" id="MlugggomKTnBPMKkcBG132APE00=">
+  <struct name="Explicit" id="bonobNKGOblPVcRjxpiPan4nYnc=">
     <file path="explicit-ctor.cpp" line="3" class="def"/>
-    <function name="Expl" access="public" id="LuL7sjn4zJ/FoPPZjNO7rl4brKA=">
-      <file path="explicit-ctor.cpp" line="6"/>
-      <explicit/><noexcept/>
-      <param type="Expl &amp;&amp;"/>
+    <function name="Explicit" access="public" id="CuzDbFSxtCdVcGerq2UySnHF7po=">
+      <file path="explicit-ctor.cpp" line="5"/>
+      <explicit/>
+      <param type="const Explicit &amp;"/>
     </function>
-    <function name="Expl" access="public" id="NmrSUe2oF1grL4YRMYCq3B5Shlg=">
+    <function name="Explicit" access="public" id="JPrjQsrkg+QoApI2wln2eGwCGP4=">
       <file path="explicit-ctor.cpp" line="4"/>
       <explicit/>
     </function>
-    <function name="Expl" access="public" id="WEjatmMEK7KyV9FkK0yzpGP0/Gc=">
-      <file path="explicit-ctor.cpp" line="5"/>
-      <explicit/>
-      <param type="const Expl &amp;"/>
-    </function>
-    <function name="Expl" access="public" id="ug+5jKgsbnRehxpOw693oClmf70=">
+    <function name="Explicit" access="public" id="Oj6cGCOaarVfZXkgsr/pOPOOiFY=">
       <file path="explicit-ctor.cpp" line="7"/>
       <explicit/>
       <param type="int"/>
       <param type="int"/>
     </function>
-  </struct>
-  <struct name="F" id="QXKJEfUwuRJdhdTj5QWZ1AEVUUY=">
-    <file path="explicit-ctor.cpp" line="27" class="def"/>
-    <function name="operator bool" access="public" id="H4xlO5ZFzbW1jvLM/nGJgMCulQk=">
-      <file path="explicit-ctor.cpp" line="30"/>
-      <explicit/>
-      <return name="_Bool"/>
-    </function>
-    <function name="F&lt;N&gt;" access="public" id="QV18E4YBXuJ0o6RepkdSJagth/Q=">
-      <file path="explicit-ctor.cpp" line="28"/>
-      <param type="int"/>
+    <function name="Explicit" access="public" id="saOH3agrCzNHcRhbXHOM0FYFxGc=">
+      <file path="explicit-ctor.cpp" line="6"/>
+      <explicit/><noexcept/>
+      <param type="Explicit &amp;&amp;"/>
     </function>
   </struct>
-  <struct name="ExplTrue" id="6Pyvs2VtiZ/83Djx/NWLOH8P/x8=">
-    <file path="explicit-ctor.cpp" line="11" class="def"/>
-    <function name="ExplTrue&lt;T&gt;" access="public" id="KwaDQkRHYmxUDE1eQCZf/YFiAWQ=">
+  <struct name="ExplicitTrue" id="htdCGapMsdazR1XkXoanrOCkvDE=">
+    <file path="explicit-ctor.cpp" line="10" class="def"/>
+    <function name="ExplicitTrue" access="public" id="Tj9uY+jY7QBYQC8IsjplHuoDgQo=">
       <file path="explicit-ctor.cpp" line="12"/>
       <explicit/>
+      <param type="const ExplicitTrue &amp;"/>
     </function>
-    <function name="ExplTrue&lt;T&gt;" access="public" id="n4aktsCbsMaf2NE3R7SKndOL/rA=">
+    <function name="ExplicitTrue" access="public" id="XCoHYDLlYJYpV6Ut7Ms0GjcQKjM=">
       <file path="explicit-ctor.cpp" line="14"/>
-      <explicit/><noexcept/>
-      <param type="ExplTrue&lt;T&gt; &amp;&amp;"/>
-    </function>
-    <function name="ExplTrue&lt;T&gt;" access="public" id="z5D93vebKh6mOA+2hAV6RhYDy/c=">
-      <file path="explicit-ctor.cpp" line="13"/>
-      <explicit/><noexcept/>
-      <param type="const ExplTrue&lt;T&gt; &amp;"/>
-    </function>
-    <function name="ExplTrue&lt;T&gt;" access="public" id="2c50pLZfEpo1bZjXJGbE0G0ZZew=">
-      <file path="explicit-ctor.cpp" line="15"/>
       <explicit/>
       <param type="int"/>
       <param type="int"/>
+    </function>
+    <function name="ExplicitTrue" access="public" id="iQOO8pEh0iNSnpupVwR9tCVIf8U=">
+      <file path="explicit-ctor.cpp" line="13"/>
+      <explicit/><noexcept/>
+      <param type="ExplicitTrue &amp;&amp;"/>
+    </function>
+    <function name="ExplicitTrue" access="public" id="3sd37ryB4gMx1BgYdDdQzVJFniU=">
+      <file path="explicit-ctor.cpp" line="11"/>
+      <explicit/>
+    </function>
+  </struct>
+  <struct name="ExplicitExpression" id="ztb0u1Q4SVBUQ0roTOM7MFlUt/o=">
+    <file path="explicit-ctor.cpp" line="25" class="def"/>
+    <function name="ExplicitExpression&lt;B&gt;" access="public" id="J31K1hQq31LWiQhVy5ro0V+1pD0=">
+      <file path="explicit-ctor.cpp" line="29"/>
+      <explicit/>
+      <param type="int"/>
+      <param type="int"/>
+    </function>
+    <function name="ExplicitExpression&lt;B&gt;" access="public" id="Ty1Sv+L6at7TykYdCITSQKmXwVs=">
+      <file path="explicit-ctor.cpp" line="27"/>
+      <explicit/>
+      <param type="const ExplicitExpression&lt;B&gt; &amp;"/>
+    </function>
+    <function name="ExplicitExpression&lt;B&gt;" access="public" id="gDoLCstIvgYYJng1jhLOLe/yz+Q=">
+      <file path="explicit-ctor.cpp" line="28"/>
+      <explicit/><noexcept/>
+      <param type="ExplicitExpression&lt;B&gt; &amp;&amp;"/>
+    </function>
+    <function name="ExplicitExpression&lt;B&gt;" access="public" id="s6L5UKI8FLTRiyny1rXgYxG/f/0=">
+      <file path="explicit-ctor.cpp" line="26"/>
+      <explicit/>
     </function>
   </struct>
 </namespace>

--- a/test-files/old-tests/explicit-ctor.xml
+++ b/test-files/old-tests/explicit-ctor.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mrdox SYSTEM "mrdox.dtd">
+<mrdox>
+<namespace name="">
+  <struct name="ExplFalse" id="HgTptXdtBz1kXtdw8hy0HEpqWm4=">
+    <file path="explicit-ctor.cpp" line="18" class="def"/>
+    <function name="ExplFalse" access="public" id="B1pPQYLa0V0HcSU7YaiAwg7Kmw4=">
+      <file path="explicit-ctor.cpp" line="22"/>
+      <explicit/>
+      <param type="int"/>
+      <param type="int"/>
+    </function>
+    <function name="ExplFalse" access="public" id="2VXMpLH6oHAGQRbo2Opm8XyfpSo=">
+      <file path="explicit-ctor.cpp" line="19"/>
+      <explicit/>
+    </function>
+    <function name="ExplFalse" access="public" id="3mZDVfGXWS6nJDf3gdaHHSqnv3k=">
+      <file path="explicit-ctor.cpp" line="21"/>
+      <explicit/><noexcept/>
+      <param type="ExplFalse &amp;&amp;"/>
+    </function>
+    <function name="ExplFalse" access="public" id="4r43v4bPb6rG6JnImJaFWp+RPCo=">
+      <file path="explicit-ctor.cpp" line="20"/>
+      <explicit/>
+      <param type="const ExplFalse &amp;"/>
+    </function>
+  </struct>
+  <struct name="Expl" id="MlugggomKTnBPMKkcBG132APE00=">
+    <file path="explicit-ctor.cpp" line="3" class="def"/>
+    <function name="Expl" access="public" id="LuL7sjn4zJ/FoPPZjNO7rl4brKA=">
+      <file path="explicit-ctor.cpp" line="6"/>
+      <explicit/><noexcept/>
+      <param type="Expl &amp;&amp;"/>
+    </function>
+    <function name="Expl" access="public" id="NmrSUe2oF1grL4YRMYCq3B5Shlg=">
+      <file path="explicit-ctor.cpp" line="4"/>
+      <explicit/>
+    </function>
+    <function name="Expl" access="public" id="WEjatmMEK7KyV9FkK0yzpGP0/Gc=">
+      <file path="explicit-ctor.cpp" line="5"/>
+      <explicit/>
+      <param type="const Expl &amp;"/>
+    </function>
+    <function name="Expl" access="public" id="ug+5jKgsbnRehxpOw693oClmf70=">
+      <file path="explicit-ctor.cpp" line="7"/>
+      <explicit/>
+      <param type="int"/>
+      <param type="int"/>
+    </function>
+  </struct>
+  <struct name="F" id="QXKJEfUwuRJdhdTj5QWZ1AEVUUY=">
+    <file path="explicit-ctor.cpp" line="27" class="def"/>
+    <function name="operator bool" access="public" id="H4xlO5ZFzbW1jvLM/nGJgMCulQk=">
+      <file path="explicit-ctor.cpp" line="30"/>
+      <explicit/>
+      <return name="_Bool"/>
+    </function>
+    <function name="F&lt;N&gt;" access="public" id="QV18E4YBXuJ0o6RepkdSJagth/Q=">
+      <file path="explicit-ctor.cpp" line="28"/>
+      <param type="int"/>
+    </function>
+  </struct>
+  <struct name="ExplTrue" id="6Pyvs2VtiZ/83Djx/NWLOH8P/x8=">
+    <file path="explicit-ctor.cpp" line="11" class="def"/>
+    <function name="ExplTrue&lt;T&gt;" access="public" id="KwaDQkRHYmxUDE1eQCZf/YFiAWQ=">
+      <file path="explicit-ctor.cpp" line="12"/>
+      <explicit/>
+    </function>
+    <function name="ExplTrue&lt;T&gt;" access="public" id="n4aktsCbsMaf2NE3R7SKndOL/rA=">
+      <file path="explicit-ctor.cpp" line="14"/>
+      <explicit/><noexcept/>
+      <param type="ExplTrue&lt;T&gt; &amp;&amp;"/>
+    </function>
+    <function name="ExplTrue&lt;T&gt;" access="public" id="z5D93vebKh6mOA+2hAV6RhYDy/c=">
+      <file path="explicit-ctor.cpp" line="13"/>
+      <explicit/><noexcept/>
+      <param type="const ExplTrue&lt;T&gt; &amp;"/>
+    </function>
+    <function name="ExplTrue&lt;T&gt;" access="public" id="2c50pLZfEpo1bZjXJGbE0G0ZZew=">
+      <file path="explicit-ctor.cpp" line="15"/>
+      <explicit/>
+      <param type="int"/>
+      <param type="int"/>
+    </function>
+  </struct>
+</namespace>
+</mrdox>

--- a/test-files/old-tests/explicit-deduct-guide.cpp
+++ b/test-files/old-tests/explicit-deduct-guide.cpp
@@ -1,0 +1,13 @@
+//Test deduction guides that can be "explicit", "explicit(true)", "explicit(false)" and "explicit(EXPR)"
+
+template<int>
+struct X {};
+
+explicit X(bool) -> X<0>;
+
+explicit(true) X(char) -> X<0>;
+
+explicit(false) X(int) -> X<0>;
+
+template<bool B = true>
+explicit(B) X(long) -> X<0>;

--- a/test-files/old-tests/explicit-deduct-guide.xml
+++ b/test-files/old-tests/explicit-deduct-guide.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mrdox SYSTEM "mrdox.dtd">
+<mrdox>
+<namespace name="">
+  <struct name="X" id="7wllQWhGGsbbeoZVa3gh4d7bcq8=">
+    <file path="explicit-deduct-guide.cpp" line="4" class="def"/>
+  </struct>
+  <function name="&lt;deduction guide for X&gt;" id="AtQyLakD3CjcM24GabAbHMNgVU4=">
+    <file path="explicit-deduct-guide.cpp" line="8"/>
+    <trailing/><explicit/>
+    <return name="X&lt;0&gt;"/>
+    <param type="char"/>
+  </function>
+  <function name="&lt;deduction guide for X&gt;" id="YS/v8XQ/9ShQ2spNAh5EY33PN7s=">
+    <file path="explicit-deduct-guide.cpp" line="13"/>
+    <trailing/><explicit/>
+    <return name="X&lt;0&gt;"/>
+    <param type="long"/>
+    <tparam decl="bool B = true"/>
+  </function>
+  <function name="&lt;deduction guide for X&gt;" id="tkYkUU6H8cbFpCU7yBuvBLkT6dg=">
+    <file path="explicit-deduct-guide.cpp" line="10"/>
+    <trailing/><explicit/>
+    <return name="X&lt;0&gt;"/>
+    <param type="int"/>
+  </function>
+  <function name="&lt;deduction guide for X&gt;" id="2IF4pOfGcA57GQDlE3PJgs7yeUs=">
+    <file path="explicit-deduct-guide.cpp" line="6"/>
+    <trailing/><explicit/>
+    <return name="X&lt;0&gt;"/>
+    <param type="_Bool"/>
+  </function>
+</namespace>
+</mrdox>


### PR DESCRIPTION
Emit `<explicit/>` when the `explicit` specifier is present at a constructor, deduction guide or conversion operator.

As discussed in slack, we will for now always emit `<explicit/>`, no matter if you write `explicit(false)` or `explicit(expr)`.