### PR TITLE
refactor: MrDox uses C++ handlebars

### DIFF
--- a/share/mrdox/addons/generator/asciidoc/helpers/add.js
+++ b/share/mrdox/addons/generator/asciidoc/helpers/add.js
@@ -1,0 +1,3 @@
+function add(a, b) {
+    return a + b;
+}

--- a/src/lib/-HTML/Builder.hpp
+++ b/src/lib/-HTML/Builder.hpp
@@ -15,6 +15,7 @@
 #include "lib/Support/Radix.hpp"
 #include <mrdox/Metadata/DomMetadata.hpp>
 #include <mrdox/Support/Error.hpp>
+#include <mrdox/Support/Handlebars.hpp>
 #include <mrdox/Support/JavaScript.hpp>
 #include <ostream>
 
@@ -33,6 +34,7 @@ class Builder
     Corpus const& corpus_;
     Options options_;
     js::Context ctx_;
+    Handlebars hbs_;
 
 public:
     Builder(

--- a/src/lib/-adoc/AdocGenerator.cpp
+++ b/src/lib/-adoc/AdocGenerator.cpp
@@ -103,13 +103,13 @@ buildOne(
         });
     errors = ex->wait();
     if(! errors.empty())
-        return Error(errors);
+        return {errors};
 
     SinglePageVisitor visitor(*ex, corpus, os);
     visitor(corpus.globalNamespace());
     errors = ex->wait();
     if(! errors.empty())
-        return Error(errors);
+        return {errors};
 
     ex->async(
         [&os](Builder& builder)
@@ -119,7 +119,7 @@ buildOne(
         });
     errors = ex->wait();
     if(! errors.empty())
-        return Error(errors);
+        return {errors};
 
     return Error::success();
 }

--- a/src/lib/-adoc/Builder.cpp
+++ b/src/lib/-adoc/Builder.cpp
@@ -35,110 +35,105 @@ Builder(
 
     Config const& config = domCorpus.getCorpus().config;
 
-    js::Scope scope(ctx_);
-
-    scope.script(files::getFileText(
-        files::appendPath(
-            config->addonsDir, "js", "handlebars.js")
-        ).value()).maybeThrow();
-    auto Handlebars = scope.getGlobal("Handlebars").value();
-
-// VFALCO refactor this
-Handlebars.setlog();
-
-    // load templates
-#if 0
-    err = forEachFile(options_.template_dir,
-        [&](std::string_view fileName)
-        {
-            if(! fileName.ends_with(".adoc.hbs"))
-                return Error::success();
-            return Error::success();
-        });
-#endif
-
-    Error err;
-
     // load partials
-    forEachFile(
-        files::appendPath(config->addonsDir,
-            "generator", "asciidoc", "partials"),
+    std::string partialsPath = files::appendPath(
+        config->addonsDir, "generator", "asciidoc", "partials");
+    forEachFile(partialsPath,
         [&](std::string_view pathName) -> Error
         {
             constexpr std::string_view ext = ".adoc.hbs";
-            if(! pathName.ends_with(ext))
+            if (!pathName.ends_with(ext))
+            {
                 return Error::success();
+            }
             auto name = files::getFileName(pathName);
             name.remove_suffix(ext.size());
             auto text = files::getFileText(pathName);
-            if(! text)
+            if (!text)
+            {
                 return text.error();
-            return Handlebars.callProp("registerPartial", name, *text)
-                .error_or(Error::success());
+            }
+            hbs_.registerPartial(name, *text);
+            return Error::success();
     }).maybeThrow();
 
     // load helpers
-#if 0
-    err = forEachFile(
-        files::appendPath(config->addonsDir,
-            "generator", "js", "helpers"),
+    js::Scope scope(ctx_);
+    std::string helpersPath = files::appendPath(
+        config->addonsDir, "generator", "asciidoc", "helpers");
+    forEachFile(helpersPath,
         [&](std::string_view pathName)
         {
+            // Register JS helper function in the global object
             constexpr std::string_view ext = ".js";
-            if(! pathName.ends_with(ext))
+            if (!pathName.ends_with(ext))
+            {
                 return Error::success();
+            }
             auto name = files::getFileName(pathName);
             name.remove_suffix(ext.size());
-            //Handlebars.callProp("registerHelper", name, *text);
-            auto err = ctx_.scriptFromFile(pathName);
+            auto text = files::getFileText(pathName);
+            if (!text)
+            {
+                return text.error();
+            }
+            auto JSFn = scope.compile(*text);
+            if (!JSFn)
+            {
+                return JSFn.error();
+            }
+            scope.getGlobalObject().set(name, *JSFn);
+
+            // Register C++ helper that retrieves the helper
+            // from the global object, converts the arguments,
+            // and invokes the JS function.
+            hbs_.registerHelper(name, dom::makeVariadicInvocable(
+                [this, name=std::string(name)](
+                    dom::Array const& args) -> Expected<dom::Value>
+                {
+                    // Get function from global scope
+                    js::Scope scope(ctx_);
+                    js::Value fn = scope.getGlobalObject().get(name);
+                    if (fn.isUndefined())
+                    {
+                        return Unexpected(Error("helper not found"));
+                    }
+                    if (!fn.isFunction())
+                    {
+                        return Unexpected(Error("helper is not a function"));
+                    }
+
+                    // Call function
+                    std::vector<dom::Value> arg_span;
+                    arg_span.reserve(args.size());
+                    for (auto const& arg : args)
+                    {
+                        arg_span.push_back(arg);
+                    }
+                    auto result = fn.apply(arg_span);
+                    if (!result)
+                    {
+                        return dom::Kind::Undefined;
+                    }
+
+                    // Convert result to dom::Value
+                    return result->getDom();
+                }));
             return Error::success();
         }).maybeThrow();
-#endif
-    scope.script(fmt::format(
-        R"(Handlebars.registerHelper(
-            'is_multipage', function()
-        {{
-            return {};
-        }});
-        )", config->multiPage)).maybeThrow();
-
-    scope.script(R"(
-        Handlebars.registerHelper(
-            'to_string', function(context, depth)
-        {
-            return JSON.stringify(context, null, 2);
-        });
-
-        Handlebars.registerHelper(
-            'eq', function(a, b)
-        {
-            return a === b;
-        });
-
-        Handlebars.registerHelper(
-            'neq', function(a, b)
-        {
-            return a !== b;
-        });
-
-        Handlebars.registerHelper(
-            'not', function(a)
-        {
-            return ! a;
-        });
-
-        Handlebars.registerHelper(
-            'or', function(a, b)
-        {
-            return a || b;
-        });
-
-        Handlebars.registerHelper(
-            'and', function(a, b)
-        {
-            return a && b;
-        });
-    )").maybeThrow();
+    hbs_.registerHelper(
+        "is_multipage",
+        dom::makeInvocable([res = config->multiPage]() -> Expected<dom::Value> {
+        return res;
+    }));
+    helpers::registerAntoraHelpers(hbs_);
+    hbs_.registerHelper("neq", dom::makeVariadicInvocable(helpers::ne_fn));
+    hbs_.registerHelper(
+        "to_string",
+        dom::makeInvocable(
+            [](dom::Value const& context) -> Expected<dom::Value> {
+        return dom::JSON::stringify(context);
+    }));
 }
 
 //------------------------------------------------
@@ -151,20 +146,20 @@ callTemplate(
 {
     Config const& config = domCorpus.getCorpus().config;
 
-    js::Scope scope(ctx_);
-    auto Handlebars = scope.getGlobal("Handlebars");
     auto layoutDir = files::appendPath(config->addonsDir,
             "generator", "asciidoc", "layouts");
     auto pathName = files::appendPath(layoutDir, name);
     MRDOX_TRY(auto fileText, files::getFileText(pathName));
-    dom::Object options;
-    options.set("noEscape", true);
-    options.set("allowProtoPropertiesByDefault", true);
-    // VFALCO This makes Proxy objects stop working
-    //options.set("allowProtoMethodsByDefault", true);
-    MRDOX_TRY(auto templateFn, Handlebars->callProp("compile", fileText, options));
-    MRDOX_TRY(auto result, templateFn.call(context, options));
-    return result.getString();
+    HandlebarsOptions options;
+    options.noEscape = true;
+
+    Expected<std::string, HandlebarsError> exp =
+        hbs_.try_render(fileText, context, options);
+    if (!exp)
+    {
+        return Unexpected(Error(exp.error().what()));
+    }
+    return *exp;
 }
 
 Expected<std::string>

--- a/src/lib/-adoc/Builder.hpp
+++ b/src/lib/-adoc/Builder.hpp
@@ -17,6 +17,7 @@
 #include <mrdox/Metadata/DomMetadata.hpp>
 #include <mrdox/Support/Error.hpp>
 #include <mrdox/Support/JavaScript.hpp>
+#include <mrdox/Support/Handlebars.hpp>
 #include <ostream>
 
 #include <mrdox/Dom.hpp>
@@ -33,6 +34,7 @@ namespace adoc {
 class Builder
 {
     js::Context ctx_;
+    Handlebars hbs_;
 
 public:
     AdocCorpus const& domCorpus;


### PR DESCRIPTION
This PR refactors the asciidoc and html generators to use the C++ implementation of handlebars. Javascript helpers are loaded with duktape.