### PR TITLE
Add library requirements to requirements section

### DIFF
--- a/docs/modules/ROOT/pages/install.adoc
+++ b/docs/modules/ROOT/pages/install.adoc
@@ -44,6 +44,13 @@ cmake --build . -j <threads>
 cmake --install .
 ----
 
+Required Libraries:
+
+* fmt >= 10
+* duktape
+* zlib
+* libtinfo
+
 === MrDox
 
 Once the LLVM variants are available in `/path/to/llvm+clang`, you can download MrDox:


### PR DESCRIPTION
May not be all-inclusive, but these are the ones that I needed to install during build. Ubuntu 23.04 does not provide fmt >= 10 in the package manager; it has 9.x.