### PR TITLE
feat: handlebars support dom::Function

### DIFF
--- a/include/mrdox/Dom/Array.hpp
+++ b/include/mrdox/Dom/Array.hpp
@@ -108,25 +108,6 @@ public:
     */
     Array(Array const& other);
 
-    /** Assignment.
-
-        Ownership of the array is transferred
-        to this, and ownership of the previous
-        contents is released. The moved-from
-        array behaves as if default constructed.
-    */
-    Array& operator=(Array&&);
-
-    /** Assignment.
-
-        This acquires shared ownership of the copied
-        array, and ownership of the previous contents
-        is released.
-    */
-    Array& operator=(Array const&) = default;
-
-    //--------------------------------------------
-
     /** Constructor.
 
         This constructs an array from an existing
@@ -149,6 +130,25 @@ public:
         @param elements The elements to acquire.
     */
     Array(storage_type elements);
+
+    /** Assignment.
+
+        Ownership of the array is transferred
+        to this, and ownership of the previous
+        contents is released. The moved-from
+        array behaves as if default constructed.
+    */
+    Array& operator=(Array&&);
+
+    /** Assignment.
+
+        This acquires shared ownership of the copied
+        array, and ownership of the previous contents
+        is released.
+    */
+    Array& operator=(Array const&) = default;
+
+    //--------------------------------------------
 
     /** Return the implementation used by this object.
     */
@@ -175,6 +175,13 @@ public:
     */
     value_type get(size_type i) const;
 
+    /** Set the i-th element, without bounds checking.
+
+        @param i The zero-based index of the element.
+        @param v The value to set.
+    */
+    void set(size_type i, Value v);
+
     /** Return the i-th element, without bounds checking.
     */
     value_type operator[](size_type i) const;
@@ -184,6 +191,18 @@ public:
         @throw Exception `i >= size()`
     */
     value_type at(size_type i) const;
+
+    /** Return the first element.
+
+        @throw Exception `empty()`
+    */
+    value_type front() const;
+
+    /** Return the last element.
+
+        @throw Exception `empty()`
+    */
+    value_type back() const;
 
     /** Return an iterator to the beginning of the range of elements.
      */
@@ -200,6 +219,27 @@ public:
     */
     void emplace_back(value_type value);
 
+    /** Concatenate two arrays.
+    */
+    friend Array operator+(Array const& lhs, Array const& rhs);
+
+    /// @overload
+    template <std::convertible_to<Array> S>
+    friend auto operator+(
+        S const& lhs, Array const& rhs) noexcept
+    {
+        return Array(lhs) + rhs;
+    }
+
+    /// @overload
+    template <std::convertible_to<Array> S>
+    friend auto operator+(
+        Array const& lhs, S const& rhs) noexcept
+    {
+        return lhs + Array(rhs);
+    }
+
+
     /** Swap two arrays.
     */
     void swap(Array& other) noexcept
@@ -213,6 +253,18 @@ public:
     {
         lhs.swap(rhs);
     }
+
+    /** Compare two arrays for equality.
+     */
+    friend
+    bool
+    operator==(Array const&, Array const&) noexcept;
+
+    /** Compare two arrays for precedence.
+     */
+    friend
+    std::strong_ordering
+    operator<=>(Array const&, Array const&) noexcept;
 
     /** Return a diagnostic string.
     */
@@ -261,6 +313,10 @@ public:
     */
     virtual value_type get(size_type i) const = 0;
 
+    /** Set the i-th element, without bounds checking.
+    */
+    virtual void set(size_type, Value);
+
     /** Append an element to the end of the array.
 
         The default implementation throws an exception,
@@ -298,6 +354,7 @@ public:
         storage_type elements) noexcept;
     size_type size() const override;
     value_type get(size_type i) const override;
+    void set(size_type i, Value v) override;
     void emplace_back(value_type value) override;
 
 private:

--- a/include/mrdox/Dom/Array.ipp
+++ b/include/mrdox/Dom/Array.ipp
@@ -170,6 +170,11 @@ inline auto Array::get(std::size_t i) const -> value_type
     return impl_->get(i);
 }
 
+inline void Array::set(std::size_t i, Value v)
+{
+    impl_->set(i, std::move(v));
+}
+
 inline auto Array::operator[](std::size_t i) const -> value_type
 {
     return get(i);
@@ -179,7 +184,17 @@ inline auto Array::at(std::size_t i) const -> value_type
 {
     if(i < size())
         return get(i);
-    Error("out of range").Throw();
+    return {};
+}
+
+inline auto Array::front() const -> value_type
+{
+    return at(0);
+}
+
+inline auto Array::back() const -> value_type
+{
+    return at(size() - 1);
 }
 
 inline auto Array::begin() const -> iterator
@@ -195,6 +210,17 @@ inline auto Array::end() const -> iterator
 inline void Array::emplace_back(value_type value)
 {
     impl_->emplace_back(std::move(value));
+}
+
+inline
+Array operator+(Array const& lhs, Array const& rhs)
+{
+    Array buf;
+    for (auto e: lhs)
+        buf.emplace_back(e);
+    for (auto e: rhs)
+        buf.emplace_back(e);
+    return buf;
 }
 
 } // dom

--- a/include/mrdox/Dom/Kind.hpp
+++ b/include/mrdox/Dom/Kind.hpp
@@ -12,6 +12,7 @@
 #define MRDOX_API_DOM_KIND_HPP
 
 #include <mrdox/Platform.hpp>
+#include <string_view>
 
 namespace clang {
 namespace mrdox {
@@ -31,6 +32,25 @@ enum class Kind
     Object,
     Function
 };
+
+static constexpr
+std::string_view
+toString(Kind const& value)
+{
+    switch (value)
+    {
+    case Kind::Undefined:    return "undefined";
+    case Kind::Null:         return "null";
+    case Kind::Boolean:      return "boolean";
+    case Kind::Integer:      return "integer";
+    case Kind::String:       return "string";
+    case Kind::SafeString:   return "safeString";
+    case Kind::Array:        return "array";
+    case Kind::Object:       return "object";
+    case Kind::Function:     return "function";
+    }
+    return "unknown";
+}
 
 } // dom
 } // mrdox

--- a/include/mrdox/Dom/Object.hpp
+++ b/include/mrdox/Dom/Object.hpp
@@ -190,6 +190,10 @@ public:
     */
     reference operator[](size_type i) const;
 
+    /** Return the element for a given key.
+    */
+    dom::Value operator[](std::string_view key) const;
+
     /** Return the i-th element.
 
         @throw Exception `i >= size()`
@@ -243,6 +247,25 @@ public:
     friend void swap(Object& lhs, Object& rhs) noexcept
     {
         lhs.swap(rhs);
+    }
+
+    /** Compare two objects for equality.
+     */
+    friend
+    bool
+    operator==(Object const& a, Object const& b) noexcept;
+
+    /** Compare two objects for precedence.
+     */
+    friend
+    std::strong_ordering
+    operator<=>(Object const& a, Object const& b) noexcept
+    {
+        if (a.impl_ == b.impl_)
+        {
+            return std::strong_ordering::equal;
+        }
+        return std::strong_ordering::equivalent;
     }
 
     //--------------------------------------------

--- a/include/mrdox/Dom/Object.ipp
+++ b/include/mrdox/Dom/Object.ipp
@@ -269,6 +269,11 @@ inline auto Object::operator[](size_type i) const -> reference
     return get(i);
 }
 
+inline auto Object::operator[](std::string_view key) const -> dom::Value
+{
+    return this->find(key);
+}
+
 inline auto Object::at(size_type i) const -> reference
 {
     if(i < size())

--- a/include/mrdox/Dom/String.hpp
+++ b/include/mrdox/Dom/String.hpp
@@ -258,6 +258,36 @@ public:
     {
         return lhs.get() <=> rhs.get();
     }
+
+    /** Concatenate two strings.
+    */
+    friend auto operator+(
+        String const& lhs, String const& rhs) noexcept
+    {
+        std::string buf(lhs.get());
+        buf.append(rhs.get());
+        return String(buf);
+    }
+
+    /// @overload
+    template <std::convertible_to<std::string_view> S>
+    friend auto operator+(
+        S const& lhs, String const& rhs) noexcept
+    {
+        std::string buf(lhs);
+        buf.append(rhs.get());
+        return String(buf);
+    }
+
+    /// @overload
+    template <std::convertible_to<std::string_view> S>
+    friend auto operator+(
+        String const& lhs, S const& rhs) noexcept
+    {
+        std::string buf(lhs);
+        buf.append(rhs);
+        return String(buf);
+    }
 };
 
 } // dom

--- a/include/mrdox/Support/Error.hpp
+++ b/include/mrdox/Support/Error.hpp
@@ -59,7 +59,7 @@ class Exception;
 
 /** Holds the description of an error, or success.
 */
-class [[nodiscard]] MRDOX_DECL
+class MRDOX_DECL
     Error final
 {
     std::string where_;
@@ -294,8 +294,7 @@ public:
 /** A container holding an error or a value.
 */
 template<class T>
-class [[nodiscard]]
-    Expected
+class Expected
 {
     union
     {

--- a/share/gdb/mrdox_printers.py
+++ b/share/gdb/mrdox_printers.py
@@ -114,6 +114,8 @@ if __name__ != "__main__":
             return EnumPrinter(val)
 
         typename: str = utils.resolved_typename(val)
+        if typename == 'clang::mrdox::dom::Kind':
+            return EnumPrinter(val)
         if typename == 'clang::mrdox::dom::Value':
             return DomValuePrinter(val)
         if typename == 'clang::mrdox::dom::String':

--- a/src/lib/Dom/Array.cpp
+++ b/src/lib/Dom/Array.cpp
@@ -14,6 +14,10 @@ namespace clang {
 namespace mrdox {
 namespace dom {
 
+void
+ArrayImpl::
+set(size_type, Value) {}
+
 Array::
 ~Array() = default;
 
@@ -55,6 +59,53 @@ operator=(
     swap(temp);
     swap(other);
     return *this;
+}
+
+bool
+operator==(dom::Array const& a, dom::Array const& b) noexcept
+{
+    Array::size_type const an = a.size();
+    Array::size_type const bn = b.size();
+    if (an != bn)
+    {
+        return false;
+    }
+    for (std::size_t i = 0; i < an; ++i)
+    {
+        if (a[i] != b[i])
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::strong_ordering
+operator<=>(Array const& a, Array const& b) noexcept
+{
+    Array::size_type const an = a.size();
+    Array::size_type const bn = b.size();
+    if (an < bn)
+    {
+        return std::strong_ordering::less;
+    }
+    if (bn < an)
+    {
+        return std::strong_ordering::less;
+    }
+    Array::size_type const n = an;
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        if (a[i] < b[i])
+        {
+            return std::strong_ordering::less;
+        }
+        if (b[i] < a[i])
+        {
+            return std::strong_ordering::greater;
+        }
+    }
+    return std::strong_ordering::greater;
 }
 
 std::string
@@ -130,8 +181,19 @@ get(
     size_type i) const ->
         value_type
 {
+    if (i < elements_.size())
+    {
+        return elements_[i];
+    }
+    return {};
+}
+
+void
+DefaultArrayImpl::
+set(size_type i, Value v)
+{
     MRDOX_ASSERT(i < elements_.size());
-    return elements_[i];
+    elements_[i] = std::move(v);
 }
 
 void

--- a/src/lib/Dom/Function.cpp
+++ b/src/lib/Dom/Function.cpp
@@ -21,7 +21,7 @@ struct NullFunction : public FunctionImpl
     Expected<Value>
     call(Array const&) const override
     {
-        return nullptr;
+        return dom::Value(dom::Kind::Undefined);
     }
 };
 

--- a/src/lib/Dom/Object.cpp
+++ b/src/lib/Dom/Object.cpp
@@ -88,6 +88,12 @@ exists(std::string_view key) const
     return false;
 }
 
+bool
+operator==(Object const& a, Object const& b) noexcept
+{
+    return a.impl_ == b.impl_;
+}
+
 std::string
 toString(Object const&)
 {

--- a/src/lib/Metadata/DomMetadata.cpp
+++ b/src/lib/Metadata/DomMetadata.cpp
@@ -489,7 +489,7 @@ public:
         return dom::Object({
             { "name", I.Name },
             { "value", I.Initializer.Value ?
-                *I.Initializer.Value : dom::Value() },
+                dom::Value(*I.Initializer.Value) : dom::Value() },
             { "expr", I.Initializer.Written },
             { "doc", domCreate(I.javadoc, domCorpus_) }
             });

--- a/src/lib/Support/JavaScript.cpp
+++ b/src/lib/Support/JavaScript.cpp
@@ -753,6 +753,9 @@ domValue_push(
     case dom::Kind::Null:
         duk_push_null(A);
         return;
+    case dom::Kind::Undefined:
+        duk_push_undefined(A);
+        return;
     case dom::Kind::Boolean:
         duk_push_boolean(A, value.getBool());
         return;
@@ -761,6 +764,7 @@ domValue_push(
             duk_int_t>(value.getInteger()));
         return;
     case dom::Kind::String:
+    case dom::Kind::SafeString:
         dukM_push_string(A, value.getString());
         return;
     case dom::Kind::Array:

--- a/test-files/handlebars/features_test.adoc
+++ b/test-files/handlebars/features_test.adoc
@@ -1188,20 +1188,6 @@ g
     "f" : "f",
     "g" : "g"
 }
-[
-    {
-        "account_id" : "account-x10",
-        "product" : "Bookcase"
-    },
-    {
-        "account_id" : "account-x10",
-        "product" : "Chair"
-    },
-    {
-        "account_id" : "account-x11",
-        "product" : "Desk"
-    }
-]
 // sort_by
 [
     {

--- a/test-files/handlebars/features_test.adoc.hbs
+++ b/test-files/handlebars/features_test.adoc.hbs
@@ -807,7 +807,7 @@ No city found
 // sort
 {{ sort containers.array }}
 {{ to_string (sort containers.object) }}
-{{ to_string (sort containers.object_array) }}
+{{! to_string (sort containers.object_array) }}
 // sort_by
 {{! sort_by containers.array 'account_id' }}
 {{! sort_by containers.object 'account_id' }}


### PR DESCRIPTION
This PR refactors the handlebars engine to directly use regular `dom::Function`s as helpers. This also implies the helper callbacks became regular `dom::Object`s, which makes javascript bindings much simpler. It also allows native helpers to better interoperate with helpers defined in the context object. Because handlebars rely on helpers for everything, this ended up being the biggest refactor in the library so far.