### PR TITLE
fix: prevent infinite recursion when extracting non-regular base class

### DIFF
--- a/src/lib/AST/ASTVisitor.cpp
+++ b/src/lib/AST/ASTVisitor.cpp
@@ -677,25 +677,18 @@ populate(
             // isn’t regular so we pick up their members/docs.
             if (config_->inheritBaseMembers != PublicSettings::BaseMemberInheritance::Never)
             {
-                if (auto const* baseDecl = BT->getAsCXXRecordDecl())
+                if (auto const* baseDecl = BT->getAsCXXRecordDecl();
+                    baseDecl && baseDecl->isCompleteDefinition())
                 {
-                    if (auto const* baseDef = baseDecl->getDefinition();
-                        baseDef)
+                    if (auto* baseInfo = find(baseDecl);
+                        !baseInfo
+                        || (baseInfo->Extraction != ExtractionMode::Regular
+                            && traversedRecordsForBaseClassExtraction_
+                                   .emplace(baseDecl)
+                                   .second))
                     {
-                        if (auto const* baseInfo = find(baseDef);
-                            baseInfo)
-                        {
-                            if (baseInfo->Extraction != ExtractionMode::Regular)
-                            {
-                                ScopeExitRestore s(mode_, TraversalMode::BaseClass);
-                                traverse(baseDef);
-                            }
-                        }
-                        else
-                        {
-                            ScopeExitRestore s(mode_, TraversalMode::BaseClass);
-                            traverse(baseDef);
-                        }
+                        ScopeExitRestore s(mode_, TraversalMode::BaseClass);
+                        traverse(baseDecl);
                     }
                 }
             }

--- a/src/lib/AST/ASTVisitor.hpp
+++ b/src/lib/AST/ASTVisitor.hpp
@@ -101,6 +101,17 @@ class ASTVisitor
      */
     UndocumentedSymbolSet undocumented_;
 
+    /*
+        A set of records already traversed for base class extraction
+
+        When traversing base classes in BaseClass traversal mode,
+        we need to avoid traversing the same record multiple times.
+        This set keeps track of records that have already been
+        traversed for base class extraction.
+    */
+    std::unordered_set<clang::CXXRecordDecl const*>
+        traversedRecordsForBaseClassExtraction_;
+
     /* Struct to hold pre-processed file information.
 
         This struct stores information about a file, including its full path,

--- a/test-files/golden-tests/symbols/record/forward-declared-member.adoc
+++ b/test-files/golden-tests/symbols/record/forward-declared-member.adoc
@@ -1,0 +1,50 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Namespaces
+
+[cols=1]
+|===
+| Name
+| link:#fmt[`fmt`] 
+|===
+
+[#fmt]
+== fmt
+
+=== Types
+
+[cols=1]
+|===
+| Name
+| link:#fmt-path[`path`] 
+|===
+
+[#fmt-path]
+== link:#fmt[fmt]::path
+
+=== Synopsis
+
+Declared in `&lt;forward&hyphen;declared&hyphen;member&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct path
+    : std::path
+----
+
+=== Base Classes
+
+[cols="1,4"]
+|===
+|Name|Description
+
+| `std::path`
+| 
+|===
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/symbols/record/forward-declared-member.cpp
+++ b/test-files/golden-tests/symbols/record/forward-declared-member.cpp
@@ -1,0 +1,9 @@
+namespace std {
+  class path {
+    struct _Cmpt;
+  };
+  struct path::_Cmpt : path {};
+} // namespace std
+namespace fmt {
+  struct path : std::path {};
+} // namespace fmt

--- a/test-files/golden-tests/symbols/record/forward-declared-member.html
+++ b/test-files/golden-tests/symbols/record/forward-declared-member.html
@@ -1,0 +1,89 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index">
+Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
+</h2>
+</div>
+<h2>
+Namespaces</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#fmt"><code>fmt</code></a> </td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="fmt">
+fmt<a class="mrdocs-anchor" href="#fmt" aria-label="Permalink">#</a>
+</h2>
+</div>
+<h2>
+Types</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#fmt-path"><code>path</code></a> </td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="fmt-path">
+fmt::path<a class="mrdocs-anchor" href="#fmt-path" aria-label="Permalink">#</a>
+</h2>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;forward-declared-member.cpp&gt;</code></div>
+<pre><code class="source-code cpp">struct path
+    : std::path</code></pre>
+</div>
+<div>
+<h2>
+Base Classes</h2>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr><td><code>std::path</code></td><td></td></tr>
+</tbody>
+</table>
+</div>
+
+
+</div>
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/symbols/record/forward-declared-member.xml
+++ b/test-files/golden-tests/symbols/record/forward-declared-member.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace id="//////////////////////////8=">
+  <namespace name="fmt" id="csn+vnio1BK5NeCdEBf/HpD6wmY=">
+    <struct name="path" id="5RffQbxkZ8sUj37sDwK63dA5ptA=">
+      <file short-path="forward-declared-member.cpp" source-path="forward-declared-member.cpp" line="8" class="def"/>
+      <base>
+        <type id="ufjqSG34/fsb1/dKE4dBgs8spHM=" name="std::path"/>
+      </base>
+    </struct>
+  </namespace>
+</namespace>
+</mrdocs>

--- a/test-files/golden-tests/symbols/record/forward-declared-member.yml
+++ b/test-files/golden-tests/symbols/record/forward-declared-member.yml
@@ -1,0 +1,2 @@
+include-symbols:
+  - 'fmt::**'


### PR DESCRIPTION
A non-regular base class can have a member class which is a base class of the former.

This fix prevents infinite recursion in this case.

Fixes https://github.com/cppalliance/mrdocs/issues/1131