### PR TITLE
test: JavaScript unit tests

### DIFF
--- a/include/mrdox/Dom/Object.hpp
+++ b/include/mrdox/Dom/Object.hpp
@@ -357,6 +357,14 @@ public:
     virtual void set(String key, Value value) = 0;
 
     /** Invoke the visitor for each key/value pair.
+
+        The visitor function must return `true` to
+        continue iteration, or `false` to stop.
+
+        The visit function returns `true` if the
+        visitor returned `true` for all elements,
+        otherwise `false`.
+
     */
     virtual bool visit(std::function<bool(String, Value)>) const = 0;
 

--- a/include/mrdox/Dom/Value.hpp
+++ b/include/mrdox/Dom/Value.hpp
@@ -238,12 +238,21 @@ public:
     */
     bool isTruthy() const noexcept;
 
+    /** Return the underlying boolean value.
+
+        @note Behaviour is undefined if `!isBoolean()`
+
+     */
     bool getBool() const noexcept
     {
         MRDOX_ASSERT(isBoolean());
         return b_ != 0;
     }
 
+    /** Return the underlying integer value.
+
+        @note Behaviour is undefined if `!isInteger()`
+    */
     std::int64_t
     getInteger() const noexcept
     {
@@ -251,6 +260,10 @@ public:
         return i_;
     }
 
+    /** Return the underlying string value.
+
+        @note Behaviour is undefined if `!isString()`
+    */
     String const&
     getString() const noexcept
     {
@@ -333,6 +346,16 @@ public:
     bool
     exists(std::string_view key) const;
 
+    /** Return if an Array or Object is empty.
+    */
+    bool
+    empty() const;
+
+    /** Return if an Array or Object is empty.
+    */
+    std::size_t
+    size() const;
+
     /** Invoke the function.
 
         If the Value is not an object, or the key
@@ -348,16 +371,6 @@ public:
         }
         return getFunction()(std::forward<Args>(args)...);
     }
-
-    /** Return if an Array or Object is empty.
-    */
-    bool
-    empty() const;
-
-    /** Return if an Array or Object is empty.
-    */
-    std::size_t
-    size() const;
 
     /// @copydoc isTruthy()
     explicit
@@ -506,7 +519,7 @@ public:
         return lhs && Value(rhs);
     }
 
-    /** Return a diagnostic string.
+    /** Return value as a string.
     */
     friend
     std::string

--- a/include/mrdox/Support/JavaScript.hpp
+++ b/include/mrdox/Support/JavaScript.hpp
@@ -75,7 +75,19 @@ public:
 
 //------------------------------------------------
 
-/** A reference to an instance of a JavaScript interpreter.
+/** An instance of a JavaScript interpreter.
+
+    This class represents a JavaScript interpreter
+    context under which we can create @ref Scope
+    objects to define variables and execute scripts.
+
+    A context represents a JavaScript heap where
+    variables can be allocated.
+
+    The heap is allocated with default memory
+    management.
+
+    @see Scope
 */
 class MRDOX_DECL
     Context
@@ -87,10 +99,6 @@ class MRDOX_DECL
     friend struct Access;
 
 public:
-    /** Copy assignment.
-    */
-    Context& operator=(Context const&) = delete;
-
     /** Destructor.
     */
     ~Context();
@@ -102,10 +110,35 @@ public:
     /** Constructor.
     */
     Context(Context const&) noexcept;
+
+    /** Copy assignment.
+     */
+    Context& operator=(Context const&) = delete;
 };
 
 //------------------------------------------------
 
+/** A JavaScript scope
+
+    This class represents a JavaScript scope
+    under which we can define variables and
+    execute scripts.
+
+    Each scope is a section of the context heap
+    in the JavaScript interpreter. A javascript
+    variable is defined by creating a
+    @ref Value that is associated with this
+    Scope, i.e., subsection of the context heap.
+
+    When a scope is destroyed, the heap section
+    is popped and all variables defined in
+    that scope are invalidated.
+
+    For this reason, two scopes of the
+    same context heap cannot be manipulated
+    at the same time.
+
+ */
 class Scope
 {
     Context ctx_;
@@ -117,42 +150,170 @@ class Scope
     void reset();
 
 public:
+    /** Constructor.
+
+        Construct a scope for the given context.
+
+        Variables defined in this scope will be
+        allocated on top of the specified
+        context heap.
+
+        When the Scope is destroyed, the
+        variables defined in this scope will
+        be popped from the heap.
+
+        @param ctx The context to use.
+    */
     MRDOX_DECL
     Scope(Context const& ctx) noexcept;
 
+    /** Destructor.
+
+        All variables defined in this scope
+        are popped from the internal context
+        heap.
+
+        There should be no @ref Value objects
+        associated with this scope when it
+        is destroyed.
+     */
     MRDOX_DECL
     ~Scope();
 
     /** Compile and run a script.
-    */
+
+        This function compiles and executes
+        the specified JavaScript code. The script
+        can be used to execute commands or define
+        global variables in the parent context.
+
+        It evaluates the ECMAScript source code and
+        converts any internal errors to @ref Error.
+
+        @param jsCode The JavaScript code to execute.
+
+     */
     MRDOX_DECL
-    Error
+    Expected<void>
     script(std::string_view jsCode);
 
+    /** Compile and run a expression.
+
+        This function compiles and executes
+        the specified JavaScript code. The script
+        can be used to execute commands or define
+        global variables in the parent context.
+
+        It evaluates the ECMAScript source code and
+        converts any internal errors to @ref Error.
+
+        @param jsCode The JavaScript code to execute.
+
+     */
+    MRDOX_DECL
+    Expected<Value>
+    eval(std::string_view jsCode);
+
     /** Compile a script and push results to stack.
+
+        Compile ECMAScript source code and return it
+        as a compiled function object that executes it.
+
+        Unlike the `script()` function, the code is not
+        executed. A compiled function that can be executed
+        is returned.
+
+        The returned function has zero arguments and
+        executes as if we called `script()`.
+
+        The script returns an implicit return value
+        equivalent to the last non-empty statement value
+        in the code.
     */
     MRDOX_DECL
     Expected<Value>
-    compile(std::string_view jsCode);
+    compile_script(std::string_view jsCode);
 
-    /** Return the global object.
+    /** Compile a script and push results to stack.
+
+        Compile ECMAScript source code that defines a
+        function and return the compiled function object.
+
+        Unlike the `script()` function, the code is not
+        executed. A compiled function with the specified
+        number of arguments that can be executed is returned.
+
+        If the function code contains more than one function, the
+        return value is the first function compiled.
+
     */
     MRDOX_DECL
-    Value
-    getGlobalObject();
+    Expected<Value>
+    compile_function(std::string_view jsCode);
 
     /** Return a global object if it exists.
+
+        This function returns a @ref Value that
+        represents a global variable in the
+        parent context.
+
+        If the variable does not exist, an
+        error is returned.
+
+        @param name The name of the global variable.
+
     */
     MRDOX_DECL
     Expected<Value>
     getGlobal(std::string_view name);
+
+    /** Return the global object.
+
+        This function returns a @ref Value that
+        represents the global object in the
+        parent context.
+
+        The global object is the root of the
+        ECMAScript object hierarchy and is
+        the value returned by the global
+        `this` expression.
+
+        If the global object does not exist, an
+        error is returned.
+
+     */
+    MRDOX_DECL
+    Value
+    getGlobalObject();
 };
 
 //------------------------------------------------
 
 /** An ECMAScript value.
+
+    This class represents a value in the
+    JavaScript interpreter.
+
+    A value is a variable that is defined
+    in a @ref Scope. It can be a primitive
+    type or an object.
+
+    A @ref Value not associated with a
+    @ref Scope is undefined.
+
+    The user is responsible for ensuring that
+    the lifetime of a @ref Value does not
+    exceed the lifetime of the @ref Scope
+    that created it.
+
+    A value can be converted to a DOM value
+    using the @ref getDom function.
+
+    @see Scope
+    @see Type
+
 */
-class Value
+class MRDOX_DECL Value
 {
 protected:
     Scope* scope_;
@@ -163,48 +324,300 @@ protected:
     Value(int, Scope&) noexcept;
 
 public:
+    /** Destructor
+
+        If the value is associated with a
+        @ref Scope and it is on top of the
+        stack, it is popped. Also, if
+        there are no other Value references
+        to the @ref Scope, all variables
+        defined in that scope are popped
+        via @ref Scope::reset.
+
+     */
     MRDOX_DECL ~Value();
+
+    /** Constructor
+
+        Construct a value that is not associated
+        with a @ref Scope.
+
+        The value is undefined.
+
+     */
     MRDOX_DECL Value() noexcept;
+
+    /** Constructor
+
+        The function pushes a duplicate of
+        value to the stack and associates
+        the new value the top of the stack.
+     */
     MRDOX_DECL Value(Value const&);
+
+    /** Constructor
+
+        The function associates the
+        existing value with this object.
+     */
     MRDOX_DECL Value(Value&&) noexcept;
+
+    /** Copy assignment.
+
+        @copydetails Value(Value const&)
+
+     */
     MRDOX_DECL Value& operator=(Value const&);
+
+    /** Move assignment.
+
+        @copydetails Value(Value&&)
+
+     */
     MRDOX_DECL Value& operator=(Value&&) noexcept;
 
+    /** Return the type of the value.
+
+        This function returns the JavaScript
+        type of the value.
+
+        The type can represent a primitive
+        type (such as boolean, number,
+        and string) or an object.
+
+        When the type is an object, the
+        return type also classifies the
+        object as an array or function.
+
+        An array is an object with the
+        internal ECMAScript class `Array`
+        or a Proxy wrapping an `Array`.
+
+        A function is an object with the
+        internal ECMAScript class `Function`.
+
+     */
     MRDOX_DECL Type type() const noexcept;
 
+    /// Check if the value is undefined.
     bool isUndefined() const noexcept;
+
+    /// Check if the value is null.
     bool isNull() const noexcept;
+
+    /// Check if the value is a boolean.
     bool isBoolean() const noexcept;
+
+    /// Check if the value is a number.
     bool isNumber() const noexcept;
+
+    /// Check if the value is an integer number.
+    bool isInteger() const noexcept;
+
+    /// Check if the value is a floating point number.
+    bool isDouble() const noexcept;
+
+    /// Check if the value is a string.
     bool isString() const noexcept;
+
+    /// Check if the value is an array.
     bool isArray() const noexcept;
+
+    /// Check if the value is an object.
     bool isObject() const noexcept;
+
+    /// Check if the value is a function.
     bool isFunction() const noexcept;
 
-    std::string getString() const;
+    /** Determine if a value is truthy
+
+        A value is truthy if it is a boolean and is true, a number and not
+        zero, or an non-empty string, array or object.
+
+        @return `true` if the value is truthy, `false` otherwise
+    */
+    bool isTruthy() const noexcept;
+
+    /** Return the underlying string
+
+        This function returns the value
+        as a string.
+
+        This function performs no coercions.
+        If the value is not a string, it is not
+        converted to a string.
+
+        @note Behaviour is undefined if `!isString()`
+
+     */
+    std::string_view getString() const;
+
+    /** Return the underlying boolean value.
+
+        @note Behaviour is undefined if `!isBoolean()`
+
+     */
+    bool getBool() const noexcept;
+
+    /** Return the underlying integer value.
+
+        @note Behaviour is undefined if `!isNumber()`
+    */
+    std::int64_t
+    getInteger() const noexcept;
+
+    /** Return the underlying double value.
+
+        @note Behaviour is undefined if `!isNumber()`
+    */
+    double
+    getDouble() const noexcept;
+
+    /** Return the underlying object.
+
+        @note Behaviour is undefined if `!isObject()`
+    */
+    dom::Object
+    getObject() const noexcept;
+
+    /** Return the underlying array.
+
+        @note Behaviour is undefined if `!isArray()`
+    */
+    dom::Array
+    getArray() const noexcept;
+
+    /** Return the underlying array.
+
+        @note Behaviour is undefined if `!isFunction()`
+    */
+    dom::Function
+    getFunction() const noexcept;
+
+    /** Return the value as a dom::Value
+
+        This function returns the value as a
+        @ref dom::Value.
+
+        If the value is a primitive type,
+        it is converted to a DOM primitive.
+
+        If the value is an object, a type with
+        reference semantics to access the
+        underlying DOM object is returned.
+
+     */
     dom::Value getDom() const;
 
+    /** Set "log" property
+
+        This function sets the "log" property
+        in the object.
+
+        The "log" property is populated with
+        a function that takes two javascript
+        arguments `(level, message)` where
+        `level` is an unsigned integer and
+        `message` is a string.
+
+        The mrdox library function
+        `clang::mrdox::report::print`
+        is then called with these
+        two arguments to report a
+        message to the console.
+
+     */
     void setlog();
 
-    /** Call a function.
+
+    /** Return the element for a given key.
+
+        If the Value is not an object, or the key
+        is not found, a Value of type @ref Kind::Undefined
+        is returned.
     */
-    template<class... Args>
+    Value
+    get(std::string_view key) const;
+
+    template <std::convertible_to<std::string_view> S>
+    Value
+    get(S const& key) const
+    {
+        return get(std::string_view(key));
+    }
+
+    /** Return the element at a given index.
+    */
+    Value
+    get(std::size_t i) const;
+
+    /** Return the element at a given index or key.
+    */
+    Value
+    get(dom::Value const& i) const;
+
+    /** Lookup a sequence of keys.
+
+        This function is equivalent to calling `get`
+        multiple times, once for each key in the sequence
+        of dot-separated keys.
+
+        @return The value at the end of the sequence, or
+        a Value of type @ref Kind::Undefined if any key
+        is not found.
+    */
+    Value
+    lookup(std::string_view keys) const;
+
+    /** Set or replace the value for a given key.
+     */
+    MRDOX_DECL
+    void
+    set(
+        std::string_view key,
+        Value const& value) const;
+
+    /** Set or replace the value for a given key.
+     */
+    MRDOX_DECL
+    void
+    set(
+        std::string_view key,
+        dom::Value const& value) const;
+
+    /** Return true if a key exists.
+    */
+    bool
+    exists(std::string_view key) const;
+
+    /** Return if an Array or Object is empty.
+    */
+    bool
+    empty() const;
+
+    /** Return if an Array or Object is empty.
+    */
+    std::size_t
+    size() const;
+
+    /** Invoke a function.
+    */
+    template<std::convertible_to<dom::Value>... Args>
     Expected<Value>
     call(Args&&... args) const
     {
         return callImpl({ dom::Value(std::forward<Args>(args))... });
     }
 
-    /** Call a function with variadic arguments.
+    /** Invoke a function with variadic arguments.
     */
-    template<class... Args>
     Expected<Value>
     apply(std::span<dom::Value> args) const
     {
         return callImpl(args);
     }
 
-    /** Call a function.
+    /** Invoke a function.
     */
     template<class... Args>
     Value
@@ -213,7 +626,7 @@ public:
         return call(std::forward<Args>(args)...).value();
     }
 
-    /** Call a method.
+    /** Invoke a method.
     */
     template<class... Args>
     Expected<Value>
@@ -225,19 +638,163 @@ public:
             { dom::Value(std::forward<Args>(args))... });
     }
 
-    /** Set a key.
-    */
-    MRDOX_DECL
-    void
-    set(
-        std::string_view key,
-        Value value) const;
+    /// @copydoc isTruthy()
+    explicit
+    operator bool() const noexcept
+    {
+        return isTruthy();
+    }
 
-    /** Get a key.
+    /** Return the string.
+     */
+    explicit
+    operator std::string() const noexcept
+    {
+        return toString(*this);
+    }
+
+    /** Swap two values.
     */
-    MRDOX_DECL
+    void
+    swap(Value& other) noexcept;
+
+    /** Swap two values.
+    */
+    friend
+    void
+    swap(Value& v0, Value& v1) noexcept
+    {
+        v0.swap(v1);
+    }
+
+    /** Compare two values for equality.
+
+        This operator uses strict equality, meaning that
+        the types must match exactly, and for objects and
+        arrays the children must match exactly.
+
+        The `==` operator behaves differently for objects
+        compared to primitive data types like numbers and strings.
+        When comparing objects using `==`, it checks for
+        reference equality, not structural equality.
+
+        This means that two objects are considered equal with
+        `===` only if they reference the exact same object in
+        memory.
+
+        @note In JavaScript, this is equivalent to the `===`
+        operator, which does not perform type conversions.
+     */
+    friend
+    bool
+    operator==(
+        Value const& lhs,
+        Value const& rhs) noexcept;
+
+    /// @overload
+    template <std::convertible_to<Value> S>
+    friend auto operator==(
+        S const& lhs, Value const& rhs) noexcept
+    {
+        return Value(lhs) == rhs;
+    }
+
+    /// @overload
+    template <std::convertible_to<Value> S>
+    friend auto operator==(
+        Value const& lhs, S const& rhs) noexcept
+    {
+        return lhs == Value(rhs);
+    }
+
+    friend
+    bool
+    operator!=(
+        Value const& lhs,
+        Value const& rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+
+    /// @overload
+    template <std::convertible_to<Value> S>
+    friend auto operator!=(
+        S const& lhs, Value const& rhs) noexcept
+    {
+        return Value(lhs) != rhs;
+    }
+
+    /// @overload
+    template <std::convertible_to<Value> S>
+    friend auto operator!=(
+        Value const& lhs, S const& rhs) noexcept
+    {
+        return lhs != Value(rhs);
+    }
+
+    /** Compare two values for inequality.
+     */
+    friend
+    std::strong_ordering
+    operator<=>(
+        Value const& lhs,
+        Value const& rhs) noexcept;
+
+    /** Return the first Value that is truthy, or the last one.
+
+        This function is equivalent to the JavaScript `||` operator.
+     */
+    friend
     Value
-    get(std::string_view key) const;
+    operator||(Value const& lhs, Value const& rhs);
+
+    /// @overload
+    template <std::convertible_to<Value> S>
+    friend auto operator||(
+        S const& lhs, Value const& rhs) noexcept
+    {
+        return Value(lhs) || rhs;
+    }
+
+    /// @overload
+    template <std::convertible_to<Value> S>
+    friend auto operator||(
+        Value const& lhs, S const& rhs) noexcept
+    {
+        return lhs || Value(rhs);
+    }
+
+    /** Return the first Value that is not truthy, or the last one.
+
+        This function is equivalent to the JavaScript `&&` operator.
+     */
+    friend
+    Value
+    operator&&(Value const& lhs, Value const& rhs);
+
+    /// @overload
+    template <std::convertible_to<Value> S>
+    friend auto operator&&(
+        S const& lhs, Value const& rhs) noexcept
+    {
+        return Value(lhs) && rhs;
+    }
+
+    /// @overload
+    template <std::convertible_to<Value> S>
+    friend auto operator&&(
+        Value const& lhs, S const& rhs) noexcept
+    {
+        return lhs && Value(rhs);
+    }
+
+    /** Return value as a string.
+
+        This function coerces any value to a string.
+    */
+    friend
+    std::string
+    toString(Value const& value);
 
 private:
     MRDOX_DECL
@@ -284,6 +841,11 @@ inline bool Value::isString() const noexcept
 inline bool Value::isObject() const noexcept
 {
     return type() == Type::object;
+}
+
+inline bool Value::isArray() const noexcept
+{
+    return type() == Type::array;
 }
 
 inline bool Value::isFunction() const noexcept

--- a/src/lib/-HTML/Builder.cpp
+++ b/src/lib/-HTML/Builder.cpp
@@ -80,7 +80,7 @@ Builder(
         {
             return text.error();
         }
-        auto JSFn = scope.compile(*text);
+        auto JSFn = scope.compile_function(*text);
         if (!JSFn)
         {
             return JSFn.error();

--- a/src/lib/-adoc/Builder.cpp
+++ b/src/lib/-adoc/Builder.cpp
@@ -77,7 +77,7 @@ Builder(
             {
                 return text.error();
             }
-            auto JSFn = scope.compile(*text);
+            auto JSFn = scope.compile_function(*text);
             if (!JSFn)
             {
                 return JSFn.error();

--- a/src/lib/Dom/Value.cpp
+++ b/src/lib/Dom/Value.cpp
@@ -866,7 +866,7 @@ operator<=>(dom::Value const& lhs, dom::Value const& rhs) noexcept
     default:
         MRDOX_UNREACHABLE();
     }
-    return std::strong_ordering::greater;
+    return std::strong_ordering::equivalent;
 }
 
 std::string

--- a/src/test/Support/Javascript.cpp
+++ b/src/test/Support/Javascript.cpp
@@ -1,0 +1,796 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2023 Vinnie Falco (vinnie.falco@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdox
+//
+
+#include <mrdox/Support/JavaScript.hpp>
+#include <test_suite/test_suite.hpp>
+#include <array>
+
+namespace clang {
+namespace mrdox {
+namespace js {
+
+struct Path_test
+{
+    void
+    test_context()
+    {
+        Context ctx;
+        Context ctx2(ctx);
+        (void) ctx;
+        (void) ctx2;
+    }
+
+    void
+    test_scope()
+    {
+        Context ctx;
+
+        // empty scope
+        {
+            Scope scope(ctx);
+        }
+
+        // script
+        {
+            Scope scope(ctx);
+            Expected<void> r = scope.script("var x = 1;");
+            BOOST_TEST(r);
+            r = scope.script("print(x);");
+            BOOST_TEST(!r);
+            auto exp = scope.getGlobal("x");
+            BOOST_TEST(exp);
+            js::Value x = *exp;
+            BOOST_TEST(x.isNumber());
+            BOOST_TEST(x.getDom() == 1);
+        }
+
+        // eval
+        {
+            Scope scope(ctx);
+            Expected<Value> r = scope.eval("1 + 2 + 3");
+            BOOST_TEST(r);
+            Value v = r.value();
+            BOOST_TEST(v.isNumber());
+            BOOST_TEST(v.getDom() == 6);
+        }
+
+        // compile_script
+        {
+            // last expression as implicit return value
+            {
+                Scope scope(ctx);
+                Expected<Value> fnr = scope.compile_script("var x = 1; x;");
+                BOOST_TEST(fnr);
+                Value fn = *fnr;
+                BOOST_TEST(fn.isFunction());
+                Value x = fn();
+                BOOST_TEST(x.isNumber());
+                BOOST_TEST(x.getDom() == 1);
+            }
+
+            // single expression
+            {
+                Scope scope(ctx);
+                Expected<Value> fnr = scope.compile_script("1 + 2 + 3");
+                BOOST_TEST(fnr);
+                Value fn = *fnr;
+                BOOST_TEST(fn.isFunction());
+                Value x = fn();
+                BOOST_TEST(x.isNumber());
+                BOOST_TEST(x.getDom() == 1 + 2 + 3);
+            }
+
+            // functions are not executed or returned
+            {
+                Scope scope(ctx);
+                Expected<Value> fnr = scope.compile_script("function (a, b) { return a + b; }");
+                BOOST_TEST(!fnr.has_value());
+            }
+        }
+
+        // compile_function
+        {
+            // function: return value is function itself as JS Value
+            {
+                // function with no args
+                {
+                    Scope scope(ctx);
+                    Expected<Value> fnr = scope.compile_function(
+                        "function () { return 3; }");
+                    BOOST_TEST(fnr);
+                    Value fn = fnr.value();
+                    BOOST_TEST(fn.isFunction());
+                    Value x = fn();
+                    BOOST_TEST(x.isNumber());
+                    BOOST_TEST(x.getDom() == 3);
+                }
+
+                // named function also returned as object
+                {
+                    Scope scope(ctx);
+                    Expected<Value> fnr = scope.compile_function(
+                        "function a() { return 3; }");
+                    BOOST_TEST(fnr);
+                    Value fn = fnr.value();
+                    BOOST_TEST(fn.isFunction());
+                    Value x = fn();
+                    BOOST_TEST(x.isNumber());
+                    BOOST_TEST(x.getDom() == 3);
+                }
+
+                // single function
+                {
+                    Scope scope(ctx);
+                    Expected<Value> fnr = scope.compile_function(
+                        "function f(a, b) { return a + b; }");
+                    BOOST_TEST(fnr);
+                    Value fn = fnr.value();
+                    BOOST_TEST(fn.isFunction());
+                    Value x = fn(1, 2);
+                    BOOST_TEST(x.isNumber());
+                    BOOST_TEST(x.getDom() == 3);
+                }
+
+                // multiple functions: first function is returned
+                {
+                    Scope scope(ctx);
+                    Expected<Value> fnr = scope.compile_function(
+                        "function f(a, b) { return a + b; }\n"
+                        "function g(a, b) { return a * b; }");
+                    BOOST_TEST(fnr);
+                    Value fn = fnr.value();
+                    BOOST_TEST(fn.isFunction());
+                    Value x = fn(3, 3);
+                    BOOST_TEST(x.isNumber());
+                    BOOST_TEST(x.getDom() == 6);
+                }
+            }
+        }
+
+        // getGlobal
+        {
+            Scope scope(ctx);
+            scope.script("var x = 1;");
+            auto exp = scope.getGlobal("x");
+            BOOST_TEST(exp);
+            js::Value x = *exp;
+            BOOST_TEST(x.isNumber());
+            BOOST_TEST(x.getDom() == 1);
+        }
+
+        // getGlobalObject
+        {
+            Scope scope(ctx);
+            scope.script("var x = 1;");
+            js::Value x = scope.getGlobalObject();
+            BOOST_TEST(x.isObject());
+            BOOST_TEST(x.get("x").isNumber());
+            BOOST_TEST(x.get("x").getDom() == 1);
+        }
+    }
+
+    void
+    test_value()
+    {
+        // Value()
+        {
+            Context ctx;
+            Scope scope(ctx);
+            Value v;
+            BOOST_TEST(v.isUndefined());
+        }
+
+        // Value(Value const&)
+        {
+            Context ctx;
+            Scope scope(ctx);
+            Value v1;
+            Value v2(v1);
+            BOOST_TEST(v2.isUndefined());
+        }
+
+        // Value(Value&&)
+        {
+            Context ctx;
+            Scope scope(ctx);
+            Value v1;
+            Value v2(std::move(v1));
+            BOOST_TEST(v2.isUndefined());
+        }
+
+        // operator=(Value const&)
+        {
+            Context ctx;
+            Scope scope(ctx);
+            Value v1;
+            Value v2;
+            v2 = v1;
+            BOOST_TEST(v2.isUndefined());
+        }
+
+        // operator=(Value&&)
+        {
+            Context ctx;
+            Scope scope(ctx);
+            Value v1;
+            Value v2;
+            v2 = std::move(v1);
+            BOOST_TEST(v2.isUndefined());
+        }
+
+        // type()
+        // is*()
+        // isTruthy()
+        // operator bool()
+        // toString()
+        // operator std::string()
+        // get*()
+        {
+            // undefined
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("undefined").value();
+                BOOST_TEST(x.isUndefined());
+                BOOST_TEST(x.type() == Type::undefined);
+                BOOST_TEST(!x.isTruthy());
+                BOOST_TEST(!static_cast<bool>(x));
+            }
+
+            // null
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("null").value();
+                BOOST_TEST(x.isNull());
+                BOOST_TEST(x.type() == Type::null);
+                BOOST_TEST(!x.isTruthy());
+                BOOST_TEST(!static_cast<bool>(x));
+            }
+
+            // boolean
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("true").value();
+                BOOST_TEST(x.isBoolean());
+                BOOST_TEST(x.type() == Type::boolean);
+                BOOST_TEST(x.isTruthy());
+                BOOST_TEST(static_cast<bool>(x));
+                BOOST_TEST(x.getBool());
+            }
+
+            // number
+            {
+                // Integer
+                {
+                    Context context;
+                    Scope scope(context);
+                    Value x = scope.eval("1 + 2 + 3").value();
+                    BOOST_TEST(x.isNumber());
+                    BOOST_TEST(x.isInteger());
+                    BOOST_TEST(x.type() == Type::number);
+                    BOOST_TEST(x.isTruthy());
+                    BOOST_TEST(static_cast<bool>(x));
+                    BOOST_TEST(x.getInteger() == 6);
+                }
+
+                // Double
+                {
+                    Context context;
+                    Scope scope(context);
+                    Value x = scope.eval("1.5 + 2.5 + 3.5").value();
+                    BOOST_TEST(x.isNumber());
+                    BOOST_TEST(x.isDouble());
+                    BOOST_TEST(x.type() == Type::number);
+                    BOOST_TEST(x.isTruthy());
+                    BOOST_TEST(static_cast<bool>(x));
+                    BOOST_TEST(x.getDouble() == 1.5 + 2.5 + 3.5);
+                    BOOST_TEST(x.getInteger() == 7);
+                }
+            }
+
+            // string
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("'hello world'").value();
+                BOOST_TEST(x.isString());
+                BOOST_TEST(x.type() == Type::string);
+                BOOST_TEST(x.isTruthy());
+                BOOST_TEST(static_cast<bool>(x));
+                BOOST_TEST(x.getString() == "hello world");
+            }
+
+            // object
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("({ x: 1 })").value();
+                BOOST_TEST(x.isObject());
+                BOOST_TEST(x.type() == Type::object);
+                BOOST_TEST(x.isTruthy());
+                BOOST_TEST(static_cast<bool>(x));
+                dom::Object o = x.getObject();
+                BOOST_TEST(o.size() == 1);
+                BOOST_TEST(o.exists("x"));
+                BOOST_TEST(o.get("x").isInteger());
+                BOOST_TEST(o.get("x").getInteger() == 1);
+            }
+
+            // function
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("(function() { return 1; })").value();
+                BOOST_TEST(x.isFunction());
+                BOOST_TEST(x.type() == Type::function);
+                BOOST_TEST(x.isTruthy());
+                BOOST_TEST(static_cast<bool>(x));
+                dom::Function f = x.getFunction();
+                BOOST_TEST(f() == 1);
+            }
+
+            // array
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("([1, 2, 3])").value();
+                BOOST_TEST(x.isArray());
+                BOOST_TEST(x.type() == Type::array);
+                BOOST_TEST(x.isTruthy());
+                BOOST_TEST(static_cast<bool>(x));
+                dom::Array a = x.getArray();
+                BOOST_TEST(a.size() == 3);
+                BOOST_TEST(a.get(0).isInteger());
+                BOOST_TEST(a.get(0).getInteger() == 1);
+                BOOST_TEST(a.get(1).isInteger());
+                BOOST_TEST(a.get(1).getInteger() == 2);
+                BOOST_TEST(a.get(2).isInteger());
+                BOOST_TEST(a.get(2).getInteger() == 3);
+            }
+        }
+
+        // getDom()
+        {
+            // undefined
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("undefined").value();
+                BOOST_TEST(x.isUndefined());
+                dom::Value y = x.getDom();
+                BOOST_TEST(y.isUndefined());
+                dom::Value z(dom::Kind::Undefined);
+                BOOST_TEST(y == z);
+            }
+
+            // null
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("null").value();
+                BOOST_TEST(x.isNull());
+                dom::Value y = x.getDom();
+                BOOST_TEST(y.isNull());
+                dom::Value z(dom::Kind::Null);
+                BOOST_TEST(y == z);
+            }
+
+            // boolean
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("true").value();
+                BOOST_TEST(x.isBoolean());
+                dom::Value y = x.getDom();
+                BOOST_TEST(y.isBoolean());
+                dom::Value z(true);
+                BOOST_TEST(y == z);
+            }
+
+            // number
+            {
+                // integer
+                {
+                    Context context;
+                    Scope scope(context);
+                    Value x = scope.eval("1 + 2 + 3").value();
+                    BOOST_TEST(x.isNumber());
+                    dom::Value y = x.getDom();
+                    BOOST_TEST(y.isInteger());
+                    dom::Value z(1 + 2 + 3);
+                    BOOST_TEST(y == z);
+                }
+
+                // double: coerce to integer
+                {
+                    Context context;
+                    Scope scope(context);
+                    Value x = scope.eval("1.5 + 2.5 + 3.5").value();
+                    BOOST_TEST(x.isNumber());
+                    BOOST_TEST(x.isDouble());
+                    dom::Value y = x.getDom();
+                    BOOST_TEST(y.isInteger());
+                    dom::Value z(1 + 2 + 3 + 1);
+                    BOOST_TEST(y == z);
+                }
+            }
+
+            // object
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("({ a: 1, b: true, c: 'c' })").value();
+                BOOST_TEST(x.isObject());
+                dom::Value y = x.getDom();
+                BOOST_TEST(y.isObject());
+                BOOST_TEST(y.get("a").isInteger());
+                BOOST_TEST(y.get("a").getInteger() == 1);
+                BOOST_TEST(y.get("b").isBoolean());
+                BOOST_TEST(y.get("b").getBool());
+                BOOST_TEST(y.get("c").isString());
+                BOOST_TEST(y.get("c").getString() == "c");
+                dom::Object z = y.getObject();
+                z.set("d", nullptr);
+                BOOST_TEST(z.size() == 4);
+                BOOST_TEST(z.exists("b"));
+                BOOST_TEST(z.exists("d"));
+                z.visit([](dom::String const& key, dom::Value const& value)
+                {
+                    BOOST_TEST(
+                        (key == "a" || key == "b" || key == "c" || key == "d"));
+                    BOOST_TEST(
+                        (value.isInteger() || value.isBoolean()
+                         || value.isString() || value.isNull()));
+                });
+            }
+
+            // array
+            {
+                Context context;
+                Scope scope(context);
+                Value x = scope.eval("([1, true, 'c'])").value();
+                BOOST_TEST(x.isArray());
+                dom::Value y = x.getDom();
+                BOOST_TEST(y.isArray());
+                BOOST_TEST(y.get(0).isInteger());
+                BOOST_TEST(y.get(0).getInteger() == 1);
+                BOOST_TEST(y.get(1).isBoolean());
+                BOOST_TEST(y.get(1).getBool());
+                BOOST_TEST(y.get(2).isString());
+                BOOST_TEST(y.get(2).getString() == "c");
+                dom::Array z = y.getArray();
+                z.push_back(nullptr);
+                z.set(1, false);
+                BOOST_TEST(z.size() == 4);
+                for (std::size_t i = 0; i < z.size(); ++i)
+                {
+                    dom::Value v = z.get(i);
+                    BOOST_TEST(
+                        (v.isInteger() || v.isBoolean() || v.isString()
+                         || v.isNull()));
+                }
+            }
+
+            // function
+            {
+                // no parameters
+                {
+                    Context context;
+                    Scope scope(context);
+                    Value x = scope.eval("(function() { return 1; })").value();
+                    BOOST_TEST(x.isFunction());
+                    dom::Value y = x.getDom();
+                    BOOST_TEST(y.isFunction());
+                    BOOST_TEST(y() == 1);
+                }
+
+                // with parameters
+                {
+                    Context context;
+                    Scope scope(context);
+                    Value x = scope.eval("(function(a, b) { return a + b; })").value();
+                    BOOST_TEST(x.isFunction());
+                    dom::Value y = x.getDom();
+                    BOOST_TEST(y.isFunction());
+                    BOOST_TEST(y(1, 2) == 3);
+                    BOOST_TEST(y(1, 2, 3) == 3);
+                    BOOST_TEST(y(3, 4) == 7);
+                }
+
+                // variadic parameters
+                {
+                    Context context;
+                    Scope scope(context);
+                    Value x = scope.eval("(function() { return arguments.length; })").value();
+                    BOOST_TEST(x.isFunction());
+                    dom::Value y = x.getDom();
+                    BOOST_TEST(y.isFunction());
+                    BOOST_TEST(y() == 0);
+                    BOOST_TEST(y(1) == 1);
+                    BOOST_TEST(y(1, 2) == 2);
+                    BOOST_TEST(y(1, 2, 3) == 3);
+                }
+            }
+        }
+
+        // setlog()
+        {
+            Context context;
+            Scope scope(context);
+            Value x = scope.eval("({})").value();
+            BOOST_TEST(x.isObject());
+            x.setlog();
+            dom::Value y = x.getDom();
+            BOOST_TEST(y.isObject());
+            BOOST_TEST(y.exists("log"));
+            BOOST_TEST(y.get("log").isFunction());
+            BOOST_TEST(y.get("log")(1, "hello world").isUndefined());
+        }
+
+        // get(std::string_view)
+        // exists(std::string_view)
+        {
+            Context context;
+            Scope scope(context);
+            Value x = scope.eval("({ a: 1, b: true, c: 'c' })").value();
+            BOOST_TEST(x.isObject());
+            BOOST_TEST(x.exists("a"));
+            BOOST_TEST(x.get("a").getDom() == 1);
+            dom::String k("b");
+            BOOST_TEST(x.exists("b"));
+            BOOST_TEST(x.get(k).getDom() == true);
+            dom::Value kv("c");
+            BOOST_TEST(x.exists("c"));
+            BOOST_TEST(x.get(kv).getDom() == "c");
+        }
+
+        // get(std::size_t)
+        // exists(std::string_view)
+        {
+            Context context;
+            Scope scope(context);
+            Value x = scope.eval("([1, true, 'c'])").value();
+            BOOST_TEST(x.isArray());
+            BOOST_TEST(x.exists("0"));
+            BOOST_TEST(x.get(0).getDom() == 1);
+            BOOST_TEST(x.exists("1"));
+            BOOST_TEST(x.get(1).getDom() == true);
+            BOOST_TEST(x.exists("2"));
+            dom::Value k(2);
+            BOOST_TEST(x.get(k).getDom() == "c");
+        }
+
+        // lookup(std::string_view)
+        {
+            Context context;
+            Scope scope(context);
+            Value x = scope.eval("({ a: { b: { c: 123 }}})").value();
+            BOOST_TEST(x.isObject());
+            BOOST_TEST(x.lookup("a.b.c").getInteger() == 123);
+        }
+
+        // set(std::string_view,js::Value)
+        {
+            Context context;
+            Scope scope(context);
+            Value x = scope.eval("({})").value();
+            Value y = scope.eval("123").value();
+            BOOST_TEST(x.isObject());
+            BOOST_TEST(y.isInteger());
+            x.set("a", y);
+            BOOST_TEST(x.get("a").getDom() == 123);
+        }
+
+        // set(std::string_view,dom::Value)
+        {
+            Context context;
+            Scope scope(context);
+            Value x = scope.eval("({})").value();
+            dom::Value y = 123;
+            BOOST_TEST(x.isObject());
+            BOOST_TEST(y.isInteger());
+            x.set("a", y);
+            BOOST_TEST(x.get("a").getDom() == 123);
+        }
+
+        // empty()
+        // size()
+        {
+            Context context;
+            Scope scope(context);
+
+            // undefined
+            {
+                Value a = scope.eval("(undefined)").value();
+                BOOST_TEST(a.isUndefined());
+                BOOST_TEST(a.empty());
+                BOOST_TEST(a.size() == 0);
+            }
+
+            // null
+            {
+                Value b = scope.eval("(null)").value();
+                BOOST_TEST(b.isNull());
+                BOOST_TEST(b.empty());
+                BOOST_TEST(b.size() == 0);
+            }
+
+            // boolean
+            {
+                Value c = scope.eval("(true)").value();
+                BOOST_TEST(c.isBoolean());
+                BOOST_TEST(!c.empty());
+                BOOST_TEST(c.size() == 1);
+            }
+
+            // number
+            {
+                Value e = scope.eval("(123)").value();
+                BOOST_TEST(e.isNumber());
+                BOOST_TEST(!e.empty());
+                BOOST_TEST(e.size() == 1);
+            }
+
+            // string
+            {
+                Value s = scope.eval("'Hello world'").value();
+                BOOST_TEST(s.isString());
+                BOOST_TEST(!s.empty());
+                BOOST_TEST(s.size() == 11);
+                Value s2 = scope.eval("('')").value();
+                BOOST_TEST(s2.isString());
+                BOOST_TEST(s2.empty());
+                BOOST_TEST(s2.size() == 0);
+            }
+
+            // object
+            {
+                Value x = scope.eval("({})").value();
+                BOOST_TEST(x.isObject());
+                BOOST_TEST(x.empty());
+                BOOST_TEST(x.size() == 0);
+                x.set("a", 1);
+                BOOST_TEST(!x.empty());
+                BOOST_TEST(x.size() == 1);
+            }
+
+            // function
+            {
+                Value f = scope.eval("(function() {})").value();
+                BOOST_TEST(f.isFunction());
+                BOOST_TEST(!f.empty());
+                BOOST_TEST(f.size() == 1);
+            }
+
+            // array
+            {
+                Value y = scope.eval("([])").value();
+                BOOST_TEST(y.isArray());
+                BOOST_TEST(y.empty());
+                BOOST_TEST(y.size() == 0);
+                Value z = scope.eval("([1, 2, 3])").value();
+                BOOST_TEST(!z.empty());
+                BOOST_TEST(z.size() == 3);
+            }
+        }
+
+        // operator()
+        // call(...)
+        // apply()
+        {
+            Context context;
+            Scope scope(context);
+            Value x = scope.eval("(function f(a, b) { return a + b; })").value();
+            BOOST_TEST(x.isFunction());
+            BOOST_TEST(x.call(1, 2).value().getDom() == 3);
+            std::array<dom::Value, 2> args = {{1, 2}};
+            BOOST_TEST(x.apply(args).value().getDom() == 3);
+            BOOST_TEST(x(1, 2).getDom() == 3);
+        }
+
+        // callProp()
+        {
+            Context context;
+            Scope scope(context);
+            Value x = scope.eval("({ f: function(a, b) { return a + b; } })").value();
+            BOOST_TEST(x.isObject());
+            BOOST_TEST(x.callProp("f", 1, 2).value().getDom() == 3);
+            BOOST_TEST(x.get("f")(1, 2).getDom() == 3);
+        }
+
+        // swap(Value& other)
+        // swap(Value& v0, Value& v1)
+        {
+            Context context;
+            Scope scope(context);
+            Value a = scope.eval("123").value();
+            Value b = scope.eval("true").value();
+            BOOST_TEST(a.isNumber());
+            BOOST_TEST(b.isBoolean());
+            BOOST_TEST(a.getInteger() == 123);
+            BOOST_TEST(b.getBool());
+            a.swap(b);
+            BOOST_TEST(a.isBoolean());
+            BOOST_TEST(b.isNumber());
+            BOOST_TEST(a.getBool());
+            BOOST_TEST(b.getInteger() == 123);
+            swap(a, b);
+            BOOST_TEST(a.isNumber());
+            BOOST_TEST(b.isBoolean());
+            BOOST_TEST(a.getInteger() == 123);
+            BOOST_TEST(b.getBool());
+        }
+
+        // operator==(Value const&, Value const&)
+        // operator!=(Value const&, Value const&)
+        // operator<=>(Value const&, Value const&)
+        {
+            Context context;
+            Scope scope(context);
+            Value x1;
+            Value x2;
+            Value undef = scope.eval("undefined").value();
+            Value i1 = scope.eval("123").value();
+            Value i2 = scope.eval("123").value();
+            Value i3 = scope.eval("124").value();
+            Value b = scope.eval("true").value();
+            BOOST_TEST(x1 == x2);
+            BOOST_TEST(!(x1 < x2));
+            BOOST_TEST(x1 == undef);
+            BOOST_TEST(!(x1 < undef));
+            BOOST_TEST(x1 != i1);
+            BOOST_TEST(x1 < i1);
+            BOOST_TEST(undef != i1);
+            BOOST_TEST(undef < i1);
+            BOOST_TEST(i1 == i2);
+            BOOST_TEST(!(i1 < i2));
+            BOOST_TEST(i1 != i3);
+            BOOST_TEST(i1 < i3);
+            BOOST_TEST(i1 != b);
+            BOOST_TEST(i1 > b);
+        }
+
+        // operator||
+        // operator&&
+        {
+            Context context;
+            Scope scope(context);
+            Value a = scope.eval("undefined").value();
+            Value b = scope.eval("123").value();
+            Value c = scope.eval("'hello world'").value();
+            BOOST_TEST((a || b).getInteger() == 123);
+            BOOST_TEST((b || c).getInteger() == 123);
+            BOOST_TEST((c || b).getString() == "hello world");
+            BOOST_TEST((a && b).isUndefined());
+            BOOST_TEST((b && c).getString() == "hello world");
+            BOOST_TEST((c && b).getInteger() == 123);
+            BOOST_TEST((a || b || c).getInteger() == 123);
+            BOOST_TEST((a && b && c).isUndefined());
+        }
+    }
+
+    void run()
+    {
+        test_context();
+        test_scope();
+        test_value();
+    }
+};
+
+TEST_SUITE(
+    Path_test,
+    "clang.mrdox.Javascript");
+
+} // js
+} // mrdox
+} // clang
+


### PR DESCRIPTION
This PR implements unit tests for the Javascript bindings based on duktape. All errors found are fixed in the same commit.

This commit also includes the complete implementation for classes that were only placeholders, including conversions to dom::Value and related wrapper classes for objects, arrays, and functions.

The changes are only related to bindings from Javascript to C++. Bindings from C++ to Javascript will be addressed in a later commit.