### PR TITLE
build: reset LLVM warning flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,8 @@ list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 include(HandleLLVMOptions)
 add_definitions(${LLVM_DEFINITIONS})
 llvm_map_components_to_libnames(llvm_libs all)
+string(REGEX REPLACE " /W[0-4]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+string(REGEX REPLACE " /W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 # Duktape
 if(NOT DEFINED DUKTAPE_SOURCE_ROOT)


### PR DESCRIPTION
LLVM unfortunately defines global compile flags that are inherited by all other targets in the project, including fetched dependencies. Warning flags, with are functionally unnecessary, can cause conflicts with other targets.

This PR resets global warnings flags set by `include(HandleLLVMOptions)` with the same pattern used internally by the script to do that. Unfortunately, the script uses this pattern only to set another unrequested warning flag and there's not option to disable this behavior.

Although this PR fixes issue #251, rebasing the branch included changes that are now triggering TSan.

fix #251