### PR TITLE
Move an include of `<cctype>` to where it belongs

### DIFF
--- a/include/mrdocs/Support/String.hpp
+++ b/include/mrdocs/Support/String.hpp
@@ -13,7 +13,6 @@
 #define MRDOCS_API_SUPPORT_STRING_HPP
 
 #include <mrdocs/Platform.hpp>
-#include <cctype>
 #include <string>
 #include <string_view>
 

--- a/src/lib/AST/ParseJavadoc.cpp
+++ b/src/lib/AST/ParseJavadoc.cpp
@@ -24,6 +24,7 @@
 #include <clang/Lex/Lexer.h>
 #include <clang/Basic/SourceLocation.h>
 #include "lib/AST/ParseRef.hpp"
+#include <cctype>
 
 #ifdef _MSC_VER
 #pragma warning(push)


### PR DESCRIPTION
The header was included in String.hpp, but that file doesn't use any of its functions. However, ParseJavadoc.cpp does, so we add the include there.