### PR TITLE
Better assertions

### DIFF
--- a/include/mrdox/Platform.hpp
+++ b/include/mrdox/Platform.hpp
@@ -11,7 +11,7 @@
 #ifndef MRDOX_API_PLATFORM_HPP
 #define MRDOX_API_PLATFORM_HPP
 
-#include <cassert>
+#include <mrdox/Support/Assert.hpp>
 #include <type_traits>
 
 #if __cplusplus < 202002L
@@ -65,18 +65,6 @@ namespace mrdox {
 #endif
 
 //------------------------------------------------
-
-#ifndef MRDOX_ASSERT
-# define MRDOX_ASSERT(x) assert(x)
-#endif
-
-#ifndef MRDOX_UNREACHABLE
-# ifdef __GNUC__
-#  define MRDOX_UNREACHABLE() do { MRDOX_ASSERT(false); __builtin_unreachable(); } while(false)
-# elif defined(_MSC_VER)
-#  define MRDOX_UNREACHABLE() do { MRDOX_ASSERT(false); __assume(false); } while(false)
-# endif
-#endif
 
 #ifndef FMT_CONSTEVAL
 # if !defined(__GNUC__) && defined(_MSC_VER)

--- a/include/mrdox/Support/Assert.hpp
+++ b/include/mrdox/Support/Assert.hpp
@@ -1,0 +1,47 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2023 Krystian Stasiowski (sdkrystian@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdox
+//
+
+#ifndef MRDOX_API_SUPPORT_ASSERT_HPP
+#define MRDOX_API_SUPPORT_ASSERT_HPP
+
+#include <cstdint>
+
+namespace clang {
+namespace mrdox {
+
+#ifdef NDEBUG
+    #ifdef __GNUC__
+        #define MRDOX_UNREACHABLE() static_cast<void>(__builtin_unreachable())
+    #elif defined(_MSC_VER)
+        #define MRDOX_UNREACHABLE() static_cast<void>(__assume(false))
+    #endif
+    #define MRDOX_ASSERT(x) static_cast<void>(false)
+#else
+    #ifdef __GNUC__
+        #define MRDOX_UNREACHABLE() static_cast<void>(__builtin_trap(), __builtin_unreachable())
+    #elif defined(_MSC_VER)
+        #define MRDOX_UNREACHABLE() static_cast<void>(__debugbreak(), __assume(false))
+    #endif
+
+    void
+    assert_failed(
+        const char* msg,
+        const char* file,
+        std::uint_least32_t line);
+
+    #define MRDOX_ASSERT(x) static_cast<void>(!! (x) || \
+        (assert_failed(#x, __builtin_FILE(), __builtin_LINE()), \
+        MRDOX_UNREACHABLE(), true))
+#endif
+
+} // mrdox
+} // clang
+
+#endif

--- a/src/lib/Support/Assert.cpp
+++ b/src/lib/Support/Assert.cpp
@@ -1,0 +1,35 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2023 Krystian Stasiowski (sdkrystian@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdox
+//
+
+#include <mrdox/Support/Assert.hpp>
+#include <mrdox/Support/Path.hpp>
+#include <fmt/format.h>
+#include <llvm/Support/raw_ostream.h>
+
+namespace SourceFileNames {
+extern char const* getFileName(char const*) noexcept;
+} // SourceFileNames
+
+namespace clang {
+namespace mrdox {
+
+void
+assert_failed(
+    const char* msg,
+    const char* file,
+    std::uint_least32_t line)
+{
+    llvm::errs() << fmt::format(
+        "assertion failed: {} on line {} in {}\n",
+        msg, line, ::SourceFileNames::getFileName(file));
+}
+
+} // mrdox
+} // clang


### PR DESCRIPTION
![image](https://github.com/cppalliance/mrdox/assets/16629302/c382dd36-de90-484e-beea-282eabb7843a)

prior to this, the breakpoint would be triggered in `Signals.inc` (so you would have to go up a few stack frames to get to the source location of the assert)