### PR TITLE
generate github releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
       - master
+      - '*'
+    tags:
+      - "v*.*.*"
 
   pull_request:
     branches:
@@ -16,12 +19,11 @@ concurrency:
 
 jobs:
   build:
-    name: ${{ matrix.name }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { name: "GCC 12 - C++20",    os: ubuntu-22.04, cc: gcc-12, cxx: g++-12, cxxstd: '20', install: g++-12 }
+          - { name: "GCC 12 - C++20",    os: ubuntu-22.04, cc: gcc-12, cxx: g++-12, cxxstd: '20', install: g++-12, github_release: true }
           - { name: "GCC 11 - C++20",    os: ubuntu-22.04, cc: gcc-11, cxx: g++-11, cxxstd: 20, install: g++-11 }
 
           # no <source_location>
@@ -38,24 +40,26 @@ jobs:
           # There's no LLVM container for MSVC yet
           # - { name: "MSVC 14.3 - C++20", os: windows-2022, cxxstd: '17,20', cmake_args: -G "Visual Studio 17 2022" -A x64, }
 
-
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     container:
       image: cppalliance/droneubuntu2204:llvm-731264b
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3
 
-#      - name: Environment
-#        run: |
-#          for dir in /usr/include/llvm /usr/local/include/llvm /usr/local/clang+llvm/include/llvm /usr/include/clang /usr/local/include/clang /usr/local/clang+llvm/include/clang
-#          do
-#          if [ -d "$dir" ]; then
-#            find "$dir" -type f -name "*.h" -print
-#          else
-#            echo "$dir directory does not exist."
-#          fi
-#          done
+      #      - name: Environment
+      #        run: |
+      #          for dir in /usr/include/llvm /usr/local/include/llvm /usr/local/clang+llvm/include/llvm /usr/include/clang /usr/local/include/clang /usr/local/clang+llvm/include/clang
+      #          do
+      #          if [ -d "$dir" ]; then
+      #            find "$dir" -type f -name "*.h" -print
+      #          else
+      #            echo "$dir directory does not exist."
+      #          fi
+      #          done
 
       - name: Install packages
         if: ${{ matrix.install }}
@@ -73,12 +77,25 @@ jobs:
       #     patches: https://github.com/CppAlliance/buffers.git,https://github.com/CppAlliance/http_proto.git,https://github.com/CppAlliance/http_io.git
       #     modules: url,../../../BoostServerTech
 
-      - name: CMake Run (C++${{ matrix.cxxstd }})
-        uses: ./.github/actions/cmake_run
+      - name: CMake Workflow (C++${{ matrix.cxxstd }})
+        uses: alandefreitas/cpp-actions/cmake_workflow@master
         with:
           cxxstd: ${{ matrix.cxxstd }}
           cxx: ${{ matrix.cxx }}
           cc: ${{ matrix.cc }}
+          install-prefix: .local
           extra-args: ${{ format('-D LLVM_ROOT={0} -D Clang_ROOT={0} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON', '/usr/local') }}
           # toolchain: ${{ steps.package-install.outputs.vcpkg_toolchain }}
+
+      - name: Create packages
+        working-directory: ./build
+        run: cpack
+
+      - name: Create GitHub Package Release
+        if: ${{ matrix.github_release && github.event_name == 'push' && (contains(fromJSON('["master", "develop"]'), github.ref_name) || startsWith(github.ref, 'refs/tags/')) }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/MrDox-?.?.?-*.*
+          tag_name: ${{ github.ref_name || github.ref }}
+          token: ${{ github.token }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ project(
     HOMEPAGE_URL "https://github.com/cppalliance/mrdox"
     LANGUAGES CXX C
 )
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
 #set(BUILD_SHARED_LIBS OFF CACHE STRING "")
 #set(CMAKE_CXX_EXTENSIONS OFF CACHE STRING "")
@@ -35,6 +37,8 @@ project(
 
 option(MRDOX_BUILD_TESTS "Build tests" ON)
 option(MRDOX_BUILD_SHARED "Link shared" OFF)
+option(MRDOX_INSTALL "Configure install target" ON)
+option(MRDOX_PACKAGE "Build install package" ON)
 
 if (MRDOX_BUILD_SHARED)
     set(MRDOX_LINK_MODE SHARED)
@@ -100,6 +104,7 @@ target_compile_features(mrdox-api PUBLIC cxx_std_20)
 target_include_directories(mrdox-api
     PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
     PRIVATE
     "${PROJECT_SOURCE_DIR}/source/api/"
 )
@@ -185,6 +190,90 @@ target_include_directories(mrdox PRIVATE source/tool)
 
 source_group(TREE ${PROJECT_SOURCE_DIR} PREFIX "" FILES CMakeLists.txt)
 source_group(TREE ${PROJECT_SOURCE_DIR}/source/mrdox PREFIX "source" FILES ${TOOL_SOURCES})
+
+#-------------------------------------------------
+#
+# Install
+#
+#-------------------------------------------------
+if (MRDOX_INSTALL)
+    # Create and install mrdox-targets.cmake
+    install(TARGETS mrdox-api mrdox
+            EXPORT mrdox-targets
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            )
+
+    install(EXPORT mrdox-targets
+            FILE mrdox-targets.cmake
+            NAMESPACE mrdox::
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mrdox)
+
+    # Headers
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/mrdox
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            FILES_MATCHING PATTERN "*.[hic]pp")
+
+    # Set variable where the cmake config is
+    # https://cliutils.gitlab.io/modern-cmake/chapters/install/installing.html
+    set(CONFIG_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/mrdox)
+
+    # Create and install mrdox-config-version.cmake
+    if (CMAKE_PROJECT_VERSION VERSION_LESS 1.0.0)
+        set(compatibility_mode SameMajorVersion)
+    else ()
+        set(compatibility_mode SameMinorVersion)
+    endif ()
+    write_basic_package_version_file(
+            mrdox-config-version.cmake
+            VERSION ${PACKAGE_VERSION}
+            COMPATIBILITY ${compatibility_mode})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mrdox-config-version.cmake
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mrdox)
+
+    # Create and install mrdox-config.cmake
+    set(INCLUDE_INSTALL_DIR include/)
+    set(LIB_INSTALL_DIR lib/)
+    configure_package_config_file(
+            ${CMAKE_CURRENT_SOURCE_DIR}/mrdox-config.cmake.in # input file
+            ${CMAKE_CURRENT_BINARY_DIR}/mrdox-config.cmake    # output file
+            INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mrdox
+            PATH_VARS CMAKE_INSTALL_LIBDIR INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mrdox-config.cmake
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mrdox)
+
+endif ()
+
+
+#-------------------------------------------------
+#
+# Packages
+#
+#-------------------------------------------------
+if (MRDOX_INSTALL AND MRDOX_PACKAGE)
+    # Set the cpack variables
+    # https://cliutils.gitlab.io/modern-cmake/chapters/install/packaging.html
+
+    # The most common cpack variables
+    set(CPACK_PACKAGE_VENDOR "mrdox")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${PROJECT_DESCRIPTION})
+    set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+    set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+    set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
+    set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.adoc")
+
+    # Set CPACK_SOURCE_IGNORE_FILES with files source packages shouldn't install
+    # We get these from .gitignore to avoid redundancy
+    FILE(READ .gitignore GITIGNORE_CONTENTS)
+    STRING(REGEX REPLACE ";" "\\\\;" GITIGNORE_CONTENTS "${GITIGNORE_CONTENTS}")
+    STRING(REGEX REPLACE "\n" ";" GITIGNORE_CONTENTS "${GITIGNORE_CONTENTS}")
+    set(CPACK_SOURCE_IGNORE_FILES ${GITIGNORE_CONTENTS})
+
+    # Always include CPack at last
+    include(CPack)
+endif ()
 
 #-------------------------------------------------
 #

--- a/mrdox-config.cmake.in
+++ b/mrdox-config.cmake.in
@@ -1,0 +1,26 @@
+@PACKAGE_INIT@
+
+# How mrdox installation was built
+set(MRDOX_BUILT_SHARED "@BUILD_SHARED_LIBS@")
+set(MRDOX_BUILT_CXX_COMPILER_ID "@CMAKE_CXX_COMPILER_ID@")
+set(MRDOX_BUILT_CXX_COMPILER_VERSION "@CMAKE_CXX_COMPILER_VERSION@")
+
+# Paths
+set_and_check(MRDOX_INSTALL_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
+set_and_check(MRDOX_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set_and_check(MRDOX_LIB_DIR     "@PACKAGE_LIB_INSTALL_DIR@")
+
+# Set module paths
+include(CMakeFindDependencyMacro)
+list(APPEND CMAKE_MODULE_PATH ${MRDOX_CONFIG_INSTALL_DIR})
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${MRDOX_INCLUDE_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${MRDOX_INSTALL_DIR}")
+
+# Find dependencies
+find_dependency(LLVM)
+find_dependency(Clang)
+
+# Create imported targets
+include("${CMAKE_CURRENT_LIST_DIR}/mrdox-targets.cmake")
+check_required_components(mrdox)


### PR DESCRIPTION
fix #139

This PR adapts CMakeLists.txt to create packages with cpack and adapts the GHA workflow to create a release with these packages whenever a tag is created or a commit is pushed to develop or master. The previous develop or master releases are always overridden.