### PR TITLE
Simplify config generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,11 +338,15 @@ if (MRDOCS_BUILD_TESTS)
     include(CTest)
     file(GLOB_RECURSE TEST_SUITE_FILES CONFIGURE_DEPENDS src/test_suite/*.cpp src/test_suite/*.hpp)
     file(GLOB_RECURSE UNIT_TEST_SOURCES CONFIGURE_DEPENDS src/test/*.cpp src/test/*.hpp)
-    add_executable(mrdocs-test ${TEST_SUITE_FILES} ${UNIT_TEST_SOURCES})
+    add_executable(mrdocs-test ${TEST_SUITE_FILES} ${UNIT_TEST_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/src/tool/PublicToolArgs.cpp)
     target_include_directories(mrdocs-test
+            PUBLIC
+            "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>"
+            "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/>"
+            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
             PRIVATE
-            "${PROJECT_SOURCE_DIR}/include"
             "${PROJECT_SOURCE_DIR}/src"
+            "${PROJECT_BINARY_DIR}/src"
             )
     target_link_libraries(mrdocs-test PUBLIC mrdocs-core)
     if (MRDOCS_CLANG)
@@ -358,9 +362,10 @@ if (MRDOCS_BUILD_TESTS)
                 --action=test
                 "${PROJECT_SOURCE_DIR}/test-files/golden-tests"
                 "--addons=${CMAKE_SOURCE_DIR}/share/mrdocs/addons"
-                --generator=${testgenerator}
+                --generate=${testgenerator}
                 "--stdlib-includes=${LIBCXX_DIR}"
                 "--stdlib-includes=${STDLIB_INCLUDE_DIR}"
+                --report=2
         )
         foreach (action IN ITEMS test create update)
             add_custom_target(
@@ -371,9 +376,10 @@ if (MRDOCS_BUILD_TESTS)
                     --action=${action}
                     "${PROJECT_SOURCE_DIR}/test-files/golden-tests"
                     "--addons=${CMAKE_SOURCE_DIR}/share/mrdocs/addons"
-                    --generator=${testgenerator}
+                    --generate=${testgenerator}
                     "--stdlib-includes=${LIBCXX_DIR}"
                     "--stdlib-includes=${STDLIB_INCLUDE_DIR}"
+                    --report=2
                 DEPENDS mrdocs-test
             )
         endforeach ()

--- a/include/mrdocs/Config.hpp
+++ b/include/mrdocs/Config.hpp
@@ -62,8 +62,6 @@ public:
      */
     struct Settings : public PublicSettings
     {
-        using ReferenceDirectories = PublicSettings::ReferenceDirectories;
-
         /**
          * @brief Loads the public configuration settings from the specified YAML file.
          *

--- a/include/mrdocs/Config/ReferenceDirectories.hpp
+++ b/include/mrdocs/Config/ReferenceDirectories.hpp
@@ -1,0 +1,31 @@
+//
+// This is a derivative work. originally part of the LLVM Project.
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2024 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_CONFIG_REFERENCE_DIRECTORIES_HPP
+#define MRDOCS_API_CONFIG_REFERENCE_DIRECTORIES_HPP
+
+#include <string>
+
+namespace clang {
+namespace mrdocs {
+
+/** Reference directories used to resolve paths
+ */
+struct ReferenceDirectories {
+    std::string configDir;
+    std::string cwd;
+    std::string mrdocsRoot;
+};
+
+} // mrdocs
+} // clang
+
+#endif

--- a/src/lib/Lib/ConfigImpl.cpp
+++ b/src/lib/Lib/ConfigImpl.cpp
@@ -133,7 +133,7 @@ Expected<std::shared_ptr<ConfigImpl const>>
 ConfigImpl::
 load(
     Config::Settings const& publicSettings,
-    Config::Settings::ReferenceDirectories const& dirs,
+    ReferenceDirectories const& dirs,
     ThreadPool& threadPool)
 {
     std::shared_ptr<ConfigImpl> c =

--- a/src/lib/Lib/ConfigImpl.hpp
+++ b/src/lib/Lib/ConfigImpl.hpp
@@ -119,7 +119,7 @@ public:
     Expected<std::shared_ptr<ConfigImpl const>>
     load(
         Config::Settings const& publicSettings,
-        Config::Settings::ReferenceDirectories const& dirs,
+        ReferenceDirectories const& dirs,
         ThreadPool& threadPool);
 
     ThreadPool&

--- a/src/test/TestArgs.cpp
+++ b/src/test/TestArgs.cpp
@@ -9,8 +9,6 @@
 //
 
 #include "TestArgs.hpp"
-#include <fmt/format.h>
-#include <cstddef>
 #include <vector>
 
 namespace clang {
@@ -22,12 +20,9 @@ TestArgs TestArgs::instance_;
 
 TestArgs::
 TestArgs()
-    : commonCat("COMMON")
+    : PublicToolArgs()
 
-    , usageText(
-R"(MrDocs Test Program
-)")
-
+    , usageText("MrDocs Test Program")
     , extraHelp(
 R"(
 EXAMPLES:
@@ -37,19 +32,8 @@ EXAMPLES:
 )")
 
 //
-// Common options
-//
-
-, reportLevel(
-    "report",
-    llvm::cl::desc("The minimum reporting level (0 to 4)."),
-    llvm::cl::init(2),
-    llvm::cl::cat(commonCat))
-
-//
 // Test options
 //
-
 , action(
     "action",
     llvm::cl::desc(R"(Which action should be performed:)"),
@@ -57,8 +41,7 @@ EXAMPLES:
     llvm::cl::values(
         clEnumVal(test, "Compare output against expected."),
         clEnumVal(create, "Create missing expected documentation files."),
-        clEnumVal(update, "Update all expected documentation files.")),
-    llvm::cl::cat(commonCat))
+        clEnumVal(update, "Update all expected documentation files.")))
 
 , badOption(
     "bad",
@@ -69,28 +52,6 @@ EXAMPLES:
     "unit",
     llvm::cl::desc("Run all or selected unit test suites."),
     llvm::cl::init(true))
-
-, inputPaths(
-    "inputs",
-    llvm::cl::Sink,
-    llvm::cl::desc("A list of directories and/or .cpp files to test."),
-    llvm::cl::cat(commonCat))
-
-, generator(
-    "generator",
-    llvm::cl::desc("The generator to use for tests."),
-    llvm::cl::init("xml"))
-
-, addons(
-    "addons",
-    llvm::cl::desc("The directory with the addons."),
-    llvm::cl::cat(commonCat))
-
-, stdlibIncludes(
-    "stdlib-includes",
-    llvm::cl::desc("A list of paths to std library headers."),
-    llvm::cl::cat(commonCat))
-
 {
 }
 
@@ -104,7 +65,6 @@ hideForeignOptions()
 
     std::vector<llvm::cl::Option const*> ours({
         &action,
-        std::addressof(inputPaths),
         &badOption,
         &unitOption
     });

--- a/src/test/TestArgs.hpp
+++ b/src/test/TestArgs.hpp
@@ -12,6 +12,7 @@
 #define MRDOCS_TEST_TESTARGS_HPP
 
 #include <llvm/Support/CommandLine.h>
+#include <tool/PublicToolArgs.hpp>
 #include <string>
 
 namespace clang {
@@ -26,11 +27,9 @@ enum Action : int
 
 /** Command line options and test settings.
 */
-class TestArgs
+class TestArgs : public PublicToolArgs
 {
     TestArgs();
-
-    llvm::cl::OptionCategory    commonCat;
 
 public:
     static TestArgs instance_;
@@ -38,19 +37,10 @@ public:
     char const*                 usageText;
     llvm::cl::extrahelp         extraHelp;
 
-    // Common options
-    llvm::cl::opt<unsigned>     reportLevel;
-
     // Test options
     llvm::cl::opt<Action>       action;
     llvm::cl::opt<bool>         badOption;
     llvm::cl::opt<bool>         unitOption;
-    llvm::cl::list<std::string> inputPaths;
-
-    // Options replication public settings
-    llvm::cl::opt<std::string>  generator;
-    llvm::cl::opt<std::string>  addons;
-    llvm::cl::list<std::string> stdlibIncludes;
 
     // Hide all options that don't belong to us
     void hideForeignOptions();

--- a/src/test/TestMain.cpp
+++ b/src/test/TestMain.cpp
@@ -23,18 +23,18 @@
 #include <llvm/Support/Signals.h>
 #include <stdlib.h>
 
-int main(int argc, char** argv);
+int main(int argc, char const** argv);
 
 namespace clang {
 namespace mrdocs {
 
-void DoTestAction()
+void DoTestAction(char const** argv)
 {
     using namespace clang::mrdocs;
 
-    TestRunner runner(testArgs.generator);
-    for(auto const& inputPath : testArgs.inputPaths)
-        runner.checkPath(inputPath);
+    TestRunner runner(testArgs.generate);
+    for(auto const& inputPath : testArgs.inputs)
+        runner.checkPath(inputPath, argv);
     auto const& results = runner.results;
 
     std::stringstream os;
@@ -63,7 +63,7 @@ void DoTestAction()
     report::print(os.str());
 }
 
-int test_main(int argc, char const* const* argv)
+int test_main(int argc, char const** argv)
 {
     // VFALCO this heap checking is too strong for
     // a clang tool's model of what is actually a leak.
@@ -80,10 +80,10 @@ int test_main(int argc, char const* const* argv)
 
     // Apply reportLevel
     report::setMinimumLevel(report::getLevel(
-        testArgs.reportLevel.getValue()));
+        testArgs.report.getValue()));
 
-    if(! testArgs.inputPaths.empty())
-        DoTestAction();
+    if(!testArgs.inputs.empty())
+        DoTestAction(argv);
 
     if(testArgs.unitOption.getValue())
         test_suite::unit_test_main(argc, argv);
@@ -106,7 +106,7 @@ static void reportUnhandledException(
 } // mrdocs
 } // clang
 
-int main(int argc, char** argv)
+int main(int argc, char const** argv)
 {
     try
     {

--- a/src/test/TestRunner.cpp
+++ b/src/test/TestRunner.cpp
@@ -264,7 +264,8 @@ handleDir(
 void
 TestRunner::
 checkPath(
-    std::string inputPath)
+    std::string inputPath,
+    char const** argv)
 {
     namespace fs = llvm::sys::fs;
     namespace path = llvm::sys::path;
@@ -274,14 +275,6 @@ checkPath(
     // Set the reference directories for the test
     dirs_.configDir = inputPath;
     dirs_.cwd = dirs_.configDir;
-    if (testArgs.addons.getValue() != "")
-    {
-        dirs_.mrdocsRoot = files::getParentDir(files::normalizePath(testArgs.addons.getValue()), 3);
-    }
-    else
-    {
-        report::warn("No addons directory specified to mrdocs tests");
-    }
 
     // See if inputPath references a file or directory
     auto fileType = files::getFileType(inputPath);
@@ -291,6 +284,7 @@ checkPath(
 
     // Check for a directory-wide config
     Config::Settings dirSettings;
+    testArgs.apply(dirSettings, dirs_, argv);
     dirSettings.sourceRoot = files::appendPath(inputPath, ".");
     dirSettings.stdlibIncludes.insert(
         dirSettings.stdlibIncludes.end(),

--- a/src/test/TestRunner.hpp
+++ b/src/test/TestRunner.hpp
@@ -53,7 +53,7 @@ class TestRunner
     ThreadPool threadPool_;
     llvm::ErrorOr<std::string> diffCmdPath_;
     Generator const* gen_;
-    Config::Settings::ReferenceDirectories dirs_;
+    ReferenceDirectories dirs_;
 
     Error writeFile(
         llvm::StringRef filePath,

--- a/src/test/TestRunner.hpp
+++ b/src/test/TestRunner.hpp
@@ -79,7 +79,7 @@ public:
         This function checks the specified path
         and blocks until completed.
     */
-    void checkPath(std::string inputPath);
+    void checkPath(std::string inputPath, char const** argv);
 };
 
 } // mrdocs

--- a/src/tool/GenerateAction.cpp
+++ b/src/tool/GenerateAction.cpp
@@ -88,7 +88,7 @@ generateCompileCommandsFile(llvm::StringRef inputPath, llvm::StringRef cmakeArgs
 Expected<void>
 DoGenerateAction(
     std::string const& configPath,
-    Config::Settings::ReferenceDirectories const& dirs,
+    ReferenceDirectories const& dirs,
     char const** argv)
 {
     // --------------------------------------------------------------

--- a/src/tool/ToolMain.cpp
+++ b/src/tool/ToolMain.cpp
@@ -27,13 +27,13 @@ namespace mrdocs {
 
 extern
 int
-DoTestAction();
+DoTestAction(char const** argv);
 
 extern
 Expected<void>
 DoGenerateAction(
     std::string const& configPath,
-    Config::Settings::ReferenceDirectories const& dirs,
+    ReferenceDirectories const& dirs,
     char const** argv);
 
 void
@@ -47,10 +47,10 @@ print_version(llvm::raw_ostream& os)
        << "\n";
 }
 
-Expected<std::pair<std::string, Config::Settings::ReferenceDirectories>>
+Expected<std::pair<std::string, ReferenceDirectories>>
 getReferenceDirectories(std::string const& execPath)
 {
-    Config::Settings::ReferenceDirectories dirs;
+    ReferenceDirectories dirs;
     dirs.mrdocsRoot = files::getParentDir(execPath, 2);
     llvm::SmallVector<char, 256> cwd;
     if (auto ec = llvm::sys::fs::current_path(cwd); ec)

--- a/test-files/handlebars/features_test.adoc.hbs
+++ b/test-files/handlebars/features_test.adoc.hbs
@@ -1,10 +1,10 @@
-=={{#unless is_multipage}}={{/unless}} {{ page.name }}
+== {{ page.name }}
 
 {{#if page.doc}}
 {{page.doc.brief}}
 {{/if}}
 
-==={{#unless is_multipage}}={{/unless}} Synopsis
+=== Synopsis
 
 {{#if page.decl }}
 [,cpp]
@@ -20,11 +20,11 @@ Declared in file <{{page.loc}}>
 {{page.synopsis}}
 
 {{#if page.doc.description}}
-==={{#unless is_multipage}}={{/unless}} Description
+=== Description
 
 {{page.doc.description}}
 
-=={{#unless is_multipage}}={{/unless}} Basic
+== Basic
 
 {{/if}}
 
@@ -53,7 +53,7 @@ People:
 {{#each page.people}}* Person: {{firstname}} {{lastname}} in page about `{{../page/name}}`
 {{/each}}
 
-=={{#unless is_multipage}}={{/unless}} Expressions
+== Expressions
 
 // Render complete context with "." as key
 {{.}}
@@ -120,7 +120,7 @@ html-escaped: {{page.specialChars}}
 
 {{>escaped}}
 
-=={{#unless is_multipage}}={{/unless}} Partials
+== Partials
 
 // Basic partials
 {{>record-detail}}
@@ -169,7 +169,7 @@ My Content
 {{/pageLayout}}
 
 
-=={{#unless is_multipage}}={{/unless}} Blocks
+== Blocks
 
 // Block noop
 <div class="entry">
@@ -290,7 +290,7 @@ My Content
     {{/each}}
 {{/each}}
 
-=={{#unless is_multipage}}={{/unless}} Built-in Helpers
+== Built-in Helpers
 
 // Author
 {{#if author}}
@@ -389,7 +389,7 @@ No city found
 {{log "logging a warning" level="warn"}}
 {{log "logging an error" level="error"}}
 
-=={{#unless is_multipage}}={{/unless}} Hooks
+== Hooks
 
 // Helper missing
 {{foo}}
@@ -403,7 +403,7 @@ No city found
     {{firstname}} {{lastname}}
 {{/person}}
 
-=={{#unless is_multipage}}={{/unless}} String helpers
+== String helpers
 
 // capitalize
 {{ capitalize 'Hello world!' }}
@@ -682,7 +682,7 @@ No city found
 {{ strip_namespace 'std::basic_string<char, typename B::value_type>' }}
 {{#strip_namespace }}std::basic_string<char, typename B::value_type>{{/strip_namespace}}
 
-=={{#unless is_multipage}}={{/unless}} Containers
+== Containers
 
 // size
 {{ size containers.array }}


### PR DESCRIPTION
- Normalization now happens via a custom visitor class so that validation can be implemented directly in C++. The generated files include only the essential information. The generator also became much shorter and easier to maintain.
- TestArgs reuse the generated public config args, avoiding duplicated code for command-line options required to test recent features.
- Fix handlebars unit tests where a unit test template file was making references to `is_multipage`. This bug was introduced in e460d86aceed8784d2cd3c7dd04daef51d74e3a8