### PR TITLE
Better bool

### DIFF
--- a/test-files/old-tests/function-parm-decay.xml
+++ b/test-files/old-tests/function-parm-decay.xml
@@ -14,7 +14,7 @@
     <file path="function-parm-decay.cpp" line="14"/>
     <file path="function-parm-decay.cpp" line="15"/>
     <file path="function-parm-decay.cpp" line="16"/>
-    <param name="x" type="int (*)(_Bool)"/>
+    <param name="x" type="int (*)(bool)"/>
   </function>
   <function name="i" id="UTOfie03KjmJww3mduHOqLZB5aI=">
     <file path="function-parm-decay.cpp" line="21"/>


### PR DESCRIPTION
Fixes `bool` in complex types (e.g. `int(*)(bool)`). Would be nice to get rid of the `ASTContext` parameter, but that would require us to move a lot of the namespace scope functions in `ASTVisitor.cpp` into `ASTVisitor`.