### PR TITLE
feat: handlebars error handling

### DIFF
--- a/include/mrdox/Dom/Function.hpp
+++ b/include/mrdox/Dom/Function.hpp
@@ -224,6 +224,12 @@ public:
     template<class... Args>
     Value operator()(Args&&... args) const;
 
+    /** Invoke the function.
+    */
+    template<class... Args>
+    Expected<Value>
+    try_invoke(Args&&... args) const;
+
     /** Swap two objects.
     */
     void swap(Function& other) noexcept

--- a/include/mrdox/Support/Error.hpp
+++ b/include/mrdox/Support/Error.hpp
@@ -23,6 +23,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <functional>
 
 namespace clang {
 namespace mrdox {
@@ -226,7 +227,9 @@ public:
         Throw();
     }
 
-    constexpr void swap(Error& rhs) noexcept
+    constexpr
+    void
+    swap(Error& rhs) noexcept
     {
         using std::swap;
         swap(message_, rhs.message_);
@@ -234,8 +237,10 @@ public:
         swap(loc_, rhs.loc_);
     }
 
-    friend constexpr void swap(
-        Error& lhs, Error& rhs) noexcept
+    friend
+    constexpr
+    void
+    swap(Error& lhs, Error& rhs) noexcept
     {
         lhs.swap(rhs);
     }
@@ -291,84 +296,2209 @@ public:
 //
 //------------------------------------------------
 
+template <class T, class E>
+class Expected;
+
+template <class E>
+class Unexpected;
+
+template <class E>
+class BadExpectedAccess;
+
+template <>
+class BadExpectedAccess<void> : public std::exception
+{
+protected:
+    BadExpectedAccess() noexcept = default;
+
+    BadExpectedAccess(const BadExpectedAccess&) = default;
+
+    BadExpectedAccess(BadExpectedAccess&&) = default;
+
+    BadExpectedAccess&
+    operator=(const BadExpectedAccess&) = default;
+
+    BadExpectedAccess&
+    operator=(BadExpectedAccess&&) = default;
+
+    ~BadExpectedAccess() override = default;
+public:
+    [[nodiscard]]
+    const char*
+    what() const noexcept override
+    {
+        return "bad access to Expected without Expected value";
+    }
+};
+
+template <class E>
+class BadExpectedAccess : public BadExpectedAccess<void> {
+    E unex_;
+public:
+    explicit
+    BadExpectedAccess(E e)
+        : unex_(std::move(e)) { }
+
+    [[nodiscard]]
+    E&
+    error() & noexcept
+    {
+        return unex_;
+    }
+
+    [[nodiscard]]
+    const E&
+    error() const & noexcept
+    {
+        return unex_;
+    }
+
+    [[nodiscard]]
+    E&&
+    error() && noexcept
+    {
+        return std::move(unex_);
+    }
+
+    [[nodiscard]]
+    const E&&
+    error() const && noexcept
+    {
+        return std::move(unex_);
+    }
+};
+
+struct unexpect_t
+{
+    explicit unexpect_t() = default;
+};
+
+inline constexpr unexpect_t unexpect{};
+
+namespace detail
+{
+    template <class T>
+    constexpr bool isExpected = false;
+    template <class T, class E>
+    constexpr bool isExpected<Expected<T, E>> = true;
+
+    template <class T>
+    constexpr bool isUnexpected = false;
+    template <class T>
+    constexpr bool isUnexpected<Unexpected<T>> = true;
+
+    template <class Fn, class T>
+    using then_result = std::remove_cvref_t<std::invoke_result_t<Fn&&, T&&>>;
+    template <class Fn, class T>
+    using result_transform = std::remove_cv_t<std::invoke_result_t<Fn&&, T&&>>;
+    template <class Fn>
+    using result0 = std::remove_cvref_t<std::invoke_result_t<Fn&&>>;
+    template <class Fn>
+    using result0_xform = std::remove_cv_t<std::invoke_result_t<Fn&&>>;
+
+    template <class E>
+    concept can_beUnexpected =
+        std::is_object_v<E> &&
+        (!std::is_array_v<E>) &&
+        (!detail::isUnexpected<E>) &&
+        (!std::is_const_v<E>) &&
+        (!std::is_volatile_v<E>);
+
+    // Tag types for in-place construction from an invocation result.
+    struct in_place_inv { };
+    struct unexpect_inv { };
+}
+
+template <class E>
+class Unexpected
+{
+    static_assert(detail::can_beUnexpected<E>);
+    E unex_;
+
+public:
+    constexpr
+    Unexpected(const Unexpected&) = default;
+
+    constexpr
+    Unexpected(Unexpected&&) = default;
+
+    template <class Er = E>
+    requires
+      (!std::is_same_v<std::remove_cvref_t<Er>, Unexpected>) &&
+      (!std::is_same_v<std::remove_cvref_t<Er>, std::in_place_t>) &&
+        std::is_constructible_v<E, Er>
+    constexpr explicit
+    Unexpected(Er&& e) noexcept(std::is_nothrow_constructible_v<E, Er>)
+        : unex_(std::forward<Er>(e))
+    {}
+
+    template <class... Args>
+    requires std::is_constructible_v<E, Args...>
+    constexpr explicit
+    Unexpected(std::in_place_t, Args&&... args)
+    noexcept(std::is_nothrow_constructible_v<E, Args...>)
+        : unex_(std::forward<Args>(args)...)
+    {}
+
+    template <class U, class... Args>
+    requires std::is_constructible_v<E, std::initializer_list<U>&, Args...>
+    constexpr explicit
+    Unexpected(
+        std::in_place_t,
+        std::initializer_list<U> il,
+        Args&&... args)
+    noexcept(std::is_nothrow_constructible_v<
+        E, std::initializer_list<U>&, Args...>)
+        : unex_(il, std::forward<Args>(args)...)
+    {}
+
+    constexpr Unexpected& operator=(const Unexpected&) = default;
+    constexpr Unexpected& operator=(Unexpected&&) = default;
+
+    [[nodiscard]]
+    constexpr const E&
+    error() const & noexcept
+    {
+        return unex_;
+    }
+
+    [[nodiscard]]
+    constexpr E&
+    error() & noexcept
+    {
+        return unex_;
+    }
+
+    [[nodiscard]]
+    constexpr const E&&
+    error() const && noexcept
+    {
+        return std::move(unex_);
+    }
+
+    [[nodiscard]]
+    constexpr E&&
+    error() && noexcept
+    {
+        return std::move(unex_);
+    }
+
+    constexpr
+    void
+    swap(Unexpected& other) noexcept(std::is_nothrow_swappable_v<E>)
+    requires std::is_swappable_v<E>
+    {
+        using std::swap;
+        swap(unex_, other.unex_);
+    }
+
+    template <class Er>
+    [[nodiscard]]
+    friend
+    constexpr
+    bool
+    operator==(const Unexpected& x, const Unexpected<Er>& y)
+    {
+        return x.unex_ == y.error();
+    }
+
+    friend
+    constexpr
+    void
+    swap(Unexpected& x, Unexpected& y)
+    noexcept(noexcept(x.swap(y)))
+    requires std::is_swappable_v<E>
+    {
+        x.swap(y);
+    }
+};
+
+template <class E> Unexpected(E) -> Unexpected<E>;
+
+#ifndef MRDOX_TRY
+#    define MRDOX_MERGE_(a, b) a##b
+#    define MRDOX_LABEL_(a)    MRDOX_MERGE_(expected_result_, a)
+#    define MRDOX_UNIQUE_NAME  MRDOX_LABEL_(__LINE__)
+#    define MRDOX_TRY_VOID(expr)                          \
+        auto MRDOX_UNIQUE_NAME = expr;                    \
+        if (!MRDOX_UNIQUE_NAME) {                         \
+            return Unexpected(MRDOX_UNIQUE_NAME.error()); \
+        }                                                 \
+        void(0)
+#    define MRDOX_TRY_VAR(var, expr)                      \
+        auto MRDOX_UNIQUE_NAME = expr;                    \
+        if (!MRDOX_UNIQUE_NAME) {                         \
+            return Unexpected(MRDOX_UNIQUE_NAME.error()); \
+        }                                                 \
+        var = *std::move(MRDOX_UNIQUE_NAME)
+#    define GET_MACRO(_1, _2, NAME, ...) NAME
+#    define MRDOX_TRY(...) \
+        GET_MACRO(__VA_ARGS__, MRDOX_TRY_VAR, MRDOX_TRY_VOID)(__VA_ARGS__)
+#endif
+
+
+/// @cond undocumented
+namespace detail
+{
+    template <class T>
+    class ExpectedGuard
+    {
+        static_assert( std::is_nothrow_move_constructible_v<T> );
+        T* guarded_;
+        T tmp_;
+
+    public:
+        constexpr explicit
+        ExpectedGuard(T& x)
+            : guarded_(std::addressof(x))
+            , tmp_(std::move(x))
+        {
+            std::destroy_at(guarded_);
+        }
+
+        constexpr
+        ~ExpectedGuard()
+        {
+            if (guarded_) [[unlikely]]
+            {
+                std::construct_at(guarded_, std::move(tmp_));
+            }
+        }
+
+        ExpectedGuard(const ExpectedGuard&) = delete;
+
+        ExpectedGuard& operator=(const ExpectedGuard&) = delete;
+
+        constexpr T&&
+        release() noexcept
+        {
+            guarded_ = nullptr;
+            return std::move(tmp_);
+        }
+    };
+
+    template <class T, class U, class Vp>
+    constexpr
+    void
+    ExpectedReinit(T* newval, U* oldval, Vp&& arg)
+    noexcept(std::is_nothrow_constructible_v<T, Vp>)
+    {
+        if constexpr (std::is_nothrow_constructible_v<T, Vp>)
+        {
+            std::destroy_at(oldval);
+            std::construct_at(newval, std::forward<Vp>(arg));
+        }
+        else if constexpr (std::is_nothrow_move_constructible_v<T>)
+        {
+            T tmp(std::forward<Vp>(arg)); // might throw
+            std::destroy_at(oldval);
+            std::construct_at(newval, std::move(tmp));
+        }
+        else
+        {
+            ExpectedGuard<U> guard(*oldval);
+            std::construct_at(newval, std::forward<Vp>(arg)); // might throw
+            guard.release();
+        }
+    }
+}
+/// @endcond
+
 /** A container holding an error or a value.
-*/
-template<class T>
+ */
+template <class T, class E = Error>
 class Expected
 {
-    union
-    {
-        T v_;
-        Error e_;
-    };
-    bool has_error_;
+    static_assert(!std::is_reference_v<T>);
+    static_assert(!std::is_function_v<T>);
+    static_assert(!std::is_same_v<std::remove_cv_t<T>, std::in_place_t>);
+    static_assert(!std::is_same_v<std::remove_cv_t<T>, unexpect_t>);
+    static_assert(!detail::isUnexpected<std::remove_cv_t<T>>);
+    static_assert(detail::can_beUnexpected<E>);
 
-#if 0
-    static_assert(! std::is_reference_v<T>);
-    static_assert(! std::convertible_to<T, Error>);
-    static_assert(std::move_constructible<T>);
-    static_assert(std::is_nothrow_move_constructible_v<T>);
-    static_assert(std::is_nothrow_move_constructible_v<Error>);
-#endif
+    template <class U, class Er, class Unex = Unexpected<E>>
+    static constexpr bool constructible_from_expected =
+           std::constructible_from<T, Expected<U, Er>&> ||
+           std::constructible_from<T, Expected<U, Er>> ||
+           std::constructible_from<T, const Expected<U, Er>&> ||
+           std::constructible_from<T, const Expected<U, Er>> ||
+           std::convertible_to<Expected<U, Er>&, T> ||
+           std::convertible_to<Expected<U, Er>, T> ||
+           std::convertible_to<const Expected<U, Er>&, T> ||
+           std::convertible_to<const Expected<U, Er>, T> ||
+           std::constructible_from<Unex, Expected<U, Er>&> ||
+           std::constructible_from<Unex, Expected<U, Er>> ||
+           std::constructible_from<Unex, const Expected<U, Er>&> ||
+           std::constructible_from<Unex, const Expected<U, Er>>;
+
+    template <class U, class Er>
+    constexpr static bool explicit_conv
+      = (!std::convertible_to<U, T>) ||
+        (!std::convertible_to<Er, E>);
+
+    template <class U>
+    static constexpr bool same_val
+      = std::is_same_v<class U::value_type, T>;
+
+    template <class U>
+    static constexpr bool same_err
+      = std::is_same_v<class U::error_type, E>;
+
+    template <class, class> friend class Expected;
+
+    union {
+        T val_;
+        E unex_;
+    };
+
+    bool has_value_;
 
 public:
     using value_type = T;
-    using error_type = Error;
+    using error_type = E;
+    using unexpected_type = Unexpected<E>;
 
-    Expected(Expected const&) = delete;
-    Expected& operator=(Expected const&) = delete;
+    template <class U>
+    using rebind = Expected<U, error_type>;
 
-    ~Expected();
-    Expected(Error err) noexcept;
-    Expected(Expected&& other) noexcept;
-    Expected& operator=(Expected&& other) noexcept;
+    constexpr
+    Expected()
+    noexcept(std::is_nothrow_default_constructible_v<T>)
+    requires std::is_default_constructible_v<T>
+        : val_()
+        , has_value_(true)
+    {}
 
-    template<class U>
-    requires std::convertible_to<U, T>
-    Expected(U&& u);
+    Expected(Expected const&) = default;
 
-    template<class U>
-    requires std::convertible_to<U, T>
-    Expected& operator=(Expected<U>&& other) noexcept;
+    constexpr
+    Expected(Expected const& x)
+    noexcept(
+        std::is_nothrow_copy_constructible_v<T> &&
+        std::is_nothrow_copy_constructible_v<E>)
+    requires
+        std::is_copy_constructible_v<T> &&
+        std::is_copy_constructible_v<E> &&
+        (!std::is_trivially_copy_constructible_v<T> ||
+         !std::is_trivially_copy_constructible_v<E>)
+        : has_value_(x.has_value_)
+    {
+        if (has_value_)
+        {
+            std::construct_at(std::addressof(val_), x.val_);
+        }
+        else
+        {
+            std::construct_at(std::addressof(unex_), x.unex_);
+        }
+    }
+
+    Expected(Expected&&) = default;
+
+    constexpr
+    Expected(Expected&& x)
+    noexcept(
+        std::is_nothrow_move_constructible_v<T> &&
+        std::is_nothrow_move_constructible_v<E>)
+    requires
+        std::is_move_constructible_v<T> &&
+        std::is_move_constructible_v<E> &&
+        (!std::is_trivially_move_constructible_v<T> ||
+         !std::is_trivially_move_constructible_v<E>)
+        : has_value_(x.has_value_)
+    {
+        if (has_value_)
+        {
+            std::construct_at(std::addressof(val_), std::move(x).val_);
+        }
+        else
+        {
+            std::construct_at(std::addressof(unex_), std::move(x).unex_);
+        }
+    }
+
+    template <class U, class G>
+    requires
+        std::is_constructible_v<T, const U&> &&
+        std::is_constructible_v<E, const G&> &&
+        (!constructible_from_expected<U, G>)
+    constexpr
+    explicit(explicit_conv<const U&, const G&>)
+    Expected(const Expected<U, G>& x)
+    noexcept(
+        std::is_nothrow_constructible_v<T, const U&> &&
+        std::is_nothrow_constructible_v<E, const G&>)
+        : has_value_(x.has_value_)
+    {
+        if (has_value_)
+        {
+            std::construct_at(std::addressof(val_), x.val_);
+        }
+        else
+        {
+            std::construct_at(std::addressof(unex_), x.unex_);
+        }
+    }
+
+    template <class U, class G>
+    requires
+        std::is_constructible_v<T, U> &&
+        std::is_constructible_v<E, G> &&
+        (!constructible_from_expected<U, G>)
+    constexpr
+    explicit(explicit_conv<U, G>)
+    Expected(Expected<U, G>&& x)
+    noexcept(
+        std::is_nothrow_constructible_v<T, U> &&
+        std::is_nothrow_constructible_v<E, G>)
+        : has_value_(x.has_value_)
+    {
+        if (has_value_)
+        {
+            std::construct_at(std::addressof(val_), std::move(x).val_);
+        }
+        else
+        {
+            std::construct_at(std::addressof(unex_), std::move(x).unex_);
+        }
+    }
+
+    template <class U = T>
+    requires
+        (!std::is_same_v<std::remove_cvref_t<U>, Expected>) &&
+        (!std::is_same_v<std::remove_cvref_t<U>, std::in_place_t>) &&
+        (!detail::isUnexpected<std::remove_cvref_t<U>>) &&
+        std::is_constructible_v<T, U>
+    constexpr
+    explicit(!std::is_convertible_v<U, T>)
+    Expected(U&& v)
+    noexcept(std::is_nothrow_constructible_v<T, U>)
+        : val_(std::forward<U>(v))
+        , has_value_(true)
+    { }
+
+    template <class G = E>
+    requires std::is_constructible_v<E, const G&>
+    constexpr
+    explicit(!std::is_convertible_v<const G&, E>)
+    Expected(const Unexpected<G>& u)
+    noexcept(std::is_nothrow_constructible_v<E, const G&>)
+        : unex_(u.error())
+        , has_value_(false)
+    { }
+
+    template <class G = E>
+    requires std::is_constructible_v<E, G>
+    constexpr
+    explicit(!std::is_convertible_v<G, E>)
+    Expected(Unexpected<G>&& u)
+    noexcept(std::is_nothrow_constructible_v<E, G>)
+        : unex_(std::move(u).error())
+        , has_value_(false)
+    { }
+
+    template <class... Args>
+    requires std::is_constructible_v<T, Args...>
+    constexpr explicit
+    Expected(std::in_place_t, Args&&... args)
+    noexcept(std::is_nothrow_constructible_v<T, Args...>)
+        : val_(std::forward<Args>(args)...)
+        , has_value_(true)
+    { }
+
+    template <class U, class... Args>
+    requires
+        std::is_constructible_v<T, std::initializer_list<U>&, Args...>
+    constexpr explicit
+    Expected(
+        std::in_place_t,
+        std::initializer_list<U> il,
+        Args&&... args)
+    noexcept(
+        std::is_nothrow_constructible_v<
+            T, std::initializer_list<U>&, Args...>)
+        : val_(il, std::forward<Args>(args)...)
+        , has_value_(true)
+    { }
+
+    template <class... Args>
+    requires std::is_constructible_v<E, Args...>
+    constexpr explicit
+    Expected(unexpect_t, Args&&... args)
+    noexcept(std::is_nothrow_constructible_v<E, Args...>)
+        : unex_(std::forward<Args>(args)...)
+        , has_value_(false)
+    { }
+
+    template <class U, class... Args>
+    requires std::is_constructible_v<E, std::initializer_list<U>&, Args...>
+    constexpr explicit
+    Expected(
+        unexpect_t,
+        std::initializer_list<U> il,
+        Args&&... args)
+    noexcept(
+        std::is_nothrow_constructible_v<
+            E, std::initializer_list<U>&, Args...>)
+        : unex_(il, std::forward<Args>(args)...)
+        , has_value_(false)
+    { }
+
+    constexpr ~Expected() = default;
+
+    constexpr ~Expected()
+    requires
+        (!std::is_trivially_destructible_v<T>)
+        || (!std::is_trivially_destructible_v<E>)
+    {
+        if (has_value_)
+        {
+            std::destroy_at(std::addressof(val_));
+        }
+        else
+        {
+            std::destroy_at(std::addressof(unex_));
+        }
+    }
+
+    Expected&
+    operator=(Expected const&) = delete;
+
+    constexpr
+    Expected&
+    operator=(Expected const& x)
+    noexcept(
+        std::is_nothrow_copy_constructible_v<T> &&
+        std::is_nothrow_copy_constructible_v<E> &&
+        std::is_nothrow_copy_assignable_v<T> &&
+        std::is_nothrow_copy_assignable_v<E>)
+    requires
+        std::is_copy_assignable_v<T> &&
+        std::is_copy_constructible_v<T> &&
+        std::is_copy_assignable_v<E> &&
+        std::is_copy_constructible_v<E> &&
+        (std::is_nothrow_move_constructible_v<T> ||
+         std::is_nothrow_move_constructible_v<E>)
+    {
+        if (x.has_value_)
+        {
+            this->assign_val_impl(x.val_);
+        }
+        else
+        {
+            this->assign_unex_impl(x.unex_);
+        }
+        return *this;
+    }
+
+    constexpr
+    Expected&
+    operator=(Expected&& x)
+    noexcept(
+        std::is_nothrow_move_constructible_v<T> &&
+        std::is_nothrow_move_constructible_v<E> &&
+        std::is_nothrow_move_assignable_v<T> &&
+        std::is_nothrow_move_assignable_v<E>)
+    requires
+        std::is_move_assignable_v<T> &&
+        std::is_move_constructible_v<T> &&
+        std::is_move_assignable_v<E> &&
+        std::is_move_constructible_v<E> &&
+        (std::is_nothrow_move_constructible_v<T> ||
+         std::is_nothrow_move_constructible_v<E>)
+    {
+        if (x.has_value_)
+        {
+            assign_val_impl(std::move(x.val_));
+        }
+        else
+        {
+            assign_unex_impl(std::move(x.unex_));
+        }
+        return *this;
+    }
+
+    template <class U = T>
+    requires
+        (!std::is_same_v<Expected, std::remove_cvref_t<U>>) &&
+        (!detail::isUnexpected<std::remove_cvref_t<U>>) &&
+        std::is_constructible_v<T, U> &&
+        std::is_assignable_v<T&, U> &&
+        (std::is_nothrow_constructible_v<T, U> ||
+         std::is_nothrow_move_constructible_v<T> ||
+         std::is_nothrow_move_constructible_v<E>)
+    constexpr
+    Expected&
+    operator=(U&& v)
+    {
+        assign_val_impl(std::forward<U>(v));
+        return *this;
+    }
+
+    template <class G>
+    requires
+        std::is_constructible_v<E, const G&> &&
+        std::is_assignable_v<E&, const G&> &&
+        (std::is_nothrow_constructible_v<E, const G&> ||
+         std::is_nothrow_move_constructible_v<T> ||
+         std::is_nothrow_move_constructible_v<E>)
+    constexpr
+    Expected&
+    operator=(const Unexpected<G>& e)
+    {
+        assign_unex_impl(e.error());
+        return *this;
+    }
+
+    template <class G>
+    requires
+        std::is_constructible_v<E, G> &&
+        std::is_assignable_v<E&, G> &&
+        (std::is_nothrow_constructible_v<E, G> ||
+         std::is_nothrow_move_constructible_v<T> ||
+         std::is_nothrow_move_constructible_v<E>)
+    constexpr
+    Expected&
+    operator=(Unexpected<G>&& e)
+    {
+        assign_unex_impl(std::move(e).error());
+        return *this;
+    }
+
+    template <class... Args>
+    requires std::is_nothrow_constructible_v<T, Args...>
+    constexpr
+    T&
+    emplace(Args&&... args) noexcept
+    {
+        if (has_value_)
+        {
+            std::destroy_at(std::addressof(val_));
+        }
+        else
+        {
+            std::destroy_at(std::addressof(unex_));
+            has_value_ = true;
+        }
+        std::construct_at(
+            std::addressof(val_),
+            std::forward<Args>(args)...);
+        return val_;
+    }
+
+    template <class U, class... Args>
+    requires
+        std::is_nothrow_constructible_v<
+            T, std::initializer_list<U>&, Args...>
+    constexpr
+    T&
+    emplace(std::initializer_list<U> il, Args&&... args) noexcept
+    {
+        if (has_value_)
+        {
+            std::destroy_at(std::addressof(val_));
+        }
+        else
+        {
+            std::destroy_at(std::addressof(unex_));
+            has_value_ = true;
+        }
+        std::construct_at(
+            std::addressof(val_), il,
+            std::forward<Args>(args)...);
+        return val_;
+    }
+
+    constexpr
+    void
+    swap(Expected& x)
+    noexcept(
+        std::is_nothrow_move_constructible_v<T> &&
+        std::is_nothrow_move_constructible_v<E> &&
+        std::is_nothrow_swappable_v<T&> &&
+        std::is_nothrow_swappable_v<E&>)
+    requires
+        std::is_swappable_v<T> &&
+        std::is_swappable_v<E> &&
+        std::is_move_constructible_v<T> &&
+        std::is_move_constructible_v<E> &&
+        (std::is_nothrow_move_constructible_v<T> ||
+         std::is_nothrow_move_constructible_v<E>)
+    {
+        if (has_value_)
+        {
+            if (x.has_value_)
+            {
+                using std::swap;
+                swap(val_, x.val_);
+            }
+            else
+            {
+                this->swap_val_unex_impl(x);
+            }
+        }
+        else
+        {
+            if (x.has_value_)
+            {
+                x.swap_val_unex_impl(*this);
+            }
+            else
+            {
+                using std::swap;
+                swap(unex_, x.unex_);
+            }
+        }
+    }
 
     // observers
 
-    constexpr bool has_value() const noexcept;
-    constexpr bool has_error() const noexcept;
-    constexpr explicit operator bool() const noexcept;
-
-    // checked value access
-
-    constexpr T& value() &;
-    constexpr T value() &&;
-    constexpr T const& value() const&;
-    constexpr T value() const&& = delete;
-    constexpr T release() noexcept;
-
-    // unchecked access
-
-    constexpr T* operator->() noexcept;
-    constexpr T& operator*() & noexcept;
-    constexpr T operator*() &&;
-
-    constexpr T const* operator->() const noexcept;
-    constexpr T const& operator*() const& noexcept;
-    constexpr T operator*() const&& noexcept = delete;
-
-    // error access
-
-    Error error() const& noexcept;
-    Error error() && noexcept;
-
-    // swap
-
-    void swap(Expected& rhs) noexcept;
-
-    friend void swap(
-        Expected& lhs, Expected& rhs) noexcept
+    [[nodiscard]]
+    constexpr
+    T const*
+    operator->() const noexcept
     {
-        lhs.swap(rhs);
+        MRDOX_ASSERT(has_value_);
+        return std::addressof(val_);
     }
+
+    [[nodiscard]]
+    constexpr
+    T*
+    operator->() noexcept
+    {
+        MRDOX_ASSERT(has_value_);
+        return std::addressof(val_);
+    }
+
+    [[nodiscard]]
+    constexpr
+    T const&
+    operator*() const & noexcept
+    {
+        MRDOX_ASSERT(has_value_);
+        return val_;
+    }
+
+    [[nodiscard]]
+    constexpr
+    T&
+    operator*() & noexcept
+    {
+        MRDOX_ASSERT(has_value_);
+        return val_;
+    }
+
+    [[nodiscard]]
+    constexpr
+    T const&&
+    operator*() const && noexcept
+    {
+        MRDOX_ASSERT(has_value_);
+        return std::move(val_);
+    }
+
+    [[nodiscard]]
+    constexpr
+    T&&
+    operator*() && noexcept
+    {
+        MRDOX_ASSERT(has_value_);
+        return std::move(val_);
+    }
+
+    [[nodiscard]]
+    constexpr explicit
+    operator bool() const noexcept
+    {
+        return has_value_;
+    }
+
+    [[nodiscard]]
+    constexpr bool has_value() const noexcept
+    {
+        return has_value_;
+    }
+
+    constexpr T const&
+    value() const &
+    {
+        if (has_value_) [[likely]]
+        {
+            return val_;
+        }
+        throw BadExpectedAccess<E>(unex_);
+    }
+
+    constexpr T&
+    value() &
+    {
+        if (has_value_) [[likely]]
+        {
+            return val_;
+        }
+        const auto& unex = unex_;
+        throw BadExpectedAccess<E>(unex);
+    }
+
+    constexpr T const&&
+    value() const &&
+    {
+        if (has_value_) [[likely]]
+        {
+            return std::move(val_);
+        }
+        throw BadExpectedAccess<E>(std::move(unex_));
+    }
+
+    constexpr T&&
+    value() &&
+    {
+        if (has_value_) [[likely]]
+        {
+            return std::move(val_);
+        }
+        throw BadExpectedAccess<E>(std::move(unex_));
+    }
+
+    constexpr const E&
+    error() const & noexcept
+    {
+        MRDOX_ASSERT(!has_value_);
+        return unex_;
+    }
+
+    constexpr E&
+    error() & noexcept
+    {
+        MRDOX_ASSERT(!has_value_);
+        return unex_;
+    }
+
+    constexpr const E&&
+    error() const && noexcept
+    {
+        MRDOX_ASSERT(!has_value_);
+        return std::move(unex_);
+    }
+
+    constexpr E&&
+    error() && noexcept
+    {
+        MRDOX_ASSERT(!has_value_);
+        return std::move(unex_);
+    }
+
+    template <class U>
+    constexpr
+    T
+    value_or(U&& v) const &
+    noexcept(
+        std::is_nothrow_copy_constructible_v<T> &&
+        std::is_nothrow_convertible_v<U, T>)
+    {
+        static_assert( std::is_copy_constructible_v<T> );
+        static_assert( std::is_convertible_v<U, T> );
+        if (has_value_)
+        {
+            return val_;
+        }
+        return static_cast<T>(std::forward<U>(v));
+    }
+
+    template <class U>
+    constexpr
+    T
+    value_or(U&& v) &&
+    noexcept(
+        std::is_nothrow_move_constructible_v<T> &&
+        std::is_nothrow_convertible_v<U, T>)
+    {
+        static_assert( std::is_move_constructible_v<T> );
+        static_assert( std::is_convertible_v<U, T> );
+        if (has_value_)
+        {
+            return std::move(val_);
+        }
+        return static_cast<T>(std::forward<U>(v));
+    }
+
+    template <class G = E>
+    constexpr
+    E
+    error_or(G&& e) const&
+    {
+        static_assert(std::is_copy_constructible_v<E>);
+        static_assert(std::is_convertible_v<G, E>);
+        if (has_value_)
+        {
+            return std::forward<G>(e);
+        }
+        return unex_;
+    }
+
+    template <class G = E>
+    constexpr E
+    error_or(G&& e) &&
+    {
+        static_assert(std::is_move_constructible_v<E>);
+        static_assert(std::is_convertible_v<G, E>);
+        if (has_value_)
+        {
+            return std::forward<G>(e);
+        }
+        return std::move(unex_);
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, E&>
+    constexpr
+    auto
+    and_then(Fn&& f) &
+    {
+        using U = detail::then_result<Fn, T&>;
+        static_assert(detail::isExpected<U>);
+        static_assert(std::is_same_v<class U::error_type, E>);
+
+        if (has_value())
+        {
+            return std::invoke(std::forward<Fn>(f), val_);
+        }
+        else
+        {
+            return U(unexpect, unex_);
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, const E&>
+    constexpr
+    auto
+    and_then(Fn&& f) const &
+    {
+        using U = detail::then_result<Fn, const T&>;
+        static_assert(detail::isExpected<U>);
+        static_assert(std::is_same_v<class U::error_type, E>);
+
+        if (has_value())
+        {
+            return std::invoke(std::forward<Fn>(f), val_);
+        }
+        else
+        {
+            return U(unexpect, unex_);
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, E>
+    constexpr
+    auto
+    and_then(Fn&& f) &&
+    {
+        using U = detail::then_result<Fn, T&&>;
+        static_assert(detail::isExpected<U>);
+        static_assert(std::is_same_v<class U::error_type, E>);
+
+        if (has_value())
+        {
+            return std::invoke(std::forward<Fn>(f), std::move(val_));
+        }
+        else
+        {
+            return U(unexpect, std::move(unex_));
+        }
+    }
+
+
+    template <class Fn>
+    requires std::is_constructible_v<E, const E>
+    constexpr
+    auto
+    and_then(Fn&& f) const &&
+    {
+        using U = detail::then_result<Fn, const T&&>;
+        static_assert(detail::isExpected<U>);
+        static_assert(std::is_same_v<class U::error_type, E>);
+
+        if (has_value())
+        {
+            return std::invoke(std::forward<Fn>(f), std::move(val_));
+        }
+        else
+        {
+            return U(unexpect, std::move(unex_));
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<T, T&>
+    constexpr
+    auto
+    or_else(Fn&& f) &
+    {
+        using G = detail::then_result<Fn, E&>;
+        static_assert(detail::isExpected<G>);
+        static_assert(std::is_same_v<class G::value_type, T>);
+
+        if (has_value())
+        {
+            return G(std::in_place, val_);
+        }
+        else
+        {
+            return std::invoke(std::forward<Fn>(f), unex_);
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<T, const T&>
+    constexpr
+    auto
+    or_else(Fn&& f) const &
+    {
+        using G = detail::then_result<Fn, const E&>;
+        static_assert(detail::isExpected<G>);
+        static_assert(std::is_same_v<class G::value_type, T>);
+
+        if (has_value())
+        {
+            return G(std::in_place, val_);
+        }
+        else
+        {
+            return std::invoke(std::forward<Fn>(f), unex_);
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<T, T>
+    constexpr
+    auto
+    or_else(Fn&& f) &&
+    {
+      using G = detail::then_result<Fn, E&&>;
+      static_assert(detail::isExpected<G>);
+      static_assert(std::is_same_v<class G::value_type, T>);
+
+      if (has_value())
+      {
+          return G(std::in_place, std::move(val_));
+      }
+      else
+      {
+          return std::invoke(std::forward<Fn>(f), std::move(unex_));
+      }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<T, const T>
+    constexpr
+    auto
+    or_else(Fn&& f) const &&
+    {
+        using G = detail::then_result<Fn, const E&&>;
+        static_assert(detail::isExpected<G>);
+        static_assert(std::is_same_v<class G::value_type, T>);
+
+        if (has_value())
+        {
+            return G(std::in_place, std::move(val_));
+        }
+        else
+        {
+            return std::invoke(std::forward<Fn>(f), std::move(unex_));
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, E&>
+    constexpr
+    auto
+    transform(Fn&& f) &
+    {
+        using U = detail::result_transform<Fn, T&>;
+        using Res = Expected<U, E>;
+
+        if (has_value())
+        {
+            return Res(
+                in_place_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), val_);
+                });
+        }
+        else
+        {
+            return Res(unexpect, unex_);
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, const E&>
+    constexpr
+    auto
+    transform(Fn&& f) const &
+    {
+        using U = detail::result_transform<Fn, const T&>;
+        using Res = Expected<U, E>;
+
+        if (has_value())
+        {
+            return Res(
+                in_place_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), val_);
+                });
+        }
+        else
+        {
+            return Res(unexpect, unex_);
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, E>
+    constexpr
+    auto
+    transform(Fn&& f) &&
+    {
+        using U = detail::result_transform<Fn, T>;
+        using Res = Expected<U, E>;
+
+        if (has_value())
+        {
+            return Res(
+                in_place_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), std::move(val_));
+                });
+        }
+        else
+        {
+            return Res(unexpect, std::move(unex_));
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, const E>
+    constexpr
+    auto
+    transform(Fn&& f) const &&
+    {
+        using U = detail::result_transform<Fn, const T>;
+        using Res = Expected<U, E>;
+
+        if (has_value())
+        {
+            return Res(
+                in_place_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), std::move(val_));
+                });
+        }
+        else
+        {
+            return Res(unexpect, std::move(unex_));
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<T, T&>
+    constexpr
+    auto
+    transform_error(Fn&& f) &
+    {
+        using G = detail::result_transform<Fn, E&>;
+        using Res = Expected<T, G>;
+
+        if (has_value())
+        {
+            return Res(std::in_place, val_);
+        }
+        else
+        {
+            return Res(
+                unexpect_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), unex_);
+                });
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<T, const T&>
+    constexpr
+    auto
+    transform_error(Fn&& f) const &
+    {
+        using G = detail::result_transform<Fn, const E&>;
+        using Res = Expected<T, G>;
+
+        if (has_value())
+        {
+            return Res(std::in_place, val_);
+        }
+        else
+        {
+            return Res(
+                unexpect_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), unex_);
+                });
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<T, T>
+    constexpr
+    auto
+    transform_error(Fn&& f) &&
+    {
+        using G = detail::result_transform<Fn, E&&>;
+        using Res = Expected<T, G>;
+
+        if (has_value())
+        {
+            return Res(std::in_place, std::move(val_));
+        }
+        else
+        {
+            return Res(
+                unexpect_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), std::move(unex_));
+                });
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<T, const T>
+    constexpr
+    auto
+    transform_error(Fn&& f) const &&
+    {
+        using G = detail::result_transform<Fn, const E&&>;
+        using Res = Expected<T, G>;
+
+        if (has_value())
+        {
+            return Res(std::in_place, std::move(val_));
+        }
+        else
+        {
+            return Res(unexpect_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), std::move(unex_));
+                });
+        }
+    }
+
+    template <class U, class E2>
+    requires (!std::is_void_v<U>)
+    friend
+    constexpr
+    bool
+    operator==(Expected const& x, const Expected<U, E2>& y)
+    noexcept(
+        noexcept(bool(*x == *y)) &&
+        noexcept(bool(x.error() == y.error())))
+    {
+        if (x.has_value())
+        {
+            return y.has_value() && bool(*x == *y);
+        }
+        else
+        {
+            return !y.has_value() && bool(x.error() == y.error());
+        }
+    }
+
+    template <class U>
+    friend
+    constexpr
+    bool
+    operator==(Expected const& x, const U& v)
+    noexcept(noexcept(bool(*x == v)))
+    {
+        return x.has_value() && bool(*x == v);
+    }
+
+    template <class E2>
+    friend
+    constexpr
+    bool
+    operator==(Expected const& x, const Unexpected<E2>& e)
+    noexcept(noexcept(bool(x.error() == e.error())))
+    {
+        return !x.has_value() && bool(x.error() == e.error());
+    }
+
+    friend
+    constexpr
+    void
+    swap(Expected& x, Expected& y)
+    noexcept(noexcept(x.swap(y)))
+    requires requires {x.swap(y);}
+    {
+        x.swap(y);
+    }
+
+private:
+    template <class Vp>
+    constexpr
+    void
+    assign_val_impl(Vp&& v)
+    {
+        if (has_value_)
+        {
+            val_ = std::forward<Vp>(v);
+        }
+        else
+        {
+            detail::ExpectedReinit(
+                std::addressof(val_),
+                std::addressof(unex_),
+                std::forward<Vp>(v));
+            has_value_ = true;
+        }
+    }
+
+    template <class Vp>
+    constexpr
+    void
+    assign_unex_impl(Vp&& v)
+    {
+        if (has_value_)
+        {
+            detail::ExpectedReinit(
+                std::addressof(unex_),
+                std::addressof(val_),
+                std::forward<Vp>(v));
+            has_value_ = false;
+        }
+        else
+        {
+            unex_ = std::forward<Vp>(v);
+        }
+    }
+
+    constexpr
+    void
+    swap_val_unex_impl(Expected& rhs)
+    noexcept(
+        std::is_nothrow_move_constructible_v<E> &&
+        std::is_nothrow_move_constructible_v<T>)
+    {
+        if constexpr (std::is_nothrow_move_constructible_v<E>)
+        {
+            detail::ExpectedGuard<E> guard(rhs.unex_);
+            std::construct_at(
+                std::addressof(rhs.val_),
+                std::move(val_));
+            rhs.has_value_ = true;
+            std::destroy_at(std::addressof(val_));
+            std::construct_at(std::addressof(unex_), guard.release());
+            has_value_ = false;
+        }
+        else
+        {
+            detail::ExpectedGuard<T> guard(val_);
+            std::construct_at(
+                std::addressof(unex_),
+                std::move(rhs.unex_));
+            has_value_ = false;
+            std::destroy_at(std::addressof(rhs.unex_));
+            std::construct_at(std::addressof(rhs.val_), guard.release());
+            rhs.has_value_ = true;
+        }
+    }
+
+    using in_place_inv = detail::in_place_inv;
+    using unexpect_inv = detail::unexpect_inv;
+
+    template <class Fn>
+    explicit constexpr
+    Expected(in_place_inv, Fn&& fn)
+        : val_(std::forward<Fn>(fn)()), has_value_(true)
+    { }
+
+    template <class Fn>
+    explicit constexpr
+    Expected(unexpect_inv, Fn&& fn)
+        : unex_(std::forward<Fn>(fn)()), has_value_(false)
+    { }
+};
+
+template <class T, class E>
+requires std::is_void_v<T>
+class Expected<T, E>
+{
+    static_assert( detail::can_beUnexpected<E> );
+
+    template <class U, class Er, class Unex = Unexpected<E>>
+    static constexpr bool constructible_from_expected =
+        std::is_constructible_v<Unex, Expected<U, Er>&> ||
+        std::is_constructible_v<Unex, Expected<U, Er>> ||
+        std::is_constructible_v<Unex, const Expected<U, Er>&> ||
+        std::is_constructible_v<Unex, const Expected<U, Er>>;
+
+    template <class U>
+    static constexpr bool same_val
+      = std::is_same_v<class U::value_type, T>;
+
+    template <class U>
+    static constexpr bool same_err
+      = std::is_same_v<class U::error_type, E>;
+
+    template <class, class> friend class Expected;
+
+    union {
+        struct { } void_;
+        E unex_;
+    };
+
+    bool has_value_;
+
+public:
+    using value_type = T;
+    using error_type = E;
+    using unexpected_type = Unexpected<E>;
+
+    template <class U>
+    using rebind = Expected<U, error_type>;
+
+    constexpr
+    Expected() noexcept
+        : void_()
+        , has_value_(true)
+    { }
+
+    Expected(Expected const&) = default;
+
+    constexpr
+    Expected(Expected const& x)
+    noexcept(std::is_nothrow_copy_constructible_v<E>)
+    requires
+        std::is_copy_constructible_v<E> &&
+        (!std::is_trivially_copy_constructible_v<E>)
+        : void_()
+        , has_value_(x.has_value_)
+    {
+        if (!has_value_)
+        {
+            std::construct_at(std::addressof(unex_), x.unex_);
+        }
+    }
+
+    Expected(Expected&&) = default;
+
+    constexpr
+    Expected(Expected&& x)
+    noexcept(std::is_nothrow_move_constructible_v<E>)
+    requires
+        std::is_move_constructible_v<E> &&
+        (!std::is_trivially_move_constructible_v<E>)
+        : void_(), has_value_(x.has_value_)
+    {
+        if (!has_value_)
+        {
+            std::construct_at(std::addressof(unex_), std::move(x).unex_);
+        }
+    }
+
+    template <class U, class G>
+    requires
+        std::is_void_v<U> &&
+        std::is_constructible_v<E, const G&> &&
+        (!constructible_from_expected<U, G>)
+    constexpr
+    explicit(!std::is_convertible_v<const G&, E>)
+    Expected(const Expected<U, G>& x)
+    noexcept(std::is_nothrow_constructible_v<E, const G&>)
+        : void_()
+        , has_value_(x.has_value_)
+    {
+        if (!has_value_)
+        {
+            std::construct_at(std::addressof(unex_), x.unex_);
+        }
+    }
+
+    template <class U, class G>
+    requires
+        std::is_void_v<U> &&
+        std::is_constructible_v<E, G> &&
+        (!constructible_from_expected<U, G>)
+    constexpr
+    explicit(!std::is_convertible_v<G, E>)
+    Expected(Expected<U, G>&& x)
+    noexcept(std::is_nothrow_constructible_v<E, G>)
+        : void_()
+        , has_value_(x.has_value_)
+    {
+        if (!has_value_)
+        {
+            std::construct_at(std::addressof(unex_), std::move(x).unex_);
+        }
+    }
+
+    template <class G = E>
+    requires std::is_constructible_v<E, const G&>
+    constexpr
+    explicit(!std::is_convertible_v<const G&, E>)
+    Expected(const Unexpected<G>& u)
+    noexcept(std::is_nothrow_constructible_v<E, const G&>)
+        : unex_(u.error())
+        , has_value_(false)
+    { }
+
+    template <class G = E>
+    requires std::is_constructible_v<E, G>
+    constexpr
+    explicit(!std::is_convertible_v<G, E>)
+    Expected(Unexpected<G>&& u)
+    noexcept(std::is_nothrow_constructible_v<E, G>)
+        : unex_(std::move(u).error()), has_value_(false)
+    { }
+
+    constexpr explicit
+    Expected(std::in_place_t) noexcept
+        : Expected()
+    { }
+
+    template <class... Args>
+    requires std::is_constructible_v<E, Args...>
+    constexpr explicit
+    Expected(unexpect_t, Args&&... args)
+    noexcept(std::is_nothrow_constructible_v<E, Args...>)
+        : unex_(std::forward<Args>(args)...)
+        , has_value_(false)
+    { }
+
+    template <class U, class... Args>
+    requires std::is_constructible_v<E, std::initializer_list<U>&, Args...>
+    constexpr explicit
+    Expected(unexpect_t, std::initializer_list<U> il, Args&&... args)
+    noexcept(
+        std::is_nothrow_constructible_v<
+            E, std::initializer_list<U>&, Args...>)
+        : unex_(il, std::forward<Args>(args)...), has_value_(false)
+    { }
+
+    constexpr ~Expected() = default;
+
+    constexpr ~Expected()
+    requires (!std::is_trivially_destructible_v<E>)
+    {
+        if (!has_value_)
+        {
+            std::destroy_at(std::addressof(unex_));
+        }
+    }
+
+    Expected& operator=(Expected const&) = delete;
+
+    constexpr
+    Expected&
+    operator=(Expected const& x)
+    noexcept(
+        std::is_nothrow_copy_constructible_v<E> &&
+        std::is_nothrow_copy_assignable_v<E>)
+    requires
+        std::is_copy_constructible_v<E> &&
+        std::is_copy_assignable_v<E>
+    {
+        if (x.has_value_)
+        {
+            emplace();
+        }
+        else
+        {
+            assign_unex_impl(x.unex_);
+        }
+        return *this;
+    }
+
+    constexpr
+    Expected&
+    operator=(Expected&& x)
+    noexcept(
+        std::is_nothrow_move_constructible_v<E> &&
+        std::is_nothrow_move_assignable_v<E>)
+    requires
+        std::is_move_constructible_v<E> &&
+        std::is_move_assignable_v<E>
+    {
+        if (x.has_value_)
+        {
+            emplace();
+        }
+        else
+        {
+            assign_unex_impl(std::move(x.unex_));
+        }
+        return *this;
+    }
+
+    template <class G>
+    requires
+        std::is_constructible_v<E, const G&> &&
+        std::is_assignable_v<E&, const G&>
+    constexpr
+    Expected&
+    operator=(const Unexpected<G>& e)
+    {
+        assign_unex_impl(e.error());
+        return *this;
+    }
+
+    template <class G>
+    requires
+        std::is_constructible_v<E, G> &&
+        std::is_assignable_v<E&, G>
+    constexpr
+    Expected&
+    operator=(Unexpected<G>&& e)
+    {
+        assign_unex_impl(std::move(e.error()));
+        return *this;
+    }
+
+    constexpr
+    void
+    emplace() noexcept
+    {
+        if (!has_value_)
+        {
+            std::destroy_at(std::addressof(unex_));
+            has_value_ = true;
+        }
+    }
+
+    constexpr
+    void
+    swap(Expected& x)
+    noexcept(
+        std::is_nothrow_swappable_v<E&> &&
+        std::is_nothrow_move_constructible_v<E>)
+    requires
+        std::is_swappable_v<E> &&
+        std::is_move_constructible_v<E>
+    {
+        if (has_value_)
+        {
+            if (!x.has_value_)
+            {
+                std::construct_at(
+                    std::addressof(unex_),
+                    std::move(x.unex_));
+                std::destroy_at(std::addressof(x.unex_));
+                has_value_ = false;
+                x.has_value_ = true;
+            }
+        }
+        else
+        {
+            if (x.has_value_)
+            {
+                std::construct_at(
+                    std::addressof(x.unex_),
+                    std::move(unex_));
+                std::destroy_at(std::addressof(unex_));
+                has_value_ = true;
+                x.has_value_ = false;
+            }
+            else
+            {
+                using std::swap;
+                swap(unex_, x.unex_);
+            }
+        }
+    }
+
+    [[nodiscard]]
+    constexpr
+    explicit
+    operator bool() const noexcept
+    {
+        return has_value_;
+    }
+
+    [[nodiscard]]
+    constexpr
+    bool has_value() const noexcept
+    {
+        return has_value_;
+    }
+
+    constexpr
+    void
+    operator*() const noexcept {
+        MRDOX_ASSERT(has_value_);
+    }
+
+    constexpr
+    void
+    value() const&
+    {
+        if (has_value_) [[likely]]
+        {
+            return;
+        }
+        throw BadExpectedAccess<E>(unex_);
+    }
+
+    constexpr
+    void
+    value() &&
+    {
+        if (has_value_) [[likely]]
+        {
+            return;
+        }
+        throw BadExpectedAccess<E>(std::move(unex_));
+    }
+
+    constexpr const E&
+    error() const & noexcept
+    {
+        MRDOX_ASSERT(!has_value_);
+        return unex_;
+    }
+
+    constexpr E&
+    error() & noexcept
+    {
+        MRDOX_ASSERT(!has_value_);
+        return unex_;
+    }
+
+    constexpr const E&&
+    error() const && noexcept
+    {
+        MRDOX_ASSERT(!has_value_);
+        return std::move(unex_);
+    }
+
+    constexpr E&&
+    error() && noexcept
+    {
+        MRDOX_ASSERT(!has_value_);
+        return std::move(unex_);
+    }
+
+    template <class G = E>
+    constexpr E
+    error_or(G&& e) const&
+    {
+      static_assert( std::is_copy_constructible_v<E> );
+      static_assert( std::is_convertible_v<G, E> );
+
+      if (has_value_)
+      {
+          return std::forward<G>(e);
+      }
+      return unex_;
+    }
+
+    template <class G = E>
+    constexpr E
+    error_or(G&& e) &&
+    {
+        static_assert( std::is_move_constructible_v<E> );
+        static_assert( std::is_convertible_v<G, E> );
+
+        if (has_value_)
+        {
+            return std::forward<G>(e);
+        }
+        return std::move(unex_);
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, E&>
+    constexpr
+    auto
+    and_then(Fn&& f) &
+    {
+        using U = detail::result0<Fn>;
+        static_assert(detail::isExpected<U>);
+        static_assert(std::is_same_v<class U::error_type, E>);
+
+        if (has_value())
+        {
+            return std::invoke(std::forward<Fn>(f));
+        }
+        else
+        {
+            return U(unexpect, unex_);
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, const E&>
+    constexpr
+    auto
+    and_then(Fn&& f) const &
+    {
+        using U = detail::result0<Fn>;
+        static_assert(detail::isExpected<U>);
+        static_assert(std::is_same_v<class U::error_type, E>);
+
+        if (has_value())
+        {
+            return std::invoke(std::forward<Fn>(f));
+        }
+        else
+        {
+            return U(unexpect, unex_);
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, E>
+    constexpr
+    auto
+    and_then(Fn&& f) &&
+    {
+      using U = detail::result0<Fn>;
+      static_assert(detail::isExpected<U>);
+      static_assert(std::is_same_v<class U::error_type, E>);
+
+      if (has_value())
+      {
+          return std::invoke(std::forward<Fn>(f));
+      }
+      else
+      {
+          return U(unexpect, std::move(unex_));
+      }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, const E>
+    constexpr
+    auto
+    and_then(Fn&& f) const &&
+    {
+        using U = detail::result0<Fn>;
+        static_assert(detail::isExpected<U>);
+        static_assert(std::is_same_v<class U::error_type, E>);
+
+        if (has_value())
+        {
+            return std::invoke(std::forward<Fn>(f));
+        }
+        else
+        {
+            return U(unexpect, std::move(unex_));
+        }
+    }
+
+    template <class Fn>
+    constexpr
+    auto
+    or_else(Fn&& f) &
+    {
+        using G = detail::then_result<Fn, E&>;
+        static_assert(detail::isExpected<G>);
+        static_assert(std::is_same_v<class G::value_type, T>);
+
+        if (has_value())
+        {
+            return G();
+        }
+        else
+        {
+            return std::invoke(std::forward<Fn>(f), unex_);
+        }
+    }
+
+    template <class Fn>
+    constexpr
+    auto
+    or_else(Fn&& f) const &
+    {
+        using G = detail::then_result<Fn, E const&>;
+        static_assert(detail::isExpected<G>);
+        static_assert(std::is_same_v<class G::value_type, T>);
+
+        if (has_value())
+        {
+            return G();
+        }
+        else
+        {
+            return std::invoke(std::forward<Fn>(f), unex_);
+        }
+    }
+
+    template <class Fn>
+    constexpr
+    auto
+    or_else(Fn&& f) &&
+    {
+        using G = detail::then_result<Fn, E&&>;
+        static_assert(detail::isExpected<G>);
+        static_assert(std::is_same_v<class G::value_type, T>);
+
+        if (has_value())
+        {
+            return G();
+        }
+        else
+        {
+            return std::invoke(std::forward<Fn>(f), std::move(unex_));
+        }
+    }
+
+    template <class Fn>
+    constexpr
+    auto
+    or_else(Fn&& f) const&&
+    {
+        using G = detail::then_result<Fn, E const&&>;
+        static_assert(detail::isExpected<G>);
+        static_assert(std::is_same_v<class G::value_type, T>);
+
+        if (has_value())
+        {
+            return G();
+        }
+        else
+        {
+            return std::invoke(std::forward<Fn>(f), std::move(unex_));
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, E&>
+    constexpr
+    auto
+    transform(Fn&& f) &
+    {
+        using U = detail::result0_xform<Fn>;
+        using Res = Expected<U, E>;
+
+        if (has_value())
+        {
+            return Res(in_place_inv{}, std::forward<Fn>(f));
+        }
+        else
+        {
+            return Res(unexpect, unex_);
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, const E&>
+    constexpr
+    auto
+    transform(Fn&& f) const &
+    {
+        using U = detail::result0_xform<Fn>;
+        using Res = Expected<U, E>;
+
+        if (has_value())
+        {
+            return Res(in_place_inv{}, std::forward<Fn>(f));
+        }
+        else
+        {
+            return Res(unexpect, unex_);
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, E>
+    constexpr
+    auto
+    transform(Fn&& f) &&
+    {
+        using U = detail::result0_xform<Fn>;
+        using Res = Expected<U, E>;
+
+        if (has_value())
+        {
+            return Res(in_place_inv{}, std::forward<Fn>(f));
+        }
+        else
+        {
+            return Res(unexpect, std::move(unex_));
+        }
+    }
+
+    template <class Fn>
+    requires std::is_constructible_v<E, const E>
+    constexpr
+    auto
+    transform(Fn&& f) const &&
+    {
+        using U = detail::result0_xform<Fn>;
+        using Res = Expected<U, E>;
+
+        if (has_value())
+        {
+            return Res(in_place_inv{}, std::forward<Fn>(f));
+        }
+        else
+        {
+            return Res(unexpect, std::move(unex_));
+        }
+    }
+
+    template <class Fn>
+    constexpr
+    auto
+    transform_error(Fn&& f) &
+    {
+        using G = detail::result_transform<Fn, E&>;
+        using Res = Expected<T, G>;
+
+        if (has_value())
+        {
+            return Res();
+        }
+        else
+        {
+            return Res(
+                unexpect_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), unex_);
+                });
+        }
+    }
+
+    template <class Fn>
+    constexpr
+    auto
+    transform_error(Fn&& f) const &
+    {
+        using G = detail::result_transform<Fn, const E&>;
+        using Res = Expected<T, G>;
+
+        if (has_value())
+        {
+            return Res();
+        }
+        else
+        {
+            return Res(
+                unexpect_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), unex_);
+                });
+        }
+    }
+
+    template <class Fn>
+    constexpr
+    auto
+    transform_error(Fn&& f) &&
+    {
+        using G = detail::result_transform<Fn, E&&>;
+        using Res = Expected<T, G>;
+
+        if (has_value())
+        {
+            return Res();
+        }
+        else
+        {
+            return Res(
+                unexpect_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), std::move(unex_));
+                });
+        }
+    }
+
+    template <class Fn>
+    constexpr
+    auto
+    transform_error(Fn&& f) const &&
+    {
+        using G = detail::result_transform<Fn, const E&&>;
+        using Res = Expected<T, G>;
+
+        if (has_value())
+        {
+            return Res();
+        }
+        else
+        {
+            return Res(
+                unexpect_inv{}, [&]() {
+                    return std::invoke(std::forward<Fn>(f), std::move(unex_));
+                });
+        }
+    }
+
+    template <class U, class E2>
+    requires std::is_void_v<U>
+    friend
+    constexpr
+    bool
+    operator==(Expected const& x, const Expected<U, E2>& y)
+    noexcept(noexcept(bool(x.error() == y.error())))
+    {
+        if (x.has_value())
+        {
+            return y.has_value();
+        }
+        else
+        {
+            return !y.has_value() && bool(x.error() == y.error());
+        }
+    }
+
+    template <class E2>
+    friend
+    constexpr
+    bool
+    operator==(Expected const& x, const Unexpected<E2>& e)
+    noexcept(noexcept(bool(x.error() == e.error())))
+    {
+        return !x.has_value() && bool(x.error() == e.error());
+    }
+
+    friend
+    constexpr
+    void
+    swap(Expected& x, Expected& y)
+    noexcept(noexcept(x.swap(y)))
+    requires requires { x.swap(y); }
+    {
+        x.swap(y);
+    }
+
+private:
+    template <class Vp>
+    constexpr
+    void
+    assign_unex_impl(Vp&& v)
+    {
+        if (has_value_)
+        {
+            std::construct_at(
+                std::addressof(unex_),
+                std::forward<Vp>(v));
+            has_value_ = false;
+        }
+        else
+        {
+            unex_ = std::forward<Vp>(v);
+        }
+    }
+
+    using in_place_inv = detail::in_place_inv;
+    using unexpect_inv = detail::unexpect_inv;
+
+    template <class Fn>
+    explicit constexpr
+    Expected(in_place_inv, Fn&& fn)
+        : void_()
+        , has_value_(true)
+    {
+        std::forward<Fn>(fn)();
+    }
+
+    template <class Fn>
+    explicit constexpr
+    Expected(unexpect_inv, Fn&& fn)
+        : unex_(std::forward<Fn>(fn)())
+        , has_value_(false)
+    { }
 };
 
 //------------------------------------------------
@@ -464,255 +2594,6 @@ formatError(
         std::back_inserter(s),
         fs.fs, fmt::make_format_args(args...));
     return Error(std::move(s), fs.loc);
-}
-
-//------------------------------------------------
-
-template<class T>
-Expected<T>::
-~Expected()
-{
-    if(has_error_)
-        std::destroy_at(&e_);
-    else
-        std::destroy_at(&v_);
-}
-
-template<class T>
-Expected<T>::
-Expected(
-    Error err) noexcept
-    : has_error_(true)
-{
-    MRDOX_ASSERT(err.failed());
-    std::construct_at(&e_, std::move(err));
-}
-
-template<class T>
-Expected<T>::
-Expected(
-    Expected&& other) noexcept
-    : has_error_(other.has_error_)
-{
-    if(other.has_error_)
-        std::construct_at(&e_, std::move(other.e_));
-    else
-        std::construct_at(&v_, std::move(other.v_));
-}
-
-template<class T>
-auto
-Expected<T>::
-operator=(
-    Expected&& other) noexcept ->
-        Expected&
-{
-    if(this != &other)
-    {
-        std::destroy_at(this);
-        std::construct_at(this, std::move(other));
-    }
-    return *this;
-}
-
-template<class T>
-template<class U>
-requires std::convertible_to<U, T>
-Expected<T>::
-Expected(
-    U&& u)
-    : has_error_(false)
-{
-    static_assert(std::is_convertible_v<U, T>);
-    static_assert(!std::convertible_to<U, Error>);
-
-    std::construct_at(&v_, std::forward<U>(u));
-}
-
-template<class T>
-template<class U>
-requires std::convertible_to<U, T>
-auto
-Expected<T>::
-operator=(
-    Expected<U>&& other) noexcept ->
-        Expected&
-{
-    static_assert(std::is_nothrow_convertible_v<U, T>);
-    static_assert(! std::convertible_to<U, Error>);
-
-    Expected temp(std::move(other));
-    temp.swap(*this);
-    return *this;
-}
-
-template<class T>
-constexpr
-bool
-Expected<T>::
-has_value() const noexcept
-{
-    return ! has_error_;
-}
-
-template<class T>
-constexpr
-bool
-Expected<T>::
-has_error() const noexcept
-{
-    return has_error_;
-}
-
-template<class T>
-constexpr
-Expected<T>::
-operator bool() const noexcept
-{
-    return ! has_error_;
-}
-
-template<class T>
-constexpr
-T&
-Expected<T>::
-value() &
-{
-    if(has_value())
-        return v_;
-    e_.Throw();
-}
-
-template<class T>
-constexpr
-T const&
-Expected<T>::
-value() const&
-{
-    if(has_value())
-        return v_;
-    e_.Throw();
-}
-
-template<class T>
-constexpr
-T
-Expected<T>::
-value() &&
-{
-    return std::move(value());
-}
-
-template<class T>
-constexpr
-T
-Expected<T>::
-release() noexcept
-{
-    return std::move(value());
-}
-
-template<class T>
-constexpr
-T*
-Expected<T>::
-operator->() noexcept
-{
-    return &v_;
-}
-
-template<class T>
-constexpr
-T&
-Expected<T>::
-operator*() & noexcept
-{
-    auto const p = operator->();
-    MRDOX_ASSERT(p != nullptr);
-    return *p;
-}
-
-template<class T>
-constexpr
-T
-Expected<T>::
-operator*() &&
-{
-    return std::move(**this);
-}
-
-template<class T>
-Error
-Expected<T>::
-error() && noexcept
-{
-    if(has_error())
-        return std::move(e_);
-    return Error::success();
-}
-
-template<class T>
-constexpr
-T const*
-Expected<T>::
-operator->() const noexcept
-{
-    return &v_;
-}
-
-template<class T>
-constexpr
-T const&
-Expected<T>::
-operator*() const& noexcept
-{
-    auto const p = operator->();
-    MRDOX_ASSERT(p != nullptr);
-    return *p;
-}
-
-template<class T>
-Error
-Expected<T>::
-error() const& noexcept
-{
-    if(has_error())
-        return e_;
-    return Error::success();
-}
-
-template<class T>
-void
-Expected<T>::
-swap(Expected& rhs) noexcept
-{
-    using std::swap;
-    if(has_error_)
-    {
-        if(rhs.has_error)
-        {
-            swap(e_, rhs.e_);
-            return;
-        }
-        Error err(std::move(e_));
-        std::destroy_at(&e_);
-        std::construct_at(&v_, std::move(rhs.v_));
-        std::destroy_at(&rhs.v_);
-        std::construct_at(&rhs.e_, std::move(err));
-        swap(has_error_, rhs.has_error_);
-        return;
-    }
-    if(! rhs.has_error)
-    {
-        swap(v_, rhs.v_);
-        return;
-    }
-    Error err(std::move(rhs.e_));
-    std::destroy_at(&rhs.e_);
-    std::construct_at(&rhs.v_, std::move(v_));
-    std::destroy_at(&v_);
-    std::construct_at(&e_, std::move(err));
-    swap(has_error_, rhs.has_error_);
 }
 
 //------------------------------------------------

--- a/include/mrdox/Support/Lua.hpp
+++ b/include/mrdox/Support/Lua.hpp
@@ -344,8 +344,8 @@ public:
     template<class... Args>
     Value operator()(Args&&... args)
     {
-        return call(
-            std::forward<Args>(args)...).release();
+        return std::move(call(
+            std::forward<Args>(args)...)).value();
     }
 
 private:

--- a/src/lib/-HTML/HTMLGenerator.cpp
+++ b/src/lib/-HTML/HTMLGenerator.cpp
@@ -29,10 +29,7 @@ Expected<ExecutorGroup<Builder>>
 createExecutors(
     DomCorpus const& domCorpus)
 {
-    auto options = loadOptions(domCorpus.getCorpus());
-    if(! options)
-        return options.error();
-
+    MRDOX_TRY(auto options, loadOptions(domCorpus.getCorpus()));
     auto const& config = domCorpus.getCorpus().config;
     auto& threadPool = config.threadPool();
     ExecutorGroup<Builder> group(threadPool);
@@ -40,11 +37,11 @@ createExecutors(
     {
         try
         {
-           group.emplace(domCorpus, *options);
+           group.emplace(domCorpus, options);
         }
         catch(Exception const& ex)
         {
-            return ex.error();
+            return Unexpected(ex.error());
         }
     }
     return group;

--- a/src/lib/-HTML/Options.cpp
+++ b/src/lib/-HTML/Options.cpp
@@ -108,7 +108,7 @@ loadOptions(
         yin.setAllowUnknownKeys(true);
         yin >> opt;
         if(auto ec = yin.error())
-            return Error(ec);
+            return Unexpected(Error(ec));
     }
 
     // extra
@@ -119,7 +119,7 @@ loadOptions(
         yin.setAllowUnknownKeys(true);
         yin >> opt;
         if(auto ec = yin.error())
-            return Error(ec);
+            return Unexpected(Error(ec));
     }
 
     // adjust relative paths

--- a/src/lib/-adoc/AdocGenerator.cpp
+++ b/src/lib/-adoc/AdocGenerator.cpp
@@ -40,7 +40,7 @@ createExecutors(
         }
         catch(Exception const& ex)
         {
-            return ex.error();
+            return Unexpected(ex.error());
         }
     }
     return group;
@@ -65,7 +65,7 @@ build(
     if(! options)
         return options.error();
 
-    AdocCorpus domCorpus(corpus, options.release());
+    AdocCorpus domCorpus(corpus, *std::move(options));
     auto ex = createExecutors(domCorpus);
     if(! ex)
         return ex.error();
@@ -88,7 +88,7 @@ buildOne(
     if(! options)
         return options.error();
 
-    AdocCorpus domCorpus(corpus, options.release());
+    AdocCorpus domCorpus(corpus, *std::move(options));
     auto ex = createExecutors(domCorpus);
     if(! ex)
         return ex.error();

--- a/src/lib/-adoc/Options.cpp
+++ b/src/lib/-adoc/Options.cpp
@@ -108,7 +108,7 @@ loadOptions(
         yin.setAllowUnknownKeys(true);
         yin >> opt;
         if(auto ec = yin.error())
-            return Error(ec);
+            return Unexpected(Error(ec));
     }
 
     // extra
@@ -119,7 +119,7 @@ loadOptions(
         yin.setAllowUnknownKeys(true);
         yin >> opt;
         if(auto ec = yin.error())
-            return Error(ec);
+            return Unexpected(Error(ec));
     }
 
     // adjust relative paths

--- a/src/lib/Lib/ConfigImpl.cpp
+++ b/src/lib/Lib/ConfigImpl.cpp
@@ -195,15 +195,11 @@ loadConfig(
     auto temp = files::normalizePath(filePath);
 
     // load the config file into a string
-    auto absPath = files::makeAbsolute(temp);
-    if(! absPath)
-        return absPath.error();
-    auto configYaml = files::getFileText(*absPath);
-    if(! configYaml)
-        return configYaml.error();
+    MRDOX_TRY(auto absPath, files::makeAbsolute(temp));
+    MRDOX_TRY(auto configYaml, files::getFileText(absPath));
 
     // calculate the working directory
-    auto workingDir = files::getParentDir(*absPath);
+    auto workingDir = files::getParentDir(absPath);
 
     // attempt to create the config
     try
@@ -211,14 +207,14 @@ loadConfig(
         return std::make_shared<ConfigImpl>(
             workingDir,
             addonsDir,
-            configYaml.value(),
+            configYaml,
             extraYaml,
             baseConfig,
             threadPool);
     }
     catch(Exception const& ex)
     {
-        return ex.error();
+        return Unexpected(ex.error());
     }
 }
 

--- a/src/lib/Lib/CorpusImpl.cpp
+++ b/src/lib/Lib/CorpusImpl.cpp
@@ -112,7 +112,7 @@ build(
             *ex.getExecutionContext(), *config))))
     {
         if(! (*config)->ignoreFailures)
-            return err;
+            return Unexpected(err);
         report::warn(
             "Warning: mapping failed because ", err);
     }
@@ -174,13 +174,13 @@ build(
             corpus->insert(std::move(I));
         });
     if(! errors.empty())
-        return Error(errors);
+        return Unexpected(Error(errors));
 
     report::format(ex.getReportLevel(),
         "Symbols collected: {}", corpus->InfoMap.size());
 
     if(GotFailure)
-        return formatError("multiple errors occurred");
+        return Unexpected(formatError("multiple errors occurred"));
 
     return corpus;
 }

--- a/src/lib/Support/JavaScript.cpp
+++ b/src/lib/Support/JavaScript.cpp
@@ -270,7 +270,7 @@ getGlobal(
         A, name.data(), name.size()))
     {
         duk_pop(A); // undefined
-        return formatError("global property {} not found", name);
+        return Unexpected(formatError("global property {} not found", name));
     }
     return A.construct<Value>(duk_get_top_index(A), *this);
 }
@@ -926,7 +926,7 @@ callImpl(
         domValue_push(A, arg);
     auto result = duk_pcall(A, args.size());
     if(result == DUK_EXEC_ERROR)
-        return dukM_popError(*scope_);
+        return Unexpected(dukM_popError(*scope_));
     return A.construct<Value>(-1, *scope_);
 }
 
@@ -939,7 +939,7 @@ callPropImpl(
     Access A(*scope_);
     if(! duk_get_prop_lstring(A,
             idx_, prop.data(), prop.size()))
-        return formatError("method {} not found", prop);
+        return Unexpected(formatError("method {} not found", prop));
     duk_dup(A, idx_);
     for(auto const& arg : args)
         domValue_push(A, arg);
@@ -948,7 +948,7 @@ callPropImpl(
     {
         Error err = dukM_popError(*scope_);
         duk_pop(A); // method
-        return err;
+        return Unexpected(err);
     }
     return A.construct<Value>(-1, *scope_);
 }

--- a/src/lib/Support/Path.cpp
+++ b/src/lib/Support/Path.cpp
@@ -92,7 +92,7 @@ getFileType(
     {
         if(ec == std::errc::no_such_file_or_directory)
             return FileType::not_found;
-        return Error(ec);
+        return Unexpected(Error(ec));
     }
     switch(fileStatus.type())
     {
@@ -186,14 +186,14 @@ getFileText(
 {
     std::ifstream file((std::string(pathName)));
     if(! file.good())
-        return formatError("std::ifstream(\"{}\" returned \"{}\"",
-            pathName, std::error_code(errno, std::generic_category()));
+        return Unexpected(formatError("std::ifstream(\"{}\" returned \"{}\"",
+            pathName, std::error_code(errno, std::generic_category())));
     std::istreambuf_iterator<char> it(file);
     std::istreambuf_iterator<char> const end;
     std::string text(it, end);
     if(! file.good())
-        return formatError("getFileText(\"{}\") returned \"{}\"",
-            pathName, std::error_code(errno, std::generic_category()));
+        return Unexpected(formatError("getFileText(\"{}\") returned \"{}\"",
+            pathName, std::error_code(errno, std::generic_category())));
     return text;
 }
 
@@ -224,7 +224,7 @@ makeAbsolute(
 
     SmallPathString result(pathName);
     if(auto ec = fs::make_absolute(result))
-        return formatError("fs::make_absolute(\"{}\") returned \"{}\"", pathName, ec);
+        return Unexpected(formatError("fs::make_absolute(\"{}\") returned \"{}\"", pathName, ec));
     return static_cast<std::string>(result);
 }
 
@@ -361,7 +361,7 @@ createDirectory(
     namespace fs = llvm::sys::fs;
 
     auto kind = files::getFileType(pathName);
-    if(kind.has_error())
+    if (!kind)
         return kind.error();
     if(*kind == files::FileType::directory)
         return Error::success();

--- a/src/test/TestRunner.cpp
+++ b/src/test/TestRunner.cpp
@@ -121,7 +121,7 @@ handleFile(
         auto result = CorpusImpl::build(ex, config);
         if(! result)
             report::error("{}: \"{}\"", result.error(), filePath);
-        corpus = result.release();
+        corpus = *std::move(result);
     }
 
     // Generate XML

--- a/src/test/lib/Support/Handlebars.cpp
+++ b/src/test/lib/Support/Handlebars.cpp
@@ -3013,7 +3013,7 @@ builtin_each()
     // each on implicit context
     {
         std::string string = "{{#each}}{{text}}! {{/each}}cruel world!";
-        BOOST_TEST_THROW_WITH(
+        BOOST_TEST_THROW_STARTS_WITH(
             hbs.render(string, dom::Object()),
             HandlebarsError, "Must pass iterator to #each");
     }
@@ -4166,7 +4166,7 @@ helpers()
         // if a context is not found, helperMissing is used
         {
             std::string string = "{{hello}} {{link_to world}}";
-            BOOST_TEST_THROW_WITH(
+            BOOST_TEST_THROW_STARTS_WITH(
                 hbs.render(string), std::runtime_error, "Missing helper: \"link_to\"");
         }
 
@@ -4486,49 +4486,49 @@ helpers()
     {
         // if helper - too few arguments
         {
-            BOOST_TEST_THROW_WITH(
+            BOOST_TEST_THROW_STARTS_WITH(
                 hbs.render("{{#if}}{{/if}}"), HandlebarsError, "#if requires exactly one argument");
         }
 
         // if helper - too many arguments, string
         {
-            BOOST_TEST_THROW_WITH(
+            BOOST_TEST_THROW_STARTS_WITH(
                 hbs.render("{{#if test \"string\"}}{{/if}}"), HandlebarsError, "#if requires exactly one argument");
         }
 
         // if helper - too many arguments, undefined
         {
-            BOOST_TEST_THROW_WITH(
+            BOOST_TEST_THROW_STARTS_WITH(
                 hbs.render("{{#if test undefined}}{{/if}}"), HandlebarsError, "#if requires exactly one argument");
         }
 
         // if helper - too many arguments, null
         {
-            BOOST_TEST_THROW_WITH(
+            BOOST_TEST_THROW_STARTS_WITH(
                 hbs.render("{{#if test null}}{{/if}}"), HandlebarsError, "#if requires exactly one argument");
         }
 
         // unless helper - too few arguments
         {
-            BOOST_TEST_THROW_WITH(
+            BOOST_TEST_THROW_STARTS_WITH(
                 hbs.render("{{#unless}}{{/unless}}"), HandlebarsError, "#unless requires exactly one argument");
         }
 
         // unless helper - too many arguments, null
         {
-            BOOST_TEST_THROW_WITH(
+            BOOST_TEST_THROW_STARTS_WITH(
                 hbs.render("{{#unless test null}}{{/unless}}"), HandlebarsError, "#unless requires exactly one argument");
         }
 
         // with helper - too few arguments
         {
-            BOOST_TEST_THROW_WITH(
+            BOOST_TEST_THROW_STARTS_WITH(
                 hbs.render("{{#with}}{{/with}}"), HandlebarsError, "#with requires exactly one argument");
         }
 
         // with helper - too many arguments
         {
-            BOOST_TEST_THROW_WITH(
+            BOOST_TEST_THROW_STARTS_WITH(
                 hbs.render("{{#with test \"string\"}}{{/with}}"), HandlebarsError, "#with requires exactly one argument");
         }
     }

--- a/src/test_suite/test_suite.hpp
+++ b/src/test_suite/test_suite.hpp
@@ -322,6 +322,24 @@ constexpr detail::log_type log{};
     (void) 0
    //
 
+# define BOOST_TEST_THROW_STARTS_WITH( expr, ex, msg ) \
+    try { \
+        (void)(expr); \
+        ::test_suite::detail::throw_failed_impl( \
+            #expr, #ex, "@anon", \
+            __FILE__, __LINE__); \
+    } \
+    catch(ex const& e) {                 \
+        BOOST_TEST(std::string_view(e.what()).starts_with(std::string_view(msg))); \
+    } \
+    catch(...) { \
+        ::test_suite::detail::throw_failed_impl( \
+            #expr, #ex, "@anon", \
+            __FILE__, __LINE__); \
+    }                            \
+    (void) 0
+   //
+
 # define BOOST_TEST_THROWS( expr, ex ) \
     try { \
         (void)(expr); \


### PR DESCRIPTION
This PR implements handlebars support for error propagation using `Expected`. In MrDox, this implies that errors can be reported, and processing can proceed, enabling the user to address all issues in a single run rather than running MrDox repeatedly. The `Expected` class was adapted to conform better with `std::expected`, which includes extra features we needed, such as `Expected<void>`.

In the Handlebars sub-library, this PR includes support for helpers to return errors that are propagated to the parent context. This PR also completes all features needed for implementing the Javascript and Lua bindings for MrDox. After integrating the bindings, we can consider moving handlebars to a standalone library since it's a low-hanging fruit. The independent library could include extra features we don't currently need in MrDox, such as compiled templates and incremental rendering. The `dom` can also be independently useful in other contexts.