### PR TITLE
fix: remove expression trim

### DIFF
--- a/src/lib/Support/Handlebars.cpp
+++ b/src/lib/Support/Handlebars.cpp
@@ -1785,7 +1785,6 @@ evalExpr(
     bool evalLiterals) const
 {
     using Res = Handlebars::evalExprResult;
-    expression = trim_spaces(expression);
     if (evalLiterals)
     {
         // ==============================================================

--- a/src/test/lib/Support/Handlebars.cpp
+++ b/src/test/lib/Support/Handlebars.cpp
@@ -1012,6 +1012,10 @@ basic_context()
         BOOST_TEST(hbs.render("Goodbye {{\"foo[bar\"}} world!", ctx) == "Goodbye beautiful world!");
         BOOST_TEST(hbs.render("Goodbye {{\"foo'bar\"}} world!", ctx) == "Goodbye beautiful world!");
         BOOST_TEST(hbs.render("Goodbye {{'foo\"bar'}} world!", ctx) == "Goodbye beautiful world!");
+
+        // literal references only convert to strings as helper parameters
+        // literal references as main helper names will decay to context keys
+        BOOST_TEST(hbs.render("{{\"\\n\"}}") == "");
     }
 
     // that current context path ({{.}}) doesn't hit helpers


### PR DESCRIPTION
The unnecessary trim_spaces(expression) was removed from Handlebars.cpp as it's not required in the current context and could potentially remove intentional characters from literal string.