### PR TITLE
fix(ci): unify redundant LLVM cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             clang: git build-essential pkg-config python3 curl unzip openjdk-11-jdk pkg-config libncurses-dev libxml2-utils libxml2-dev g++-14=14.2.0-4ubuntu2~24.04
             msvc: ''
           extra-values: |
-            use-libcxx: {{#if (and (ieq compiler 'clang') (ge major 19)) }}true{{else}}false{{/if}}
+            use-libcxx: {{#if (and (ieq compiler 'clang') msan) }}true{{else}}false{{/if}}
             libcxx-runtimes: libcxx{{#if (ne compiler 'msvc')}};libcxxabi{{/if}}
             llvm-runtimes: {{#if (ine use-libcxx 'true') }}{{{ libcxx-runtimes }}}{{/if}}
             llvm-hash: dc4cef81d47c7bc4a3c4d58fbacf8a6359683fae
@@ -82,8 +82,8 @@ jobs:
             llvm-build-preset-os: {{#if (ieq os 'windows') }}win{{else}}unix{{/if}}
             llvm-sanitizer: {{#if (eq compiler 'gcc')}}{{else if ubsan}}-UBSan{{else if asan}}-ASan{{else if msan}}-MSan{{/if}}
             llvm-build-preset: {{{ llvm-build-preset-prefix }}}-{{{ llvm-build-preset-os }}}
-            llvm-compiler-version: {{#if (or (contains version '*') (contains version '^'))}}{{else}}-{{{ version }}}{{/if}}
-            llvm-archive-basename: llvm-{{{ lowercase os }}}-{{{ compiler }}}{{{ llvm-compiler-version }}}-{{{ llvm-build-preset-prefix }}}{{{ llvm-sanitizer }}}-{{{ substr llvm-hash 0 7 }}}
+            llvm-os-key: {{#if container}}{{{ container }}}{{else}}{{{ runs-on }}}{{/if}}
+            llvm-archive-basename: {{#if msan}}llvm-{{{ substr llvm-hash 0 7 }}}-{{{ llvm-build-preset-prefix }}}-{{{ llvm-os-key }}}-{{{ compiler }}}-{{{ version }}}-MSan{{else}}llvm-{{{ substr llvm-hash 0 7 }}}-{{{ llvm-build-preset-prefix }}}-{{{ llvm-os-key }}}{{/if}}
             llvm-archive-extension: {{#if (ieq os 'windows') }}7z{{else}}tar.bz2{{/if}}
             llvm-archive-filename: {{{ llvm-archive-basename }}}.{{{ llvm-archive-extension }}}
             llvm-sanitizer-config: {{#if (and (ne compiler 'clang') (ne compiler 'apple-clang'))}}{{else if ubsan}}Undefined{{else if asan}}Address{{else if msan}}MemoryWithOrigins{{/if}}
@@ -322,12 +322,16 @@ jobs:
           fi
           echo "common-ldflags=$common_ldflags" >> $GITHUB_OUTPUT
 
+          llvm_cache_key="${{ matrix.llvm-archive-basename }}"
+          llvm_cache_key="${llvm_cache_key//:/-}"
+          echo "llvm-cache-key=$llvm_cache_key" >> $GITHUB_OUTPUT
+
       - name: Cached LLVM Binaries
         id: llvm-cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.rmatrix.outputs.llvm-path }}
-          key: ${{ matrix.llvm-archive-basename }}
+          key: ${{ steps.rmatrix.outputs.llvm-cache-key }}
 
       # Installs libc++ separately, using the LLVM standalone runtimes build.
       # The libc++ built here will be built using the host compiler, so this is
@@ -1229,6 +1233,10 @@ jobs:
           llvm_path=$third_party_dir/llvm
           echo "llvm-path=$llvm_path" >> $GITHUB_OUTPUT
 
+          llvm_cache_key="${{ matrix.llvm-archive-basename }}"
+          llvm_cache_key="${llvm_cache_key//:/-}"
+          echo "llvm-cache-key=$llvm_cache_key" >> $GITHUB_OUTPUT
+
       - name: Install packages
         uses: alandefreitas/cpp-actions/package-install@v1.9.1
         id: package-install
@@ -1240,4 +1248,4 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.rmatrix.outputs.llvm-path }}
-          key: ${{ matrix.llvm-archive-basename }}
+          key: ${{ steps.rmatrix.outputs.llvm-cache-key }}


### PR DESCRIPTION
Recent PR runs exceeded GitHub Actions cache limits, causing LLVM to be recompiled on every job of the workflow run. This led to hours-long turnaround times to verify changes. As a workaround, the fork workflow was being used to test the PR.

This commit simplifies the cache key structure to reduce redundant cache entries:

- Add `llvm-os-key` using container name or runs-on for OS versioning
- Make `llvm-archive-basename` conditional based on MSan only
- Transform cache keys to replace ":" with "-" for safety
- Only build instrumented libc++ for MSan where it's required

MSan requires all code, including libc++ to be instrumented to track initialization state correctly. ASan and UBSan can effectively catch errors without instrumenting dependencies, making custom libc++ builds low-ROI for these sanitizers.

Resulting cache key structure:
- MSan builds: include compiler, version, and sanitizer type (e.g., llvm-dc4cef8-release-ubuntu-24.04-clang-21-MSan)
- All other builds: omit compiler info since ABI is compatible (e.g., llvm-dc4cef8-release-ubuntu-24.04)

Non-sanitizer builds, ASan builds, and UBSan builds across gcc/clang versions on the same OS now share a single cache entry, as they produce ABI-compatible LLVM binaries.

Fixes #981