### PR TITLE
handlebars basic spec tests

### DIFF
--- a/src/test_suite/detail/decomposer.hpp
+++ b/src/test_suite/detail/decomposer.hpp
@@ -47,6 +47,10 @@ namespace test_suite::detail
     format_value(T const& value)
     {
         std::string out;
+        if constexpr (std::is_convertible_v<std::decay_t<T>, std::string_view>)
+        {
+            out += '\"';
+        }
 #ifdef MRDOX_TEST_HAS_FMT
         if constexpr (fmt::has_formatter<T, fmt::format_context>::value) {
             out += fmt::format("{}", value);
@@ -58,6 +62,10 @@ namespace test_suite::detail
             out += ss.str();
         } else {
             out += demangle<T>();
+        }
+        if constexpr (std::is_convertible_v<std::decay_t<T>, std::string_view>)
+        {
+            out += '\"';
         }
         return out;
     }

--- a/src/test_suite/diff.cpp
+++ b/src/test_suite/diff.cpp
@@ -277,8 +277,7 @@ BOOST_TEST_DIFF(
     else
     {
         // Compare rendered template with reference
-        auto success_contents = expected_contents;
-        DiffStringsResult diff = diffStrings(success_contents, rendered_contents);
+        DiffStringsResult diff = diffStrings(expected_contents, rendered_contents);
         if (diff.added > 0 || diff.removed > 0)
         {
             std::ofstream out((std::string(error_output_path)));
@@ -292,8 +291,8 @@ BOOST_TEST_DIFF(
             BOOST_TEST(diff.added == 0);
             BOOST_TEST(diff.removed == 0);
         }
-        BOOST_TEST(rendered_contents.size() == success_contents.size());
-        BOOST_TEST(rendered_contents == success_contents);
+        BOOST_TEST(rendered_contents.size() == expected_contents.size());
+        BOOST_TEST((rendered_contents == expected_contents));
     }
 }
 

--- a/src/test_suite/test_suite.cpp
+++ b/src/test_suite/test_suite.cpp
@@ -459,10 +459,10 @@ test(
     (void)func;
     log_ <<
         "#" << id << " " <<
-        file << "(" << line << ") "
-        "failed: " << expr <<
+        file << "(" << line << ")\n"
+        "failed:\n    " << expr <<
         //" in " << func <<
-        "\n";
+        "\n\n";
     log_.flush();
     return false;
 }

--- a/test-files/handlebars/features_test.adoc
+++ b/test-files/handlebars/features_test.adoc
@@ -1,0 +1,833 @@
+== from_chars
+
+
+
+=== Synopsis
+
+[,cpp]
+----
+std::from_chars
+----
+
+
+Declared in file <charconv>
+
+
+This is the from_chars function
+
+
+
+
+
+
+
+// Record detail partial
+[,cpp]
+----
+struct from_chars
+{
+};
+----
+
+
+// #with to change context
+Person: John Doe in page about `from_chars`
+
+
+// #each to iterate, change context, and access parent context
+People:
+* Person: Alice Doe in page about `from_chars`
+* Person: Bob Doe in page about `from_chars`
+* Person: Carol Smith in page about `from_chars`
+
+
+== Expressions
+
+// Render complete context with "." as key
+[object Object]
+
+// Use to_string
+{"page":{"kind":"record","name":"from_chars","decl":"std::from_chars","loc":"charconv","javadoc":{"brief":"Converts strings to numbers","details":"This function converts strings to numbers"},"synopsis":"This is the from_chars function","person":{"firstname":"John","lastname":"Doe"},"people":[{"firstname":"Alice","lastname":"Doe","book":[{},{},{},{}]},{"firstname":"Bob","lastname":"Doe","book":[{},{},{},{}]},{"firstname":"Carol","lastname":"Smith","book":[{},{},{},{}]}],"prefix":"Hello","specialChars":"& < > " ' ` =","url":"https://cppalliance.org/","author":{"firstname":"Yehuda","lastname":"Katz"}},"nav":[{"url":"foo","test":true,"title":"bar"},{"url":"bar"}],"myVariable":"lookupMyPartial","myOtherContext":{"information":"Interesting!"},"favoriteNumber":123,"prefix":"Hello","title":"My Title","body":"My Body","story":{"intro":"Before the jump","body":"After the jump"},"comments":[{"subject":"subject 1","body":"body 1"},{"subject":"subject 2","body":"body 2"}],"isActive":true,"isInactive":false,"peopleobj":{"Alice":{"firstname":"Alice","lastname":"Doe"},"Bob":{"firstname":"Bob","lastname":"Doe"},"Carol":{"firstname":"Carol","lastname":"Smith"}},"author":true,"firstname":"Yehuda","lastname":"Katz","names":["Yehuda Katz","Alan Johnson","Charles Jolley"],"namesobj":{"Yehuda":"Yehuda Katz","Alan":"Alan Johnson","Charles":"Charles Jolley"},"city":{"name":"San Francisco","summary":"San Francisco is the <b>cultural center</b> of <b>Northern California</b>","location":{"north":"37.73,","east":"-122.44"},"population":883305},"lookup_test":{"people":["Nils","Yehuda"],"cities":["Darmstadt","San Francisco"]},"lookup_test2":{"persons":[{"name":"Nils","resident-in":"darmstadt"},{"name":"Yehuda","resident-in":"san-francisco"}],"cities":{"darmstadt":{"name":"Darmstadt","country":"Germany"},"san-francisco":{"name":"San Francisco","country":"USA"}}},"containers":{"array":["a","b","c","d","e","f","g"],"array2":["e","f","g","h","i","j","k"],"object":{"a":"a","b":"b","c":"c","d":"d","e":"e","f":"f","g":"g"},"object2":{"e":"e","f":"f","g":"g","h":"h","i":"i","j":"j","k":"k"},"object_array":[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x11","product":"Desk"}]},"symbol":{"tag":"struct","kind":"record","name":"T"}}
+
+// Literals
+true = Missing: true()
+false = Missing: false()
+null = Missing: null()
+undefined = Missing: undefined()
+./[true] = Missing: ./[true]()
+./[false] = Missing: ./[false]()
+./[null] = Missing: ./[null]()
+./[undefined] = Missing: ./[undefined]()
+
+// Arrays
+Second person is Bob Doe
+Second person is Bob Doe
+
+// Dot segments
+Second person is Bob Doe
+
+// Special characters (disabled for adoc)
+raw: & < > " ' ` =
+html-escaped: & < > " ' ` =
+
+// Helpers
+JOHN DOE
+https://cppalliance.org/[See Website]
+
+// Helpers with literal values
+[source]
+----
+** 10% Search 
+****************** 90% Upload stalled
+******************** 100% Finish 
+----
+
+// Undefined helper
+Missing: undefinedhelper("Doe")
+
+// Helpers with hashes
+https://chat.asciidoc.org[*project chat*^,role=green]
+
+// Subexpressions
+****************** 90% Upload stalled
+****************** 90% Upload stalled
+
+// Whitespace control
+<a href="foo">bar</a><a href="bar">Empty</a>
+// Inline escapes
+{{escaped}}
+Missing: true()
+
+// Raw blocks
+{{escaped}}
+
+
+// Raw blocks
+{{bar}}
+
+
+// Raw block helper
+{{BAR}}
+
+
+
+== Partials
+
+// Basic partials
+[,cpp]
+----
+struct from_chars
+{
+};
+----
+
+[,cpp]
+----
+struct from_chars
+{
+};
+----
+
+
+// Dynamic partials
+Dynamo!
+Found!
+
+// Partial context switch
+Interesting!
+
+// Partial parameters
+The result is 123
+
+  Hello, Alice Doe.
+  Hello, Bob Doe.
+  Hello, Carol Smith.
+
+
+// Partial blocks
+  Failover content
+
+
+// Pass templates to partials
+Site Content My Content
+
+
+// Inline partials
+    My Content
+    My Content
+    My Content
+
+
+// Block inline partials
+<div class="nav">
+      My Nav
+</div>
+<div class="content">
+      My Content
+</div>
+
+== Blocks
+
+// Block noop
+<div class="entry">
+  <h1>My Title</h1>
+  <div class="body">
+    My Body
+  </div>
+</div>
+
+// Block function
+<div class="entry">
+  <h1>My Title</h1>
+  <div class="body">
+    <div class="mybold">My Body</div>
+  </div>
+</div>
+
+// Block helper parameter
+<div class="entry">
+    <h1>My Title</h1>
+            <div class="intro">Before the jump</div>
+        <div class="body">After the jump</div>
+
+</div>
+
+// Simple iterators
+<div class="entry">
+  <h1>My Title</h1>
+      <div class="intro">Before the jump</div>
+    <div class="body">After the jump</div>
+
+</div>
+<div class="comments">
+      <div class="comment">
+      <h2>subject 1</h2>
+      body 1
+    </div>
+    <div class="comment">
+      <h2>subject 2</h2>
+      body 2
+    </div>
+
+</div>
+
+// Custom list helper
+<ul><li>    <a href="foo">bar</a>
+</li><li>    <a href="bar">Missing: title()</a>
+</li></ul>
+
+// Conditionals
+    <img src="star.gif" alt="Active">
+
+
+  <img src="star.gif" alt="Active">
+
+
+
+  <img src="cry.gif" alt="Inactive">
+
+
+// Chained blocks
+// 1
+   HIT <img src="star.gif" alt="Active 1">
+
+
+// 2
+   HIT <img src="star.gif" alt="Active 2">
+
+
+// 3
+
+    HIT No User
+
+
+// Block hash arguments
+<ul id="nav-bar" class="top"><li>    <a href="foo">bar</a>
+</li><li>    <a href="bar">Missing: title()</a>
+</li></ul>
+
+// Private variables
+<ul><li>  0. foo
+</li><li>  1. bar
+</li></ul>
+
+// Iterate objects
+    Id: 0, Key: Alice, Name: Alice Doe
+    Id: 1, Key: Bob, Name: Bob Doe
+    Id: 2, Key: Carol, Name: Carol Smith
+
+
+// Block parameters
+    Id: 0 Name: Alice
+    Id: 1 Name: Bob
+    Id: 2 Name: Carol
+
+
+// Recursive block parameters
+            User Id: 0 Book Id: 0
+        User Id: 0 Book Id: 1
+        User Id: 0 Book Id: 2
+        User Id: 0 Book Id: 3
+
+            User Id: 1 Book Id: 0
+        User Id: 1 Book Id: 1
+        User Id: 1 Book Id: 2
+        User Id: 1 Book Id: 3
+
+            User Id: 2 Book Id: 0
+        User Id: 2 Book Id: 1
+        User Id: 2 Book Id: 2
+        User Id: 2 Book Id: 3
+
+
+
+== Built-in Helpers
+
+// Author
+<h1>Yehuda Katz</h1>
+
+
+// Unknown
+<div class="entry">
+
+<h1>Unknown Author</h1>
+
+</div>
+
+// Include zero
+<h1>Does render</h1>
+
+
+
+<h1>Does render</h1>
+
+
+// Custom
+author defined
+value2 undefined
+
+// unless
+<div class="entry">
+<h3 class="warning">WARNING: This entry does not have a license!</h3>
+
+</div>
+
+// each with non objects
+<ul class="people_list">
+        <li>Yehuda Katz</li>
+    <li>Alan Johnson</li>
+    <li>Charles Jolley</li>
+
+</ul>
+
+// No paragraphs
+
+<p class="empty">No paragraphs</p>
+
+
+// indexes and keys
+ 0: Yehuda Katz  1: Alan Johnson  2: Charles Jolley 
+ Yehuda: Yehuda Katz  Alan: Alan Johnson  Charles: Charles Jolley 
+
+// with
+Yehuda Katz
+
+
+// with block parameters
+      San Francisco: 37.73, -122.44
+
+
+
+// with inverse
+
+No city found
+
+
+// lookup
+
+Nils lives in Darmstadt
+Yehuda lives in San Francisco
+
+
+// lookup2
+    Nils lives in Darmstadt (Germany)
+    Yehuda lives in San Francisco (USA)
+
+
+// log (there should be no rendered output)
+
+
+
+
+
+
+
+
+== Hooks
+
+// Helper missing
+Missing: foo()
+Missing: foo(true)
+Missing: foo(2, true)
+Missing: foo(true)
+Helper 'foo' not found. Printing block: block content
+
+// Block helper missing
+Helper 'person' not found. Printing block:     Yehuda Katz
+
+
+== String helpers
+
+// capitalize
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+// center
+                   Hello world!                   
+                   Hello world!                   
+-------------------Hello world!-------------------
+-------------------Hello world!-------------------
+// ljust
+Hello world!                                      
+Hello world!                                      
+Hello world!--------------------------------------
+Hello world!--------------------------------------
+// pad_end
+Hello world!                                      
+Hello world!                                      
+Hello world!--------------------------------------
+Hello world!--------------------------------------
+// rjust
+                                      Hello world!
+                                      Hello world!
+--------------------------------------Hello world!
+--------------------------------------Hello world!
+// pad_start
+                                      Hello world!
+                                      Hello world!
+--------------------------------------Hello world!
+--------------------------------------Hello world!
+// count
+2
+2
+1
+1
+1
+1
+// ends_with
+true
+true
+true
+true
+true
+true
+false
+false
+// starts_with
+true
+true
+true
+true
+true
+true
+false
+false
+// expandtabs
+Hello        world!
+Hello        world!
+Hello world!
+Hello world!
+Helloworld!
+Helloworld!
+// find
+6
+6
+// index_of
+6
+6
+// includes
+true
+true
+false
+false
+// rfind
+-1
+-1
+-1
+-1
+// rindex_of
+-1
+-1
+-1
+-1
+// last_index_of
+-1
+-1
+-1
+-1
+// at
+e
+e
+// char_at
+e
+e
+// isalnum
+true
+true
+false
+false
+// isalpha
+true
+true
+true
+true
+false
+false
+// isascii
+true
+true
+// isdecimal
+false
+false
+true
+true
+// isdigit
+false
+false
+true
+true
+// islower
+false
+false
+false
+false
+// isupper
+false
+false
+false
+false
+// isprintable
+true
+true
+false
+false
+// isspace
+false
+false
+true
+true
+true
+true
+// istitle
+false
+false
+true
+true
+// upper
+HELLO WORLD!
+HELLO WORLD!
+// to_upper
+HELLO WORLD!
+HELLO WORLD!
+// lower
+hello world!
+hello world!
+// to_lower
+hello world!
+hello world!
+// swapcase
+hELLO WORLD!
+hELLO WORLD!
+// join
+Hello,world!
+Hello,world!
+// concat
+Hello world!,Bye!
+Hello world!,Bye!
+// strip
+Hello world!
+Hello world!
+Hello world!
+Hello world!
+// trim
+Hello world!
+Hello world!
+Hello world!
+Hello world!--------'
+// lstrip
+Hello world!        
+Hello world!        
+Hello world!--------
+Hello world!--------
+// trim_start
+Hello world!         
+Hello world!         
+Hello world!--------
+Hello world!--------
+// rstrip
+           Hello world!
+           Hello world!
+--------Hello world!
+--------Hello world!
+// trim_end
+         Hello world!
+         Hello world!
+--------Hello world!
+--------Hello world!
+// partition
+[Hello, ,world!]
+[Hello, ,world!]
+[Hello world!,,]
+[Hello world!,,]
+// rpartition
+[Hello, ,world!]
+[Hello, ,world!]
+[Hello world!,,]
+[Hello world!,,]
+// remove_prefix
+ world!
+ world!
+// remove_suffix
+Hello 
+Hello 
+Hello world
+Hello world
+// replace
+Hello!
+Hello!
+// split
+[Hello,world!]
+[Hello,world!]
+[He,]
+[He,]
+// rsplit
+[world!,Hell]
+[world!,Hell]
+[d!,o wo]
+[d!,o wo]
+// splitlines
+[Hello world!\nBye!]
+[Hello world!\nBye!]
+// zfill
+00000000000000000000000000000000000000Hello world!
+00000000000000000000000000000000000000Hello world!
+00000000000000000000000000000000000000000000000000000000000000000000000000000030
+00000000000000000000000000000000000000000000000000000000000000000000000000000030
+-0000000000000000000000000000000000000000000000000000000000000000000000000000030
+-0000000000000000000000000000000000000000000000000000000000000000000000000000030
+// repeat
+Hello world!Hello world!Hello world!
+Hello world!Hello world!Hello world!
+// escape
+Hello world!
+Hello world!
+&lt;Hello world!&gt;&lt;/Hello&gt;
+&lt;Hello world!&gt;&lt;/Hello&gt;
+// slice
+ello
+ello
+ello world!
+ello world!
+ello world
+ello world
+ell
+ell
+// substr
+ello
+ello
+ello world!
+ello world!
+ello world
+ello world
+ell
+ell
+// safe_anchor_id
+hello-world!
+hello-world!
+// strip_namespace
+Hello world!
+Hello world!
+memory_order
+memory_order
+memory_order_acquire
+memory_order_acquire
+basic_string<char, typename B::value_type>
+basic_string<char, typename B::value_type>
+
+== Containers
+
+// size
+7
+7
+3
+// len
+7
+7
+3
+// keys
+
+[a,b,c,d,e,f,g]
+
+// list
+
+list helper requires array argument: object provided
+
+// iter
+
+[a,b,c,d,e,f,g]
+
+// values
+[a,b,c,d,e,f,g]
+[a,b,c,d,e,f,g]
+[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x11","product":"Desk"}]
+// del
+[a,b,d,e,f,g]
+{"a":"a","b":"b","d":"d","e":"e","f":"f","g":"g"}
+[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x11","product":"Desk"}]
+// delete
+[a,b,d,e,f,g]
+{"a":"a","b":"b","d":"d","e":"e","f":"f","g":"g"}
+[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x11","product":"Desk"}]
+// has
+true
+true
+false
+// exist
+true
+false
+true
+false
+false
+// contains
+true
+false
+true
+false
+false
+// has_any
+true
+false
+false
+true
+false
+false
+false
+// exist_any
+true
+true
+false
+// contains_any
+true
+true
+false
+// get
+c
+c
+{"account_id":"account-x11","product":"Desk"}
+// get_or
+y
+y
+y
+// items
+[a,b,c,d,e,f,g]
+[[a,a],[b,b],[c,c],[d,d],[e,e],[f,f],[g,g]]
+[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x11","product":"Desk"}]
+// entries
+[a,b,c,d,e,f,g]
+[[a,a],[b,b],[c,c],[d,d],[e,e],[f,f],[g,g]]
+[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x11","product":"Desk"}]
+// first
+a
+"a"
+{"account_id":"account-x10","product":"Chair"}
+// head
+a
+"a"
+{"account_id":"account-x10","product":"Chair"}
+// front
+a
+"a"
+{"account_id":"account-x10","product":"Chair"}
+// last
+g
+"g"
+{"account_id":"account-x11","product":"Desk"}
+// tail
+g
+"g"
+{"account_id":"account-x11","product":"Desk"}
+// back
+g
+"g"
+{"account_id":"account-x11","product":"Desk"}
+// reverse
+[g,f,e,d,c,b,a]
+[["g","g"],["f","f"],["e","e"],["d","d"],["c","c"],["b","b"],["a","a"]]
+[{"account_id":"account-x11","product":"Desk"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x10","product":"Chair"}]
+// reversed
+[g,f,e,d,c,b,a]
+[["g","g"],["f","f"],["e","e"],["d","d"],["c","c"],["b","b"],["a","a"]]
+[{"account_id":"account-x11","product":"Desk"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x10","product":"Chair"}]
+// update
+[a,b,c,d,e,f,g,h,i,j,k]
+{"e":"e","f":"f","g":"g","h":"h","i":"i","j":"j","k":"k","a":"a","b":"b","c":"c","d":"d"}
+[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x11","product":"Desk"},"e","f","g","h","i","j","k"]
+// merge
+[a,b,c,d,e,f,g,h,i,j,k]
+{"e":"e","f":"f","g":"g","h":"h","i":"i","j":"j","k":"k","a":"a","b":"b","c":"c","d":"d"}
+[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x11","product":"Desk"},"e","f","g","h","i","j","k"]
+// sort
+[a,b,c,d,e,f,g]
+{"a":"a","b":"b","c":"c","d":"d","e":"e","f":"f","g":"g"}
+[{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x11","product":"Desk"}]
+// sort_by
+
+
+[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x11","product":"Desk"}]
+// at
+c
+c
+{"account_id":"account-x11","product":"Desk"}
+// fill
+[a,b,-,-,-,f,g]
+[a,b,-,-,-,-,g]
+
+
+// count
+1
+1
+0
+// concat
+[a,b,c,d,e,f,g,e,f,g,h,i,j,k]
+[object Object]
+[[object Object],[object Object],[object Object],e,f,g,h,i,j,k]
+// replace
+[a,b,d,d,e,f,g]
+[a,b,d,d,e,f,g]
+{"c":"d","a":"a","b":"b","c":"c","d":"d","e":"e","f":"f"}
+[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"},{"account_id":"account-x11","product":"Desk"}]
+// chunk
+[[a,b,c],[d,e,f],[g]]
+[{"a":"a","b":"b","c":"c"},{"d":"d","e":"e","f":"f"},{"g":"g"}]
+[[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"}],[{"account_id":"account-x11","product":"Desk"}]]
+// group_by
+
+
+{"account-x10":[{"account_id":"account-x10","product":"Chair"},{"account_id":"account-x10","product":"Bookcase"}],"account-x11":[{"account_id":"account-x11","product":"Desk"}]}
+{"Chair":[{"account_id":"account-x10","product":"Chair"}],"Bookcase":[{"account_id":"account-x10","product":"Bookcase"}],"Desk":[{"account_id":"account-x11","product":"Desk"}]}
+// pluck
+
+
+["account-x10","account-x10","account-x11"]
+["Chair","Bookcase","Desk"]
+// unique
+["a","b","c","d","e","f","g","h","i","j","k"]
+
+
+
+// Inverse block with no helper expands expressions
+    
+    struct T
+
+

--- a/test-files/handlebars/features_test.adoc.hbs
+++ b/test-files/handlebars/features_test.adoc.hbs
@@ -61,8 +61,6 @@ undefined = {{undefined}}
 ./[false] = {{./[false]}}
 ./[null] = {{./[null]}}
 ./[undefined] = {{./[undefined]}}
-'See Website' = {{'See Website'}}
-"See Website" = {{"See Website"}}
 
 // Arrays
 Second person is {{page.people.[1].firstname}} {{page.people.[1].lastname}}

--- a/test-files/handlebars/record.adoc.hbs
+++ b/test-files/handlebars/record.adoc.hbs
@@ -1,0 +1,9 @@
+{{#if symbol.template}}
+    {{>template-head symbol.template}}
+    {{symbol.tag}} {{symbol.name~}}
+    {{#if (neq symbol.template.kind "primary")~}}
+        {{>template-args args=symbol.template.args}}
+    {{/if}}
+{{else}}
+    {{symbol.tag}} {{symbol.name~}}
+{{/if}}


### PR DESCRIPTION
This PR replicates the basic spec tests from https:github.com/handlebars-lang/handlebars.js/blob/4.x/spec/basic.js

Fortunately the C++ implementation passed most tests without any changes. A few bugs in corner cases related to double escapes, specific types of whitespace control, and tag options were fixed.

On the other hand, Handlebars.js includes many undocumented features that are only being implemented now as I find out about them. For instance, `&` can be used in tags as an alternative for disabling HTML escaping. This does not seem to be documented anywhere.

There are also cases that can't be supported by the C++ implementation right now but are worth to thinking about. Especifically, Handlebars.js allows the context objects to include functions that are executed as helpers. This also doesn't seem to be documented anywhere, I have never seen that being used, and it's possible to use regular helpers instead. Nonetheless, it's a supported feature that is tested in the original test suite.