### PR TITLE
ci: unify release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       matrix: ${{ steps.cpp-matrix.outputs.matrix }}
     steps:
       - name: Generate Test Matrix
-        uses: alandefreitas/cpp-actions/cpp-matrix@v1.8.3
+        uses: alandefreitas/cpp-actions/cpp-matrix@v1.8.4
         id: cpp-matrix
         with:
           compilers: |
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup CMake
-        uses: alandefreitas/cpp-actions/setup-cmake@v1.8.3
+        uses: alandefreitas/cpp-actions/setup-cmake@v1.8.4
         id: setup-cmake
         with:
           version: ${{ matrix.compiler == 'clang' && '3.26' || '>=3.26' }}
@@ -72,7 +72,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
 
       - name: Setup C++
-        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.3
+        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.4
         id: setup-cpp
         with:
           compiler: ${{ matrix.compiler }}
@@ -80,7 +80,7 @@ jobs:
           check-latest: ${{ matrix.compiler == 'clang' }}
 
       - name: Install System Packages
-        uses: alandefreitas/cpp-actions/package-install@v1.8.3
+        uses: alandefreitas/cpp-actions/package-install@v1.8.4
         id: package-install
         env:
           DEBIAN_FRONTEND: 'noninteractive'
@@ -237,7 +237,7 @@ jobs:
           node-version: '18'
 
       - name: CMake Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.3
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.4
         with:
           cmake-version: ${{ matrix.compiler == 'clang' && '3.26' || '>=3.26' }}
           cxxstd: ${{ matrix.cxxstd }}
@@ -275,7 +275,7 @@ jobs:
           retention-days: 1
 
       - name: FlameGraph
-        uses: alandefreitas/cpp-actions/flamegraph@v1.8.3
+        uses: alandefreitas/cpp-actions/flamegraph@v1.8.4
         if: matrix.time-trace
         with:
           build-dir: build
@@ -290,12 +290,12 @@ jobs:
           gcov: true
           verbose: true
 
-  website:
+  releases:
     needs: build
     defaults:
       run:
         shell: bash
-    name: Website
+    name: Releases
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     container: ubuntu:23.04
@@ -303,7 +303,7 @@ jobs:
       contents: write
     steps:
       - name: Setup C++
-        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.3
+        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.4
         id: setup-cpp
         with:
           compiler: clang
@@ -311,7 +311,7 @@ jobs:
           check-latest: true
 
       - name: Install packages
-        uses: alandefreitas/cpp-actions/package-install@v1.8.3
+        uses: alandefreitas/cpp-actions/package-install@v1.8.4
         id: package-install
         with:
           apt-get: libstdc++-12-dev asciidoctor cmake bzip2 git
@@ -332,6 +332,11 @@ jobs:
           name: release-packages-Linux
           path: packages
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-packages-Windows
+          path: packages
+
       - name: Install MrDocs
         run: |
           set -x
@@ -343,7 +348,7 @@ jobs:
           echo -e "CXX=$CXX" >> $GITHUB_ENV
 
       - name: Clone Boost.URL
-        uses: alandefreitas/cpp-actions/boost-clone@v1.8.3
+        uses: alandefreitas/cpp-actions/boost-clone@v1.8.4
         id: boost-url-clone
         with:
           branch: develop
@@ -530,51 +535,22 @@ jobs:
           chmod 755 -R $(pwd)/demos
           scp -o StrictHostKeyChecking=no -r $(pwd)/demos/* ubuntu@dev-websites.cpp.al:$demo_dir/
 
-  releases:
-    needs: build
-    defaults:
-      run:
-        shell: bash
-
-    name: Releases
-    timeout-minutes: 120
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-
-    steps:
       - name: Clone mrdocs
         uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: release-packages-Linux
-          path: build
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: release-packages-Windows
-          path: build
-
-      - name: List artifacts
-        run: ls -R
-        working-directory: build
+      - name: Set Repository Ownership
+        run: |
+          git config --global --add safe.directory "$(pwd)"
 
       - name: Create changelog
-        uses: alandefreitas/cpp-actions/create-changelog@v1.8.3
+        uses: alandefreitas/cpp-actions/create-changelog@v1.8.4
         with:
           output-path: CHANGELOG.md
           thank-non-regular: ${{ startsWith(github.ref, 'refs/tags/') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           limit: 150
 
-      - name: Compare Markup Templates
-        run: |
-          set -x
-          chmod +x .github/compare_templates.sh
-          .github/compare_templates.sh
-
-      - name: Check info nodes
+      - name: Check Info Nodes
         run: |
           set -x
           chmod +x .github/check_info_nodes_support.sh
@@ -584,7 +560,7 @@ jobs:
         if: ${{ github.event_name == 'push' && (contains(fromJSON('["master", "develop"]'), github.ref_name) || startsWith(github.ref, 'refs/tags/')) }}
         uses: softprops/action-gh-release@v1
         with:
-          files: build/MrDocs-?.?.?-*.*
+          files: packages/MrDocs-?.?.?-*.*
           name: ${{ github.ref_name || github.ref }}
           tag_name: ${{ github.ref_name || github.ref }}${{ ((!startsWith(github.ref, 'refs/tags/')) && '-release') || '' }}
           body_path: CHANGELOG.md
@@ -592,7 +568,8 @@ jobs:
           draft: false
           token: ${{ github.token }}
 
-      - uses: dev-drprasad/delete-older-releases@v0.2.1
+      - name: Delete Older Releases
+        uses: dev-drprasad/delete-older-releases@v0.2.1
         if: ${{ github.event_name == 'push' && contains(fromJSON('["master", "develop"]'), github.ref_name) }}
         with:
           keep_latest: 1


### PR DESCRIPTION
This PR unifies the release workflows, removing redundant steps in both workflows. This should have been done in a previous PR, but it wasn't possible because the changelog action was a composite action, which caused problems in different containers.