### PR TITLE
fix: don't produce warnings for symbols copied from base classes

### DIFF
--- a/include/mrdocs/Metadata/Symbol/SymbolBase.hpp
+++ b/include/mrdocs/Metadata/Symbol/SymbolBase.hpp
@@ -71,6 +71,11 @@ struct MRDOCS_VISIBLE Symbol {
     */
     ExtractionMode Extraction = ExtractionMode::Dependency;
 
+    /** Whether this a copy of an inherited method, as produced when
+        `inherit-base-members` is not `never`.
+    */
+    bool IsCopyFromInherited = false;
+
     /** The parent symbol, if any.
 
         This is the parent namespace or record

--- a/src/lib/Metadata/Finalizers/BaseMembersFinalizer.cpp
+++ b/src/lib/Metadata/Finalizers/BaseMembersFinalizer.cpp
@@ -172,6 +172,7 @@ inheritBaseMembers(
             otherCopy->id = SymbolID::createFromString(
                 std::format("{}-{}", toBase16Str(otherCopy->Parent),
                             toBase16Str(otherInfo.id)));
+            otherCopy->IsCopyFromInherited = true;
             derived.push_back(otherCopy->id);
             // Get the extraction mode from the derived class
             if (otherCopy->Extraction == ExtractionMode::Dependency ||

--- a/src/lib/Metadata/Finalizers/DocCommentFinalizer.cpp
+++ b/src/lib/Metadata/Finalizers/DocCommentFinalizer.cpp
@@ -1731,7 +1731,8 @@ DocCommentFinalizer::warnUndocumented()
         if (Symbol const* I = corpus_.find(undocI.id))
         {
             MRDOCS_CHECK_OR(
-                !I->doc || I->Extraction == ExtractionMode::Regular);
+                !I->doc || I->Extraction == ExtractionMode::Regular
+                || I->IsCopyFromInherited == false);
         }
         bool const prefer_definition = is_one_of(
             undocI.kind, {SymbolKind::Record, SymbolKind::Enum});
@@ -1752,6 +1753,7 @@ warnDocErrors()
     for (auto const& I : corpus_.info_)
     {
         MRDOCS_CHECK_OR_CONTINUE(I->Extraction == ExtractionMode::Regular);
+        MRDOCS_CHECK_OR_CONTINUE(I->IsCopyFromInherited == false);
         MRDOCS_CHECK_OR_CONTINUE(I->isFunction());
         warnParamErrors(dynamic_cast<FunctionSymbol const&>(*I));
     }
@@ -1807,6 +1809,7 @@ warnNoParamDocs()
     for (auto const& I : corpus_.info_)
     {
         MRDOCS_CHECK_OR_CONTINUE(I->Extraction == ExtractionMode::Regular);
+        MRDOCS_CHECK_OR_CONTINUE(I->IsCopyFromInherited == false);
         MRDOCS_CHECK_OR_CONTINUE(I->isFunction());
         MRDOCS_CHECK_OR_CONTINUE(I->doc);
         warnNoParamDocs(dynamic_cast<FunctionSymbol const&>(*I));
@@ -1869,6 +1872,7 @@ warnUndocEnumValues()
     {
         MRDOCS_CHECK_OR_CONTINUE(I->isEnumConstant());
         MRDOCS_CHECK_OR_CONTINUE(I->Extraction == ExtractionMode::Regular);
+        MRDOCS_CHECK_OR_CONTINUE(I->IsCopyFromInherited == false);
         MRDOCS_CHECK_OR_CONTINUE(!I->doc);
         this->warn(
             *getPrimaryLocation(*I),
@@ -1886,6 +1890,7 @@ warnUnnamedParams()
     {
         MRDOCS_CHECK_OR_CONTINUE(I->isFunction());
         MRDOCS_CHECK_OR_CONTINUE(I->Extraction == ExtractionMode::Regular);
+        MRDOCS_CHECK_OR_CONTINUE(I->IsCopyFromInherited == false);
         MRDOCS_CHECK_OR_CONTINUE(I->doc);
         warnUnnamedParams(dynamic_cast<FunctionSymbol const&>(*I));
     }

--- a/test-files/golden-tests/regression/1119.adoc
+++ b/test-files/golden-tests/regression/1119.adoc
@@ -1,0 +1,8 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/regression/1119.cpp
+++ b/test-files/golden-tests/regression/1119.cpp
@@ -1,0 +1,13 @@
+namespace ns {
+struct Foo {
+    /// bar
+    int
+    bar();
+};
+} // namespace ns
+
+/// project namespace
+namespace mrdocs {
+/// Baz
+struct Baz : ns::Foo {};
+} // namespace mrdocs

--- a/test-files/golden-tests/regression/1119.html
+++ b/test-files/golden-tests/regression/1119.html
@@ -1,0 +1,19 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index"></h2>
+</div>
+</div>
+
+</div>
+<div>
+<h4>Created with <a href="https://www.mrdocs.com">MrDocs</a></h4>
+</div>
+</body>
+</html>

--- a/test-files/golden-tests/regression/1119.xml
+++ b/test-files/golden-tests/regression/1119.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace id="//////////////////////////8=">
+</namespace>
+</mrdocs>

--- a/test-files/golden-tests/regression/1119.yml
+++ b/test-files/golden-tests/regression/1119.yml
@@ -1,0 +1,2 @@
+include-symbols:
+  - 'foobar::**'


### PR DESCRIPTION
Fixes #1119