### PR TITLE
fix(ast): prevent TU parent from including unmatched globals 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,9 @@ jobs:
             apple-clang: Release
             msvc: RelWithDebInfo
           install: |
-            gcc: git build-essential pkg-config python3 curl openjdk-11-jdk pkg-config libncurses-dev libxml2-utils libxml2-dev
-            gcc Coverage: git build-essential pkg-config python3 curl openjdk-11-jdk pkg-config libncurses-dev libxml2-utils libxml2-dev lcov
-            clang: git build-essential pkg-config python3 curl openjdk-11-jdk pkg-config libncurses-dev libxml2-utils libxml2-dev g++-14=14.2.0-4ubuntu2~24.04
+            gcc: git build-essential pkg-config python3 curl unzip openjdk-11-jdk pkg-config libncurses-dev libxml2-utils libxml2-dev
+            gcc Coverage: git build-essential pkg-config python3 curl unzip openjdk-11-jdk pkg-config libncurses-dev libxml2-utils libxml2-dev lcov
+            clang: git build-essential pkg-config python3 curl unzip openjdk-11-jdk pkg-config libncurses-dev libxml2-utils libxml2-dev g++-14=14.2.0-4ubuntu2~24.04
             msvc: ''
           extra-values: |
             use-libcxx: {{#if (and (ieq compiler 'clang') (ge major 19)) }}true{{else}}false{{/if}}
@@ -332,36 +332,6 @@ jobs:
           path: ${{ steps.rmatrix.outputs.llvm-path }}
           key: ${{ matrix.llvm-archive-basename }}
 
-      - name: Download LLVM Binaries
-        id: llvm-download
-        if: steps.llvm-cache.outputs.cache-hit != 'true'
-        run: |
-          set -x
-          url=https://mrdocs.com/llvm+clang/${{ matrix.llvm-archive-filename }}
-          http_status=$(curl -s -o /dev/null -w "%{http_code}" -I "$url")
-          if [ "$http_status" -eq 200 ]; then
-              found="true"
-              echo "found=$found" >> $GITHUB_OUTPUT
-              curl -L -o ${{ matrix.llvm-archive-filename }} "$url"
-              install_prefix=${{ steps.rmatrix.outputs.llvm-path }}
-              mkdir -p $install_prefix
-              if [[ ${{ matrix.llvm-archive-extension }} == '7z' ]]; then
-                  7z x ${{ matrix.llvm-archive-filename }} -o$install_prefix
-              else
-                  tar -xjf ${{ matrix.llvm-archive-filename }} -C $install_prefix
-              fi
-              if [[ $(ls -1 $install_prefix | wc -l) -eq 1 ]]; then
-                  single_dir=$(ls -1 $install_prefix)
-                  if [[ -d $install_prefix/$single_dir ]]; then
-                      mv $install_prefix/$single_dir/* $install_prefix/
-                      rmdir $install_prefix/$single_dir
-                  fi
-              fi
-          else
-              found="false"
-              echo "found=$found" >> $GITHUB_OUTPUT
-          fi
-
       # Installs libc++ separately, using the LLVM standalone runtimes build.
       # The libc++ built here will be built using the host compiler, so this is
       # limited by what libc++ at the current LLVM revision supports.
@@ -375,16 +345,27 @@ jobs:
       # FIXME: Build this for the GCC and MacOS sanitizer jobs.
       # Currently GCC fails linking it, and for MacOS there are compiler-rt
       # requirements not satisfied.
+      - name: Fetch LLVM source archive
+        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        run: |
+          set -eux
+          mkdir -p ../third-party
+          cd ../third-party
+          archive="llvm-${{ matrix.llvm-hash }}.zip"
+          if [ ! -d llvm-project ]; then
+            curl -L -o "$archive" "https://github.com/llvm/llvm-project/archive/${{ matrix.llvm-hash }}.zip"
+            unzip -q "$archive"
+            mv "llvm-project-${{ matrix.llvm-hash }}" llvm-project
+            rm "$archive"
+          fi
+
       - name: Install libc++
         id: install_libcxx
         uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.12
-        if: matrix.use-libcxx == 'true' && steps.llvm-cache.outputs.cache-hit != 'true' && steps.llvm-download.outputs.found != 'true'
+        if: matrix.use-libcxx == 'true' && steps.llvm-cache.outputs.cache-hit != 'true'
         with:
           cmake-version: '>=3.26'
           source-dir: ../third-party/llvm-project/runtimes
-          git-repository: https://github.com/llvm/llvm-project.git
-          git-tag: ${{ matrix.llvm-hash }}
-          download-dir: ../third-party/llvm-project
           build-dir: ${sourceDir}/build
           build-type: ${{ matrix.build-type }}
           extra-args: |
@@ -415,13 +396,10 @@ jobs:
       - name: Install LLVM
         id: install_llvm
         uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.12
-        if: steps.llvm-cache.outputs.cache-hit != 'true' && steps.llvm-download.outputs.found != 'true'
+        if: steps.llvm-cache.outputs.cache-hit != 'true'
         with:
           cmake-version: '>=3.26'
           source-dir: ../third-party/llvm-project/llvm
-          git-repository: https://github.com/llvm/llvm-project.git
-          git-tag: ${{ matrix.llvm-hash }}
-          download-dir: ../third-party/llvm-project
           patches: |
             ./third-party/patches/llvm/llvm/CMakePresets.json
             ./third-party/patches/llvm/llvm/CMakeUserPresets.json
@@ -1246,69 +1224,9 @@ jobs:
         with:
           apt-get: ${{ matrix.install }}
 
-      - name: Check website releases
-        id: website-releases
-        run: |
-          set -x
-          archive_url="https://mrdocs.com/llvm+clang/${{ matrix.llvm-archive-filename }}"
-          http_status=$(curl -s -o /dev/null -w "%{http_code}" -I "$archive_url")
-          if [ "$http_status" -eq 200 ]; then
-              exists="true"
-          else
-              exists="false"
-          fi
-          echo "exists=$exists" >> $GITHUB_OUTPUT
-
       - name: LLVM Binaries
         id: llvm-cache
-        if: steps.website-releases.outputs.exists != 'true'
         uses: actions/cache@v4
         with:
           path: ${{ steps.rmatrix.outputs.llvm-path }}
           key: ${{ matrix.llvm-archive-basename }}
-
-      - name: Compress LLVM
-        id: llvm-upload
-        if: steps.llvm-cache.outputs.cache-hit == 'true'
-        shell: bash
-        run: |
-          # LLVM is be installed with the default compiler
-          set -x
-
-          # Use 7z on windows
-          if [[ ${{ runner.os }} == 'Windows' ]]; then
-              7z a -t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on "${{ matrix.llvm-archive-filename }}" "${{ steps.rmatrix.outputs.llvm-path }}"
-          else
-              tar -cjf "${{ matrix.llvm-archive-filename }}" -C "${{ steps.rmatrix.outputs.llvm-path }}/.." llvm
-          fi
-
-      - name: Website LLVM Releases
-        if: steps.llvm-cache.outputs.cache-hit == 'true' && github.event_name == 'push' && (contains(fromJSON('["master", "develop"]'), github.ref_name) || startsWith(github.ref, 'refs/tags/'))
-        run: |
-          set -x
-          
-          # Ensure required commands exist
-          for cmd in ssh-keyscan ssh-agent ssh-add scp; do
-            if ! command -v $cmd >/dev/null; then
-              echo "$cmd not found"
-              exit 1
-            fi
-          done
-          
-          # Add SSH key
-          mkdir -p ~/.ssh
-          ssh-keyscan dev-websites.cpp.al >> ~/.ssh/known_hosts
-          chmod 600 ~/.ssh/known_hosts
-          echo "${{ secrets.DEV_WEBSITES_SSH_KEY }}" > ~/.ssh/github_actions
-          chmod 600 ~/.ssh/github_actions
-
-          # Start ssh-agent and add the key
-          SSH_AUTH_SOCK="$RUNNER_TEMP/ssh_agent.sock"
-          export SSH_AUTH_SOCK
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add ~/.ssh/github_actions
-
-          # Copy llvm archive: This step will copy the archive to www.mrdocs.com/llvm+clang
-          llvm_dir="/var/www/mrdox.com/llvm+clang"
-          chmod 755 ${{ matrix.llvm-archive-filename }}
-          scp -o StrictHostKeyChecking=no $(pwd)/${{ matrix.llvm-archive-filename }} ubuntu@dev-websites.cpp.al:$llvm_dir/

--- a/.github/workflows/pr-target-checks.yml
+++ b/.github/workflows/pr-target-checks.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install repo-check tools
         run: npm --prefix util/danger ci
 
-      - name: Repo checks (Danger)
+      - name: Repo checks (Danger.js)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx --prefix util/danger danger ci --dangerfile util/danger/dangerfile.ts

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -3132,7 +3132,7 @@ class MrDocsInstaller:
 
     def collect_user_inputs(self):
         """
-        Phase 1: ask all questions up front to mirror bootstrap-other's two-phase flow.
+        Phase 1: ask all questions up front for a two-phase flow.
         This keeps prompts grouped before any work begins.
         """
         self.ui.section("MrDocs Bootstrap", icon="🚀")

--- a/src/lib/AST/ASTVisitor.cpp
+++ b/src/lib/AST/ASTVisitor.cpp
@@ -3201,6 +3201,26 @@ checkSymbolFilters(clang::Decl const* D, bool const AllowParent)
     else if (AllowParent)
     {
         clang::Decl const* P = getParent(D);
+        while (P)
+        {
+            // Only propagate inclusion from meaningful scopes. Translation units
+            // (and other non-scope wrappers like linkage specs) should not cause
+            // otherwise-unmatched globals to be extracted.
+            if (isa<clang::NamespaceDecl>(P) ||
+                isa<clang::RecordDecl>(P) ||
+                isa<clang::EnumDecl>(P))
+            {
+                break;
+            }
+
+            if (isa<clang::TranslationUnitDecl>(P))
+            {
+                P = nullptr;
+                break;
+            }
+
+            P = getParent(P);
+        }
         if (P)
         {
             // 4) Parent symbols imply this symbol should be included

--- a/test-files/golden-tests/config/include-symbols/global-symbol-excluded.adoc
+++ b/test-files/golden-tests/config/include-symbols/global-symbol-excluded.adoc
@@ -1,0 +1,45 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Namespaces
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#mrdocs[`mrdocs`] 
+| Included namespace
+|===
+
+[#mrdocs]
+== mrdocs
+
+Included namespace
+
+=== Types
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#mrdocs-Foo[`Foo`] 
+| Included record
+|===
+
+[#mrdocs-Foo]
+== link:#mrdocs[mrdocs]::Foo
+
+Included record
+
+=== Synopsis
+
+Declared in `&lt;global&hyphen;symbol&hyphen;excluded&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct Foo;
+----
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/config/include-symbols/global-symbol-excluded.cpp
+++ b/test-files/golden-tests/config/include-symbols/global-symbol-excluded.cpp
@@ -1,0 +1,9 @@
+// Regression test for #1121: limiting include-symbols to a namespace should
+// not extract global symbols that do not match the pattern.
+struct Baz {};
+
+/// Included namespace
+namespace mrdocs {
+/// Included record
+struct Foo {};
+} // namespace mrdocs

--- a/test-files/golden-tests/config/include-symbols/global-symbol-excluded.html
+++ b/test-files/golden-tests/config/include-symbols/global-symbol-excluded.html
@@ -1,0 +1,79 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index">
+Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
+</h2>
+</div>
+<h2>
+Namespaces</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th><th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#mrdocs"><code>mrdocs</code></a> </td><td>Included namespace</td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="mrdocs">
+mrdocs<a class="mrdocs-anchor" href="#mrdocs" aria-label="Permalink">#</a>
+</h2>
+<div>
+<p>Included namespace</p>
+</div>
+</div>
+<h2>
+Types</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th><th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#mrdocs-Foo"><code>Foo</code></a> </td><td>Included record</td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="mrdocs-Foo">
+mrdocs::Foo<a class="mrdocs-anchor" href="#mrdocs-Foo" aria-label="Permalink">#</a>
+</h2>
+<div>
+<p>Included record</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;global-symbol-excluded.cpp&gt;</code></div>
+<pre><code class="source-code cpp">struct Foo;</code></pre>
+</div>
+
+
+</div>
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/include-symbols/global-symbol-excluded.xml
+++ b/test-files/golden-tests/config/include-symbols/global-symbol-excluded.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace id="//////////////////////////8=">
+  <namespace name="mrdocs" id="rQr6X4pFwyRradNsE4fgTcl6Jmk=">
+    <doc>
+      <brief>
+        <text>Included namespace</text>
+      </brief>
+    </doc>
+    <struct name="Foo" id="yJQinsro3N5aSu4KK6p+ChnY5FM=">
+      <file short-path="global-symbol-excluded.cpp" source-path="global-symbol-excluded.cpp" line="8" class="def"/>
+      <doc>
+        <brief>
+          <text>Included record</text>
+        </brief>
+      </doc>
+    </struct>
+  </namespace>
+</namespace>
+</mrdocs>

--- a/test-files/golden-tests/config/include-symbols/global-symbol-excluded.yml
+++ b/test-files/golden-tests/config/include-symbols/global-symbol-excluded.yml
@@ -1,0 +1,2 @@
+include-symbols:
+  - 'mrdocs::**'

--- a/third-party/patches/llvm/llvm/CMakePresets.json
+++ b/third-party/patches/llvm/llvm/CMakePresets.json
@@ -18,6 +18,12 @@
         "LLVM_ENABLE_RUNTIMES": "libcxx",
         "LLVM_TARGETS_TO_BUILD": "Native",
 
+
+        "LLVM_ENABLE_ZLIB": false,
+        "LLVM_ENABLE_ZSTD": false,
+        "LLVM_ENABLE_LIBXML2": false,
+        "LLVM_ENABLE_BACKTRACES": false,
+
         "LLVM_UNREACHABLE_OPTIMIZE": false,
         "LLVM_ADD_NATIVE_VISUALIZERS_TO_SOLUTION": false,
         "LLVM_ENABLE_RTTI": true,
@@ -43,14 +49,19 @@
         "LLVM_BUILD_DOCS": false,
         "LLVM_BUILD_EXAMPLES": false,
         "LLVM_ENABLE_TERMINFO": false,
-        "CLANG_ENABLE_ARCMT": true,
         "CLANG_ENABLE_HLSL": false,
         "CLANG_ENABLE_OBJC_REWRITER": false,
         "CLANG_ENABLE_PROTO_FUZZER": false,
-        "CLANG_ENABLE_STATIC_ANALYZER": true,
+        "CLANG_ENABLE_STATIC_ANALYZER": false,
+        "CLANG_ENABLE_FORMAT": false,
         "CLANG_INCLUDE_TESTS": false,
         "CLANG_INCLUDE_DOCS": false,
-        "CLANG_BUILD_EXAMPLES": false
+        "CLANG_BUILD_EXAMPLES": false,
+
+        "LIBCXX_ENABLE_SHARED": false,
+        "LIBCXX_ENABLE_STATIC": true,
+        "LIBCXX_INCLUDE_TESTS": false,
+        "LIBCXX_INCLUDE_BENCHMARKS": false
       },
       "warnings": {
         "unusedCli": false

--- a/util/danger/format.test.ts
+++ b/util/danger/format.test.ts
@@ -1,0 +1,51 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2025 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+import { describe, expect, it } from "vitest";
+import { renderDangerReport } from "./format";
+import { summarizeScopes, type DangerResult } from "./logic";
+
+describe("renderDangerReport", () => {
+    it("puts warnings at the top as GitHub admonitions", () => {
+        const summary = summarizeScopes([
+            { filename: "src/lib/example.cpp", additions: 10, deletions: 2 },
+            { filename: "docs/index.adoc", additions: 1, deletions: 0 },
+        ]);
+        const result: DangerResult = {
+            warnings: ["First issue", "Second issue"],
+            summary,
+        };
+
+        const output = renderDangerReport(result);
+
+        expect(output.startsWith("> 🚧 Danger.js checks for MrDocs")).toBe(true);
+        expect(output).toContain("## ⚠️ Warnings");
+        expect((output.match(/> \[!WARNING\]/g) || []).length).toBe(2);
+        expect(output).toContain("## 🧾 Changes by Scope");
+        expect(output).toMatch(/\|\s*\*\*Total\*\*\s*\|/);
+        expect(output).toContain("Legend: Files + (added), Files ~ (modified), Files ↔ (renamed), Files - (removed)");
+        expect(output).toContain("## 🔝 Top Files");
+    });
+
+    it("formats scope totals with bold metrics and consistent churn", () => {
+        const summary = summarizeScopes([
+            { filename: "src/lib/example.cpp", additions: 3, deletions: 1 },
+            { filename: "src/test/example_test.cpp", additions: 2, deletions: 0 },
+        ]);
+        const result: DangerResult = { warnings: [], summary };
+
+        const output = renderDangerReport(result);
+
+        expect(output).toMatch(/\|\s*Source\s*\|\s*\*\*4\*\*\s*\|\s*3\s*\|\s*1\s*\|\s*\*\*1\*\*\s*\|\s*-\s*\|\s*1\s*\|\s*-\s*\|\s*-\s*\|/);
+        expect(output).toMatch(/\|\s*Tests\s*\|\s*\*\*2\*\*\s*\|\s*2\s*\|\s*-\s*\|\s*\*\*1\*\*\s*\|\s*-\s*\|\s*1\s*\|\s*-\s*\|\s*-\s*\|/);
+        expect(output).toMatch(/\|\s*\*\*Total\*\*\s*\|\s*\*\*6\*\*\s*\|\s*5\s*\|\s*1\s*\|\s*\*\*2\*\*\s*\|/);
+        expect(output).toContain("## ✨ Highlights");
+        expect(output.trim().startsWith("> 🚧 Danger.js checks for MrDocs")).toBe(true);
+    });
+});

--- a/util/danger/format.ts
+++ b/util/danger/format.ts
@@ -1,0 +1,212 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2025 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+import { formatChurn, scopeDisplayOrder, type DangerResult, type ScopeReport, type ScopeTotals } from "./logic";
+
+const notice = "> 🚧 Danger.js checks for MrDocs are experimental; expect some rough edges while we tune the rules.";
+
+const scopeLabels: Record<string, string> = {
+    source: "Source",
+    tests: "Tests",
+    "golden-tests": "Golden Tests",
+    docs: "Docs",
+    ci: "CI / Roadmap",
+    build: "Build / Toolchain",
+    tooling: "Tooling",
+    "third-party": "Third-party",
+    other: "Other",
+};
+
+function labelForScope(scope: string): string {
+    return scopeLabels[scope] ?? scope;
+}
+
+/**
+ * Pad cells so pipes align in the raw Markdown.
+ */
+function renderAlignedTable(headers: string[], alignRight: boolean[], rows: string[][]): string {
+    const allRows = [headers, ...rows];
+    const widths = headers.map((_, col) => Math.max(...allRows.map((r) => r[col].length)));
+
+    const formatCell = (text: string, col: number, right: boolean): string => {
+        const width = widths[col];
+        return right ? text.padStart(width, " ") : text.padEnd(width, " ");
+    };
+
+    const renderRow = (cells: string[], isHeader = false): string =>
+        `| ${cells
+            .map((cell, idx) => formatCell(cell, idx, alignRight[idx]))
+            .join(" | ")} |`;
+
+    const headerRow = renderRow(headers, true);
+    const separatorCells = headers.map((_, idx) => {
+        const width = Math.max(3, widths[idx]);
+        if (alignRight[idx]) {
+            const dashes = Math.max(3, width) - 1;
+            return "-".repeat(dashes) + ":";
+        }
+        return "-".repeat(width);
+    });
+    const separatorRow = `| ${separatorCells.join(" | ")} |`;
+    const bodyRows = rows.map((r) => renderRow(r));
+
+    return [headerRow, separatorRow, ...bodyRows].join("\n");
+}
+
+/**
+ * Format counts so zeros stay quiet while non-zero values draw attention.
+ */
+function formatCount(value: number, bold: boolean = true): string {
+    if (value === 0) {
+        return "-";
+    }
+    return bold ? `**${value}**` : `${value}`;
+}
+
+/**
+ * Render warnings as GitHub admonition blocks grouped under a heading.
+ */
+function renderWarnings(warnings: string[]): string {
+    if (warnings.length === 0) {
+        return "";
+    }
+    const blocks = warnings.map((message) => ["> [!WARNING]", `> ${message}`].join("\n"));
+    return ["## ⚠️ Warnings", blocks.join("\n\n")].join("\n");
+}
+
+/**
+ * Render a single table combining change summary and per-scope breakdown.
+ */
+function renderChangeTable(summary: ScopeReport): string {
+    const headers = ["Scope", "Lines Δ", "Lines +", "Lines -", "Files Δ", "Files +", "Files ~", "Files ↔", "Files -"];
+    const alignRight = [false, true, true, true, true, true, true, true, true];
+
+    const sortedScopes = [...scopeDisplayOrder].sort((a, b) => {
+        const ta = summary.totals[a];
+        const tb = summary.totals[b];
+        const churnA = ta.additions + ta.deletions;
+        const churnB = tb.additions + tb.deletions;
+        if (churnA === churnB) {
+            return tb.files - ta.files;
+        }
+        return churnB - churnA;
+    });
+
+    const scopeHasChange = (totals: ScopeTotals): boolean => {
+        const churn = totals.additions + totals.deletions;
+        const fileDelta = totals.status.added + totals.status.modified + totals.status.renamed - totals.status.removed;
+        return churn !== 0 || fileDelta !== 0;
+    };
+
+    const scopeRows = sortedScopes.filter((scope) => scopeHasChange(summary.totals[scope])).map((scope) => {
+        const scoped: ScopeTotals = summary.totals[scope];
+        const s = scoped.status;
+        const fileDelta = s.added + s.modified + s.renamed - s.removed;
+        const churn = scoped.additions + scoped.deletions;
+        const fileDeltaBold = formatCount(fileDelta); // bold delta
+        const label = labelForScope(scope);
+        return [
+            label,
+            formatCount(churn),
+            formatCount(scoped.additions, false),
+            formatCount(scoped.deletions, false),
+            fileDeltaBold,
+            formatCount(s.added, false),
+            formatCount(s.modified, false),
+            formatCount(s.renamed, false),
+            formatCount(s.removed, false),
+        ];
+    });
+
+    const total = summary.overall;
+    const totalStatus = total.status;
+    const totalChurn = total.additions + total.deletions;
+    const totalFileDelta = totalStatus.added + totalStatus.modified + totalStatus.renamed - totalStatus.removed;
+    const totalRow = [
+        "**Total**",
+        formatCount(totalChurn),
+        formatCount(total.additions, false),
+        formatCount(total.deletions, false),
+        formatCount(totalFileDelta),
+        formatCount(totalStatus.added, false),
+        formatCount(totalStatus.modified, false),
+        formatCount(totalStatus.renamed, false),
+        formatCount(totalStatus.removed, false),
+    ];
+
+    const rows = scopeRows.length > 0 ? scopeRows.concat([totalRow]) : [["(no changes)", "-", "-", "-", "-", "-", "-", "-", "-"]];
+
+    const table = renderAlignedTable(headers, alignRight, rows);
+    const legend = "Legend: Files + (added), Files ~ (modified), Files ↔ (renamed), Files - (removed)";
+
+    return ["## 🧾 Changes by Scope", table, "", `> ${legend}`].join("\n");
+}
+
+/**
+ * Render highlight bullets, keeping the section compact.
+ */
+function renderHighlights(highlights: string[]): string {
+    if (highlights.length === 0) {
+        return "## ✨ Highlights\n- None noted.";
+    }
+    const decorated = highlights.map((note) => {
+        const lower = note.toLowerCase();
+        if (lower.includes("golden")) {
+            return `- 🧪 ${note}`;
+        }
+        if (lower.includes("test")) {
+            return `- 🧪 ${note}`;
+        }
+        if (lower.includes("doc")) {
+            return `- 📄 ${note}`;
+        }
+        if (lower.includes("source")) {
+            return `- 🛠️ ${note}`;
+        }
+        if (lower.includes("ci") || lower.includes("workflow") || lower.includes("pipeline")) {
+            return `- ⚙️ ${note}`;
+        }
+        if (lower.includes("build")) {
+            return `- 🏗️ ${note}`;
+        }
+        return `- ✨ ${note}`;
+    });
+    return ["## ✨ Highlights", ...decorated].join("\n");
+}
+
+/**
+ * Render a short "Top changes" summary from the highest-churn scopes.
+ */
+function renderTopChanges(summary: ScopeReport): string {
+    if (!summary.topFiles || summary.topFiles.length === 0) {
+        return "";
+    }
+
+    const bullets = summary.topFiles.map((file) => {
+        const scopeLabel = labelForScope(file.scope);
+        return `- ${file.filename} (${scopeLabel}): **${file.churn}** lines Δ (+${file.additions} / -${file.deletions})`;
+    });
+
+    return ["### 🔝 Top Files", ...bullets].join("\n");
+}
+
+/**
+ * Build the full Danger Markdown report as a single, structured comment.
+ */
+export function renderDangerReport(result: DangerResult): string {
+    const sections = [
+        notice,
+        renderWarnings(result.warnings),
+        renderHighlights(result.summary.highlights),
+        renderChangeTable(result.summary),
+        renderTopChanges(result.summary),
+    ].filter(Boolean);
+
+    return sections.join("\n\n");
+}


### PR DESCRIPTION
Parent-based include-symbol propagation walked up to the translation unit, causing global symbols to be extracted even when include-symbols were restricted to namespaces.

fix #1121