### PR TITLE
style: hide close button on larger screens in docs nav

### DIFF
--- a/docs/ui/src/css/nav.css
+++ b/docs/ui/src/css/nav.css
@@ -311,6 +311,12 @@
   margin-top: 0.5rem;
 }
 
+@media screen and (min-width: 769px) {
+  .nav-close {
+    display: none;
+  }
+}
+
 .nav-close span {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
Hide nav close button on tablet/desktop screens (≥769px) where it's not needed.

**Change:** Added CSS media query to hide .nav-close button on screens 769px and wider.