### PR TITLE
fix: remove duplicate ellipsis in parameter pack expansion

### DIFF
--- a/src/lib/AST/TypeBuilder.cpp
+++ b/src/lib/AST/TypeBuilder.cpp
@@ -113,7 +113,6 @@ buildDecltype(
     MRDOCS_ASSERT(Inner);
     *Inner = Polymorphic<Type>(std::in_place_type<DecltypeType>);
     (*Inner)->Constraints = this->Constraints;
-    (*Inner)->IsPackExpansion = pack;
 
     auto &I = (*Inner)->asDecltype();
     getASTVisitor().populate(I.Operand, T->getUnderlyingExpr());
@@ -134,7 +133,6 @@ buildAuto(
     MRDOCS_ASSERT(Inner);
     *Inner = Polymorphic<Type>(std::in_place_type<AutoType>);
     (*Inner)->Constraints = this->Constraints;
-    (*Inner)->IsPackExpansion = pack;
 
     auto &I = (*Inner)->asAuto();
     I.IsConst = quals & clang::Qualifiers::Const;
@@ -167,7 +165,6 @@ buildTerminal(
     MRDOCS_SYMBOL_TRACE(T, getASTVisitor().context_);
     MRDOCS_ASSERT(Inner);
     *Inner = Polymorphic<Type>(std::in_place_type<NamedType>);
-    (*Inner)->IsPackExpansion = pack;
     (*Inner)->Constraints = this->Constraints;
 
     auto &TI = (*Inner)->asNamed();
@@ -195,7 +192,6 @@ buildTerminal(
 {
     MRDOCS_ASSERT(Inner);
     *Inner = Polymorphic<Type>(std::in_place_type<NamedType>);
-    (*Inner)->IsPackExpansion = pack;
     (*Inner)->Constraints = this->Constraints;
 
     auto &I = (*Inner)->asNamed();
@@ -247,7 +243,6 @@ buildTerminal(
 
     MRDOCS_ASSERT(Inner);
     *Inner = Polymorphic<Type>(std::in_place_type<NamedType>);
-    (*Inner)->IsPackExpansion = pack;
     (*Inner)->Constraints = this->Constraints;
 
     auto &TI = (*Inner)->asNamed();

--- a/test-files/golden-tests/symbols/function/pack-expansion.adoc
+++ b/test-files/golden-tests/symbols/function/pack-expansion.adoc
@@ -1,0 +1,107 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Functions
+
+[cols=1]
+|===
+| Name
+| link:#by_const_ref[`by&lowbar;const&lowbar;ref`] 
+| link:#by_pointer[`by&lowbar;pointer`] 
+| link:#by_ref[`by&lowbar;ref`] 
+| link:#by_value[`by&lowbar;value`] 
+| link:#forward_all[`forward&lowbar;all`] 
+| link:#make_ptr[`make&lowbar;ptr`] 
+|===
+
+[#by_const_ref]
+== by&lowbar;const&lowbar;ref
+
+=== Synopsis
+
+Declared in `&lt;pack&hyphen;expansion&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;typename&period;&period;&period; Ts&gt;
+void
+by&lowbar;const&lowbar;ref(Ts const&&period;&period;&period; args);
+----
+
+[#by_pointer]
+== by&lowbar;pointer
+
+=== Synopsis
+
+Declared in `&lt;pack&hyphen;expansion&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;typename&period;&period;&period; Ts&gt;
+void
+by&lowbar;pointer(Ts*&period;&period;&period; args);
+----
+
+[#by_ref]
+== by&lowbar;ref
+
+=== Synopsis
+
+Declared in `&lt;pack&hyphen;expansion&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;typename&period;&period;&period; Ts&gt;
+void
+by&lowbar;ref(Ts&&period;&period;&period; args);
+----
+
+[#by_value]
+== by&lowbar;value
+
+=== Synopsis
+
+Declared in `&lt;pack&hyphen;expansion&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;typename&period;&period;&period; Ts&gt;
+void
+by&lowbar;value(Ts&period;&period;&period; args);
+----
+
+[#forward_all]
+== forward&lowbar;all
+
+=== Synopsis
+
+Declared in `&lt;pack&hyphen;expansion&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;class&period;&period;&period; Args&gt;
+void
+forward&lowbar;all(Args&&&period;&period;&period; args);
+----
+
+[#make_ptr]
+== make&lowbar;ptr
+
+=== Synopsis
+
+Declared in `&lt;pack&hyphen;expansion&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;
+    class T,
+    class&period;&period;&period; Args&gt;
+T*
+make&lowbar;ptr(Args&&&period;&period;&period; args);
+----
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/symbols/function/pack-expansion.cpp
+++ b/test-files/golden-tests/symbols/function/pack-expansion.cpp
@@ -1,0 +1,20 @@
+// Test parameter pack expansion in function parameters
+// Issue #1129: Args&&... args rendered as Args...&&... args
+
+template<class T, class... Args>
+T* make_ptr(Args&&... args);
+
+template<class... Args>
+void forward_all(Args&&... args);
+
+template<typename... Ts>
+void by_value(Ts... args);
+
+template<typename... Ts>
+void by_ref(Ts&... args);
+
+template<typename... Ts>
+void by_const_ref(const Ts&... args);
+
+template<typename... Ts>
+void by_pointer(Ts*... args);

--- a/test-files/golden-tests/symbols/function/pack-expansion.html
+++ b/test-files/golden-tests/symbols/function/pack-expansion.html
@@ -1,0 +1,139 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index">
+Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
+</h2>
+</div>
+<h2>
+Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#by_const_ref"><code>by_const_ref</code></a> </td></tr><tr>
+<td><a href="#by_pointer"><code>by_pointer</code></a> </td></tr><tr>
+<td><a href="#by_ref"><code>by_ref</code></a> </td></tr><tr>
+<td><a href="#by_value"><code>by_value</code></a> </td></tr><tr>
+<td><a href="#forward_all"><code>forward_all</code></a> </td></tr><tr>
+<td><a href="#make_ptr"><code>make_ptr</code></a> </td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="by_const_ref">
+by_const_ref<a class="mrdocs-anchor" href="#by_const_ref" aria-label="Permalink">#</a>
+</h2>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;pack-expansion.cpp&gt;</code></div>
+<pre><code class="source-code cpp">template&lt;typename... Ts&gt;
+void
+by_const_ref(Ts const&... args);</code></pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="by_pointer">
+by_pointer<a class="mrdocs-anchor" href="#by_pointer" aria-label="Permalink">#</a>
+</h2>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;pack-expansion.cpp&gt;</code></div>
+<pre><code class="source-code cpp">template&lt;typename... Ts&gt;
+void
+by_pointer(Ts*... args);</code></pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="by_ref">
+by_ref<a class="mrdocs-anchor" href="#by_ref" aria-label="Permalink">#</a>
+</h2>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;pack-expansion.cpp&gt;</code></div>
+<pre><code class="source-code cpp">template&lt;typename... Ts&gt;
+void
+by_ref(Ts&... args);</code></pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="by_value">
+by_value<a class="mrdocs-anchor" href="#by_value" aria-label="Permalink">#</a>
+</h2>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;pack-expansion.cpp&gt;</code></div>
+<pre><code class="source-code cpp">template&lt;typename... Ts&gt;
+void
+by_value(Ts... args);</code></pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="forward_all">
+forward_all<a class="mrdocs-anchor" href="#forward_all" aria-label="Permalink">#</a>
+</h2>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;pack-expansion.cpp&gt;</code></div>
+<pre><code class="source-code cpp">template&lt;class... Args&gt;
+void
+forward_all(Args&&... args);</code></pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="make_ptr">
+make_ptr<a class="mrdocs-anchor" href="#make_ptr" aria-label="Permalink">#</a>
+</h2>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;pack-expansion.cpp&gt;</code></div>
+<pre><code class="source-code cpp">template&lt;
+    class T,
+    class... Args&gt;
+T*
+make_ptr(Args&&... args);</code></pre>
+</div>
+</div>
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/symbols/function/pack-expansion.xml
+++ b/test-files/golden-tests/symbols/function/pack-expansion.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace id="//////////////////////////8=">
+  <template>
+    <tparam name="Ts" class="type"/>
+    <function name="by_const_ref" id="48I+DPPjc7oVgnOqvRHnCnFIMRA=">
+      <file short-path="pack-expansion.cpp" source-path="pack-expansion.cpp" line="16"/>
+      <param name="args">
+        <type class="lvalue-reference" is-pack="1">
+          <pointee-type name="Ts" cv-qualifiers="const"/>
+        </type>
+      </param>
+    </function>
+  </template>
+  <template>
+    <tparam name="Ts" class="type"/>
+    <function name="by_pointer" id="1uVKKR0qH3jqJg3vUUY+gN0nO6o=">
+      <file short-path="pack-expansion.cpp" source-path="pack-expansion.cpp" line="19"/>
+      <param name="args">
+        <type class="pointer" is-pack="1">
+          <pointee-type name="Ts"/>
+        </type>
+      </param>
+    </function>
+  </template>
+  <template>
+    <tparam name="Ts" class="type"/>
+    <function name="by_ref" id="/W/y4BHD5QC3h6HiQc2zHFs9XZM=">
+      <file short-path="pack-expansion.cpp" source-path="pack-expansion.cpp" line="13"/>
+      <param name="args">
+        <type class="lvalue-reference" is-pack="1">
+          <pointee-type name="Ts"/>
+        </type>
+      </param>
+    </function>
+  </template>
+  <template>
+    <tparam name="Ts" class="type"/>
+    <function name="by_value" id="2dPhCCrvmoBHZ2V3zGebTIf1GJw=">
+      <file short-path="pack-expansion.cpp" source-path="pack-expansion.cpp" line="10"/>
+      <param name="args">
+        <type is-pack="1" name="Ts"/>
+      </param>
+    </function>
+  </template>
+  <template>
+    <tparam name="Args" class="type"/>
+    <function name="forward_all" id="s1dIpJCzH1qM6C834Cm+Cj1mh9M=">
+      <file short-path="pack-expansion.cpp" source-path="pack-expansion.cpp" line="7"/>
+      <param name="args">
+        <type class="rvalue-reference" is-pack="1">
+          <pointee-type name="Args"/>
+        </type>
+      </param>
+    </function>
+  </template>
+  <template>
+    <tparam name="T" class="type"/>
+    <tparam name="Args" class="type"/>
+    <function name="make_ptr" id="8RneSjP7y4RoThh/UAa4tw8/cC0=">
+      <file short-path="pack-expansion.cpp" source-path="pack-expansion.cpp" line="4"/>
+      <return>
+        <type class="pointer">
+          <pointee-type name="T"/>
+        </type>
+      </return>
+      <param name="args">
+        <type class="rvalue-reference" is-pack="1">
+          <pointee-type name="Args"/>
+        </type>
+      </param>
+    </function>
+  </template>
+</namespace>
+</mrdocs>


### PR DESCRIPTION
Only set IsPackExpansion on the outermost Result type in TypeBuilder's terminal builder functions.