### PR TITLE
ci: update cpp-actions to v1.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,16 +79,15 @@ jobs:
           find "$llvm_dir" -type f
 
       - name: Setup C++
-        uses: alandefreitas/cpp-actions/setup-cpp@v1.4.0
+        uses: alandefreitas/cpp-actions/setup-cpp@v1.5.0
         id: setup-cpp
         with:
           compiler: ${{ matrix.compiler }}
           version: ${{ matrix.version }}
-          update-ld-library-path: ${{ matrix.compiler == 'gcc' }}
           check-latest: ${{ matrix.compiler == 'clang' }}
 
       - name: Install packages
-        uses: alandefreitas/cpp-actions/package-install@v1.4.0
+        uses: alandefreitas/cpp-actions/package-install@v1.5.0
         id: package-install
         with:
           apt-get: ${{ matrix.install }} openjdk-11-jdk ninja-build
@@ -99,7 +98,7 @@ jobs:
           cxxflags: ${{ matrix.cxxflags }}
 
       - name: CMake Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.4.0
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.5.0
         with:
           cmake-version: '>=3.20'
           generator: Ninja
@@ -125,12 +124,11 @@ jobs:
           retention-days: 1
 
       - name: FlameGraph
-        uses: alandefreitas/cpp-actions/flamegraph@v1.4.0
+        uses: alandefreitas/cpp-actions/flamegraph@v1.5.0
         if: matrix.time-trace
         with:
           build-dir: build
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          trace-commands: true
 
       - name: Codecov
         if: ${{ matrix.coverage }}
@@ -233,7 +231,7 @@ jobs:
         working-directory: build
 
       - name: Create changelog
-        uses: alandefreitas/cpp-actions/create-changelog@v1.4.0
+        uses: alandefreitas/cpp-actions/create-changelog@v1.5.0
         with:
           output-path: CHANGELOG.md
           thank-non-regular: ${{ startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
Among [changes](https://github.com/alandefreitas/cpp-actions/releases/tag/v1.5.0) with many bug fixes and performance improvements in all actions, the new setup-cpp step now sets up official apt repositories whenever possible for the compiler version being set. 

In practice, this allows all the most recent compiler versions to be set up with APT rather than our custom binaries, which is not only faster but also fixes many of the unstable workarounds we had before, such as manually setting LD_LIBRARY_PATH and the standard library configuration flags.