### PR TITLE
ci: make the build 'Setup Ninja' job windows-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
 
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@v5
+        if: ${{ runner.os == 'Windows' }}
 
       - name: Setup C++
         uses: alandefreitas/cpp-actions/setup-cpp@v1.8.10


### PR DESCRIPTION
Ninja comes pre-installed in every other image except Windows.