### PR TITLE
fix(ci): setup C++ when building releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -687,7 +687,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
 
       - name: Setup C++
-        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.10
+        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.12
         id: setup-cpp
         with:
           compiler: ${{ matrix.compiler }}


### PR DESCRIPTION
Setup C++ in releases, same as used for building. Note this causes windows releases to use msvc rather than mingw.

If supporting mingw is explicitly desired then I suggest giving it its own distinct build where it is used throughout the process, rather than building with msvc but testing against mingw.