### PR TITLE
feat(lib): public API for generator registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1157,21 +1157,6 @@ jobs:
           path: demos-diff
           retention-days: 30
 
-      # Generate a static roadmap page from the git-tracked issue index.
-      #
-      # Output location:
-      # - Writes `build/website/roadmap/index.html`.
-      # - The generator may copy `styles.css` into `build/website/` if it's missing,
-      #   so the report can reference `../styles.css`.
-      # - Since the website is published from `build/website`, this becomes
-      #   `/roadmap/` on the deployed site.
-      - name: Generate Roadmap Report
-        if: env.PUBLISH_WEBSITE == 'true'
-        run: |
-          set -euvx
-          cd ${{ github.workspace }}
-          python -m util.roadmap report -o build/website/roadmap
-
       - name: Publish Website to GitHub Pages
         if: env.PUBLISH_WEBSITE == 'true'
         uses: peaceiris/actions-gh-pages@v3

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,61 @@
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Copyright (c) 2025 Alan de Freitas (alandefreitas@gmail.com)
+#
+# Official repository: https://github.com/cppalliance/mrdocs
+#
+
+# Codecov Configuration
+# https://docs.codecov.com/docs/codecovyml-reference
+#
+# Patch Coverage Threshold Rationale
+# ==================================
+#
+# We allow a small threshold for patch coverage NOT because reduced coverage
+# is acceptable, but because some lines are inherently uncoverable and
+# produce false positives:
+#
+#   - Class declarations (e.g., `class Foo : public Bar`)
+#   - Struct declarations (e.g., `struct MyTest`)
+#   - Access specifiers (`public:`, `private:`)
+#   - Pure virtual method declarations
+#   - Opening/closing braces on their own lines
+#
+# These are not executable code - they don't generate machine instructions -
+# yet coverage tools (gcov) report them as "uncovered lines."
+#
+# Preferred Solutions (in order)
+# ------------------------------
+#
+# 1st best: Configure gcov/lcov to exclude declarations from coverage
+#           tracking entirely, so they never appear as uncovered lines.
+#           This would eliminate false positives at the source.
+#           Status: Not currently available/configured.
+#
+# 2nd best: Use an absolute threshold (e.g., "allow up to 5 uncovered lines")
+#           rather than a percentage. This would be precise and predictable.
+#           Status: Codecov only supports percentage-based thresholds.
+#
+# 3rd best: Use a percentage-based threshold (what we implement below).
+#           The threshold is set small enough that any real logic
+#           (conditionals, loops, function bodies, error paths) that isn't
+#           covered will still trigger a failure. Only trivial declaration
+#           noise should pass through.
+#
+# With typical PR sizes, a 90% patch target achieves a similar effect to
+# allowing ~5 uncovered lines in a 50-line change.
+
+coverage:
+  status:
+    # Project-wide coverage should not decrease
+    project:
+      default:
+        threshold: 1%
+
+    # Patch coverage: only applies to new/modified lines in the PR
+    patch:
+      default:
+        target: 90%

--- a/include/mrdocs/Generator.hpp
+++ b/include/mrdocs/Generator.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (c) 2023 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2023 Alan de Freitas (alandefreitas@gmail.com)
 //
 // Official repository: https://github.com/cppalliance/mrdocs
 //
@@ -19,6 +20,7 @@
 #include <mrdocs/Config.hpp>
 #include <mrdocs/Corpus.hpp>
 #include <mrdocs/Support/Error.hpp>
+#include <memory>
 #include <ostream>
 #include <string>
 #include <string_view>
@@ -201,10 +203,49 @@ public:
     @param outputPath The specified output path, which can be a directory or file.
     @param extension The file extension to use for single-page output.
 */
+MRDOCS_DECL
 Expected<std::string>
 getSinglePageFullPath(
     std::string_view outputPath,
     std::string_view extension);
+
+/** Install a custom generator.
+
+    This function registers a generator with the global
+    generator registry, making it available for use.
+
+    Plugins can use this function to register custom
+    generators.
+
+    @par Thread Safety
+    This function is thread-safe and may be called
+    concurrently from multiple threads.
+
+    @return An error if a generator with the same id
+    already exists.
+
+    @param G The generator to install. Ownership is
+    transferred to the registry.
+*/
+MRDOCS_DECL
+Expected<void>
+installGenerator(std::unique_ptr<Generator> G);
+
+/** Find a generator by its id.
+
+    @par Thread Safety
+    This function is thread-safe and may be called
+    concurrently from multiple threads.
+
+    @return A pointer to the generator, or `nullptr`
+    if no generator with the given id exists.
+
+    @param id The symbolic name of the generator.
+    The name must be an exact match, including case.
+*/
+MRDOCS_DECL
+Generator const*
+findGenerator(std::string_view id) noexcept;
 
 } // mrdocs
 

--- a/share/mrdocs/addons/generator/html/layouts/wrapper.html.hbs
+++ b/share/mrdocs/addons/generator/html/layouts/wrapper.html.hbs
@@ -49,6 +49,11 @@
 {{#if page.hasDefaultStyles}}
 <script>
 (function(){
+    // Enable anchor visibility (hidden by default for graceful degradation)
+    document.querySelectorAll("a.mrdocs-anchor").forEach(function(el){
+        el.style.visibility = "visible";
+    });
+    // Copy permalink URL to clipboard on anchor click
     document.addEventListener("click", function(e){
         var anchor = e.target.closest && e.target.closest("a.mrdocs-anchor");
         if (!anchor) return;

--- a/share/mrdocs/addons/generator/html/partials/markup/h.html.hbs
+++ b/share/mrdocs/addons/generator/html/partials/markup/h.html.hbs
@@ -1,6 +1,10 @@
 <h{{or level 3}}{{#if class}} class="{{{class}}}"{{/if}}{{#if id}} id="{{{id}}}"{{/if}}>
 {{> @partial-block }}
 {{#if id}}
-<a class="mrdocs-anchor" href="#{{id}}" aria-label="Permalink">#</a>
+{{#if @root.config.multipage}}
+{{#unless @root.config.embedded}}
+<a class="mrdocs-anchor" style="visibility:hidden" href="#{{id}}" aria-label="Permalink">#</a>
+{{/unless}}
+{{/if}}
 {{/if}}
 </h{{or level 3}}>

--- a/src/lib/Support/Generator.cpp
+++ b/src/lib/Support/Generator.cpp
@@ -5,12 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (c) 2023 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2023 Alan de Freitas (alandefreitas@gmail.com)
 //
 // Official repository: https://github.com/cppalliance/mrdocs
 //
 
 #include <lib/AST/ExtractDocComment.hpp>
 #include <lib/Support/Chrono.hpp>
+#include <lib/Support/GeneratorRegistryImpl.hpp>
 #include <lib/Support/Path.hpp>
 #include <mrdocs/Generator.hpp>
 #include <mrdocs/Support/Error.hpp>
@@ -154,6 +156,18 @@ getSinglePageFullPath(
     path::append(fileName, "reference");
     path::replace_extension(fileName, ext);
     return fileName.str().str();
+}
+
+Expected<void>
+installGenerator(std::unique_ptr<Generator> G)
+{
+    return getGeneratorRegistryImpl().insert(std::move(G));
+}
+
+Generator const*
+findGenerator(std::string_view id) noexcept
+{
+    return getGeneratorRegistryImpl().find(id);
 }
 
 } // mrdocs

--- a/src/lib/Support/GeneratorRegistry.hpp
+++ b/src/lib/Support/GeneratorRegistry.hpp
@@ -4,12 +4,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (c) 2023 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2023 Alan de Freitas (alandefreitas@gmail.com)
 //
 // Official repository: https://github.com/cppalliance/mrdocs
 //
 
-#ifndef MRDOCS_API_GENERATORS_HPP
-#define MRDOCS_API_GENERATORS_HPP
+#ifndef MRDOCS_LIB_SUPPORT_GENERATORREGISTRY_HPP
+#define MRDOCS_LIB_SUPPORT_GENERATORREGISTRY_HPP
 
 #include <mrdocs/Platform.hpp>
 #include <mrdocs/Generator.hpp>
@@ -22,11 +23,11 @@ namespace mrdocs {
 /** A dynamic list of @ref Generator elements.
 */
 class MRDOCS_VISIBLE
-    Generators
+    GeneratorRegistry
 {
 protected:
     /// Construct an empty generator registry; only derived singletons create this.
-    Generators() noexcept = default;
+    GeneratorRegistry() noexcept = default;
 
 public:
     /// Pointer type for generator entries.
@@ -48,7 +49,7 @@ public:
     */
     MRDOCS_DECL
     virtual
-    ~Generators() noexcept;
+    ~GeneratorRegistry() noexcept;
 
     /** Return an iterator to the beginning.
     */
@@ -78,13 +79,7 @@ public:
         std::string_view name) const noexcept = 0;
 };
 
-/** Return a reference to the global Generators instance.
-*/
-MRDOCS_DECL
-Generators const&
-getGenerators() noexcept;
-
 } // mrdocs
 
 
-#endif // MRDOCS_API_GENERATORS_HPP
+#endif // MRDOCS_LIB_SUPPORT_GENERATORREGISTRY_HPP

--- a/src/lib/Support/GeneratorRegistryImpl.cpp
+++ b/src/lib/Support/GeneratorRegistryImpl.cpp
@@ -4,11 +4,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (c) 2023 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2023 Alan de Freitas (alandefreitas@gmail.com)
 //
 // Official repository: https://github.com/cppalliance/mrdocs
 //
 
-#include "GeneratorsImpl.hpp"
+#include "GeneratorRegistryImpl.hpp"
 #include <mrdocs/Support/Report.hpp>
 #include <llvm/ADT/STLExtras.h>
 
@@ -27,11 +28,11 @@ extern
 std::unique_ptr<Generator>
 makeHTMLGenerator();
 
-Generators::
-~Generators() noexcept = default;
+GeneratorRegistry::
+~GeneratorRegistry() noexcept = default;
 
 void
-GeneratorsImpl::
+GeneratorRegistryImpl::
 refresh_plist()
 {
     plist_.clear();
@@ -40,8 +41,8 @@ refresh_plist()
         plist_.push_back(g.get());
 }
 
-GeneratorsImpl::
-GeneratorsImpl()
+GeneratorRegistryImpl::
+GeneratorRegistryImpl()
 {
     insert(makeAdocGenerator());
     insert(makeXMLGenerator());
@@ -49,10 +50,11 @@ GeneratorsImpl()
 }
 
 Generator const*
-GeneratorsImpl::
+GeneratorRegistryImpl::
 find(
     std::string_view id) const noexcept
 {
+    std::lock_guard<std::mutex> lock(mutex_);
     for (auto const& li : list_)
     {
         if(li->id() == id)
@@ -64,11 +66,22 @@ find(
 }
 
 Expected<void>
-GeneratorsImpl::
+GeneratorRegistryImpl::
 insert(
     std::unique_ptr<Generator> G)
 {
-    MRDOCS_CHECK(find(G->id()) == nullptr, formatError("generator id=\"{}\" already exists", G->id()));
+    if (!G)
+    {
+        return Unexpected(formatError("cannot install null generator"));
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto const& li : list_)
+    {
+        if (li->id() == G->id())
+        {
+            return Unexpected(formatError("generator id=\"{}\" already exists", G->id()));
+        }
+    }
     list_.emplace_back(std::move(G));
     refresh_plist();
     return {};
@@ -76,18 +89,11 @@ insert(
 
 //------------------------------------------------
 
-GeneratorsImpl&
-getGeneratorsImpl() noexcept
+GeneratorRegistryImpl&
+getGeneratorRegistryImpl() noexcept
 {
-    static GeneratorsImpl impl;
+    static GeneratorRegistryImpl impl;
     return impl;
 }
 
-Generators const&
-getGenerators() noexcept
-{
-    return getGeneratorsImpl();
-}
-
 } // mrdocs
-

--- a/src/lib/Support/GeneratorRegistryImpl.hpp
+++ b/src/lib/Support/GeneratorRegistryImpl.hpp
@@ -4,28 +4,31 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (c) 2023 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2023 Alan de Freitas (alandefreitas@gmail.com)
 //
 // Official repository: https://github.com/cppalliance/mrdocs
 //
 
-#ifndef MRDOCS_LIB_SUPPORT_GENERATORSIMPL_HPP
-#define MRDOCS_LIB_SUPPORT_GENERATORSIMPL_HPP
+#ifndef MRDOCS_LIB_SUPPORT_GENERATORREGISTRYIMPL_HPP
+#define MRDOCS_LIB_SUPPORT_GENERATORREGISTRYIMPL_HPP
 
 #include <mrdocs/Platform.hpp>
-#include <mrdocs/Generators.hpp>
+#include <lib/Support/GeneratorRegistry.hpp>
 #include <mrdocs/Support/Error.hpp>
 #include <llvm/ADT/SmallVector.h>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 
 namespace mrdocs {
 
-/** Implementaiton of Generators.
+/** Implementation of GeneratorRegistry.
 */
 class MRDOCS_VISIBLE
-    GeneratorsImpl : public Generators
+    GeneratorRegistryImpl : public GeneratorRegistry
 {
+    mutable std::mutex mutex_;
     llvm::SmallVector<Generator const*, 3> plist_;
     llvm::SmallVector<
         std::unique_ptr<Generator>> list_;
@@ -33,7 +36,7 @@ class MRDOCS_VISIBLE
     void refresh_plist();
 
 public:
-    GeneratorsImpl();
+    GeneratorRegistryImpl();
 
     iterator
     begin() const noexcept override
@@ -57,10 +60,10 @@ public:
     insert(std::unique_ptr<Generator> G);
 };
 
-/** Return a reference to the global GeneratorsImpl instance.
+/** Return a reference to the global GeneratorRegistryImpl instance.
 */
-GeneratorsImpl&
-getGeneratorsImpl() noexcept;
+GeneratorRegistryImpl&
+getGeneratorRegistryImpl() noexcept;
 
 } // mrdocs
 

--- a/src/test/TestRunner.cpp
+++ b/src/test/TestRunner.cpp
@@ -23,7 +23,7 @@
 #include <lib/Support/Path.hpp>
 #include <lib/Support/Report.hpp>
 #include <mrdocs/Config.hpp>
-#include <mrdocs/Generators.hpp>
+#include <mrdocs/Generator.hpp>
 #include <mrdocs/Support/Error.hpp>
 #include <test_suite/diff.hpp>
 #include <llvm/Support/CommandLine.h>
@@ -37,7 +37,7 @@ namespace mrdocs {
 
 TestRunner::
 TestRunner(std::string_view generator)
-    : gen_(getGenerators().find(generator))
+    : gen_(findGenerator(generator))
 {
     MRDOCS_ASSERT(gen_ != nullptr);
 }

--- a/src/test/lib/Support/Generator.cpp
+++ b/src/test/lib/Support/Generator.cpp
@@ -1,0 +1,136 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2025 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#include <mrdocs/Generator.hpp>
+#include <test_suite/test_suite.hpp>
+#include <memory>
+
+
+namespace mrdocs {
+
+namespace {
+
+// Mock generator for testing installGenerator
+class MockGenerator : public Generator
+{
+    std::string id_;
+    std::string displayName_;
+    std::string fileExtension_;
+
+public:
+    MockGenerator(
+        std::string id,
+        std::string displayName,
+        std::string fileExtension)
+        : id_(std::move(id))
+        , displayName_(std::move(displayName))
+        , fileExtension_(std::move(fileExtension))
+    {
+    }
+
+    std::string_view
+    id() const noexcept override
+    {
+        return id_;
+    }
+
+    std::string_view
+    displayName() const noexcept override
+    {
+        return displayName_;
+    }
+
+    std::string_view
+    fileExtension() const noexcept override
+    {
+        return fileExtension_;
+    }
+
+    Expected<void>
+    buildOne(
+        std::ostream&,
+        Corpus const&) const override
+    {
+        return {};
+    }
+};
+
+} // anonymous namespace
+
+struct GeneratorTest
+{
+    void
+    testFindGenerator()
+    {
+        // Built-in generators should be found
+        BOOST_TEST(findGenerator("adoc") != nullptr);
+        BOOST_TEST(findGenerator("xml") != nullptr);
+        BOOST_TEST(findGenerator("html") != nullptr);
+
+        // Non-existent generator should return nullptr
+        BOOST_TEST(findGenerator("nonexistent") == nullptr);
+        BOOST_TEST(findGenerator("") == nullptr);
+    }
+
+    void
+    testInstallGenerator()
+    {
+        // Install a new generator
+        auto mockGen = std::make_unique<MockGenerator>(
+            "mock-test", "Mock Test Generator", "mock");
+
+        auto result = installGenerator(std::move(mockGen));
+        BOOST_TEST(result.has_value());
+
+        // Should now be findable
+        auto* found = findGenerator("mock-test");
+        BOOST_TEST(found != nullptr);
+        if (found)
+        {
+            BOOST_TEST(found->id() == "mock-test");
+            BOOST_TEST(found->displayName() == "Mock Test Generator");
+            BOOST_TEST(found->fileExtension() == "mock");
+        }
+    }
+
+    void
+    testInstallDuplicateGenerator()
+    {
+        // Try to install a generator with an existing id
+        auto duplicateGen = std::make_unique<MockGenerator>(
+            "adoc", "Duplicate Adoc", "adoc");
+
+        auto result = installGenerator(std::move(duplicateGen));
+        BOOST_TEST(!result.has_value());
+    }
+
+    void
+    testInstallNullGenerator()
+    {
+        // Try to install a null generator
+        auto result = installGenerator(std::unique_ptr<Generator>{});
+        BOOST_TEST(!result.has_value());
+    }
+
+    void
+    run()
+    {
+        testFindGenerator();
+        testInstallGenerator();
+        testInstallDuplicateGenerator();
+        testInstallNullGenerator();
+    }
+};
+
+TEST_SUITE(
+    GeneratorTest,
+    "clang.mrdocs.Generator");
+
+} // mrdocs

--- a/src/tool/GenerateAction.cpp
+++ b/src/tool/GenerateAction.cpp
@@ -16,7 +16,7 @@
 #include <lib/CorpusImpl.hpp>
 #include <lib/MrDocsCompilationDatabase.hpp>
 #include <lib/Support/Path.hpp>
-#include <mrdocs/Generators.hpp>
+#include <mrdocs/Generator.hpp>
 #include <mrdocs/Support/Path.hpp>
 #include <mrdocs/Support/Report.hpp>
 #include <mrdocs/Support/ThreadPool.hpp>
@@ -53,7 +53,7 @@ DoGenerateAction(
     auto& settings = config->settings();
     MRDOCS_TRY(
         Generator const& generator,
-        getGenerators().find(to_string(settings.generator)),
+        findGenerator(to_string(settings.generator)),
         formatError(
             "the Generator \"{}\" was not found",
             to_string(config->settings().generator)));

--- a/test-files/golden-tests/config/auto-brief/auto-brief.html
+++ b/test-files/golden-tests/config/auto-brief/auto-brief.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -60,8 +59,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="copyBriefFromCopyBrief">
-copyBriefFromCopyBrief<a class="mrdocs-anchor" href="#copyBriefFromCopyBrief" aria-label="Permalink">#</a>
-</h2>
+copyBriefFromCopyBrief</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -78,8 +76,7 @@ copyBriefFromCopyBrief();</code></pre>
 <div>
 <div>
 <h2 id="copyBriefFromExplicitBrief">
-copyBriefFromExplicitBrief<a class="mrdocs-anchor" href="#copyBriefFromExplicitBrief" aria-label="Permalink">#</a>
-</h2>
+copyBriefFromExplicitBrief</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -96,8 +93,7 @@ copyBriefFromExplicitBrief();</code></pre>
 <div>
 <div>
 <h2 id="copyBriefFromFirstSentenceAsBrief">
-copyBriefFromFirstSentenceAsBrief<a class="mrdocs-anchor" href="#copyBriefFromFirstSentenceAsBrief" aria-label="Permalink">#</a>
-</h2>
+copyBriefFromFirstSentenceAsBrief</h2>
 <div>
 <p>This is the brief.</p>
 </div>
@@ -114,8 +110,7 @@ copyBriefFromFirstSentenceAsBrief();</code></pre>
 <div>
 <div>
 <h2 id="copyBriefFromFirstValid">
-copyBriefFromFirstValid<a class="mrdocs-anchor" href="#copyBriefFromFirstValid" aria-label="Permalink">#</a>
-</h2>
+copyBriefFromFirstValid</h2>
 <div>
 <p>This function has documentation but no brief.</p>
 </div>
@@ -132,8 +127,7 @@ copyBriefFromFirstValid();</code></pre>
 <div>
 <div>
 <h2 id="copyDetailsFromCopyBrief">
-copyDetailsFromCopyBrief<a class="mrdocs-anchor" href="#copyDetailsFromCopyBrief" aria-label="Permalink">#</a>
-</h2>
+copyDetailsFromCopyBrief</h2>
 <div>
 <p>Details will be copied</p>
 </div>
@@ -150,8 +144,7 @@ copyDetailsFromCopyBrief();</code></pre>
 <div>
 <div>
 <h2 id="copyDetailsFromDocNoBrief">
-copyDetailsFromDocNoBrief<a class="mrdocs-anchor" href="#copyDetailsFromDocNoBrief" aria-label="Permalink">#</a>
-</h2>
+copyDetailsFromDocNoBrief</h2>
 <div>
 <p>Custom brief</p>
 </div>
@@ -168,8 +161,7 @@ copyDetailsFromDocNoBrief();</code></pre>
 <div>
 <div>
 <h2 id="copyDetailsFromExplicitBrief">
-copyDetailsFromExplicitBrief<a class="mrdocs-anchor" href="#copyDetailsFromExplicitBrief" aria-label="Permalink">#</a>
-</h2>
+copyDetailsFromExplicitBrief</h2>
 </div>
 <div>
 <h3>
@@ -188,8 +180,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="copyDetailsFromFirstSentenceAsBrief">
-copyDetailsFromFirstSentenceAsBrief<a class="mrdocs-anchor" href="#copyDetailsFromFirstSentenceAsBrief" aria-label="Permalink">#</a>
-</h2>
+copyDetailsFromFirstSentenceAsBrief</h2>
 </div>
 <div>
 <h3>
@@ -208,8 +199,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="copyDetailsFromNoDoc">
-copyDetailsFromNoDoc<a class="mrdocs-anchor" href="#copyDetailsFromNoDoc" aria-label="Permalink">#</a>
-</h2>
+copyDetailsFromNoDoc</h2>
 <div>
 <p>Custom brief</p>
 </div>
@@ -226,8 +216,7 @@ copyDetailsFromNoDoc();</code></pre>
 <div>
 <div>
 <h2 id="copyDocFromCopyBrief">
-copyDocFromCopyBrief<a class="mrdocs-anchor" href="#copyDocFromCopyBrief" aria-label="Permalink">#</a>
-</h2>
+copyDocFromCopyBrief</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -249,8 +238,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="copyDocFromExplicitBrief">
-copyDocFromExplicitBrief<a class="mrdocs-anchor" href="#copyDocFromExplicitBrief" aria-label="Permalink">#</a>
-</h2>
+copyDocFromExplicitBrief</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -272,8 +260,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="copyDocFromFirstSentenceAsBrief">
-copyDocFromFirstSentenceAsBrief<a class="mrdocs-anchor" href="#copyDocFromFirstSentenceAsBrief" aria-label="Permalink">#</a>
-</h2>
+copyDocFromFirstSentenceAsBrief</h2>
 <div>
 <p>This is the brief.</p>
 </div>
@@ -295,8 +282,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="docNoBriefFunction">
-docNoBriefFunction<a class="mrdocs-anchor" href="#docNoBriefFunction" aria-label="Permalink">#</a>
-</h2>
+docNoBriefFunction</h2>
 <div>
 <p>This function has documentation but no brief.</p>
 </div>
@@ -313,8 +299,7 @@ docNoBriefFunction();</code></pre>
 <div>
 <div>
 <h2 id="explicitBriefFunction">
-explicitBriefFunction<a class="mrdocs-anchor" href="#explicitBriefFunction" aria-label="Permalink">#</a>
-</h2>
+explicitBriefFunction</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -336,8 +321,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="explicitBriefFunction2">
-explicitBriefFunction2<a class="mrdocs-anchor" href="#explicitBriefFunction2" aria-label="Permalink">#</a>
-</h2>
+explicitBriefFunction2</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -359,8 +343,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="failCircularReferenceCopyFunction">
-failCircularReferenceCopyFunction<a class="mrdocs-anchor" href="#failCircularReferenceCopyFunction" aria-label="Permalink">#</a>
-</h2>
+failCircularReferenceCopyFunction</h2>
 </div>
 <div>
 <h3>
@@ -374,8 +357,7 @@ failCircularReferenceCopyFunction();</code></pre>
 <div>
 <div>
 <h2 id="failCircularSourceFunctionA">
-failCircularSourceFunctionA<a class="mrdocs-anchor" href="#failCircularSourceFunctionA" aria-label="Permalink">#</a>
-</h2>
+failCircularSourceFunctionA</h2>
 </div>
 <div>
 <h3>
@@ -389,8 +371,7 @@ failCircularSourceFunctionA();</code></pre>
 <div>
 <div>
 <h2 id="failCircularSourceFunctionB">
-failCircularSourceFunctionB<a class="mrdocs-anchor" href="#failCircularSourceFunctionB" aria-label="Permalink">#</a>
-</h2>
+failCircularSourceFunctionB</h2>
 </div>
 <div>
 <h3>
@@ -404,8 +385,7 @@ failCircularSourceFunctionB();</code></pre>
 <div>
 <div>
 <h2 id="failCopyBriefFromDocNoBrief">
-failCopyBriefFromDocNoBrief<a class="mrdocs-anchor" href="#failCopyBriefFromDocNoBrief" aria-label="Permalink">#</a>
-</h2>
+failCopyBriefFromDocNoBrief</h2>
 <div>
 <p>This function has documentation but no brief.</p>
 </div>
@@ -422,8 +402,7 @@ failCopyBriefFromDocNoBrief();</code></pre>
 <div>
 <div>
 <h2 id="failCopyBriefFromInvalidReference">
-failCopyBriefFromInvalidReference<a class="mrdocs-anchor" href="#failCopyBriefFromInvalidReference" aria-label="Permalink">#</a>
-</h2>
+failCopyBriefFromInvalidReference</h2>
 </div>
 <div>
 <h3>
@@ -437,8 +416,7 @@ failCopyBriefFromInvalidReference();</code></pre>
 <div>
 <div>
 <h2 id="failCopyBriefFromNoDoc">
-failCopyBriefFromNoDoc<a class="mrdocs-anchor" href="#failCopyBriefFromNoDoc" aria-label="Permalink">#</a>
-</h2>
+failCopyBriefFromNoDoc</h2>
 </div>
 <div>
 <h3>
@@ -452,8 +430,7 @@ failCopyBriefFromNoDoc();</code></pre>
 <div>
 <div>
 <h2 id="failCopyDetailsFromInvalidReference">
-failCopyDetailsFromInvalidReference<a class="mrdocs-anchor" href="#failCopyDetailsFromInvalidReference" aria-label="Permalink">#</a>
-</h2>
+failCopyDetailsFromInvalidReference</h2>
 </div>
 <div>
 <h3>
@@ -467,8 +444,7 @@ failCopyDetailsFromInvalidReference();</code></pre>
 <div>
 <div>
 <h2 id="failCopyDocFromDocNoBrief">
-failCopyDocFromDocNoBrief<a class="mrdocs-anchor" href="#failCopyDocFromDocNoBrief" aria-label="Permalink">#</a>
-</h2>
+failCopyDocFromDocNoBrief</h2>
 <div>
 <p>This function has documentation but no brief.</p>
 </div>
@@ -485,8 +461,7 @@ failCopyDocFromDocNoBrief();</code></pre>
 <div>
 <div>
 <h2 id="failCopyDocFromInvalidReference">
-failCopyDocFromInvalidReference<a class="mrdocs-anchor" href="#failCopyDocFromInvalidReference" aria-label="Permalink">#</a>
-</h2>
+failCopyDocFromInvalidReference</h2>
 </div>
 <div>
 <h3>
@@ -500,8 +475,7 @@ failCopyDocFromInvalidReference();</code></pre>
 <div>
 <div>
 <h2 id="failCopyDocFromNoDoc">
-failCopyDocFromNoDoc<a class="mrdocs-anchor" href="#failCopyDocFromNoDoc" aria-label="Permalink">#</a>
-</h2>
+failCopyDocFromNoDoc</h2>
 </div>
 <div>
 <h3>
@@ -515,8 +489,7 @@ failCopyDocFromNoDoc();</code></pre>
 <div>
 <div>
 <h2 id="failInvalidReferenceCopyFunctions">
-failInvalidReferenceCopyFunctions<a class="mrdocs-anchor" href="#failInvalidReferenceCopyFunctions" aria-label="Permalink">#</a>
-</h2>
+failInvalidReferenceCopyFunctions</h2>
 </div>
 <div>
 <h3>
@@ -530,8 +503,7 @@ failInvalidReferenceCopyFunctions();</code></pre>
 <div>
 <div>
 <h2 id="firstSentenceAsBriefFunction">
-firstSentenceAsBriefFunction<a class="mrdocs-anchor" href="#firstSentenceAsBriefFunction" aria-label="Permalink">#</a>
-</h2>
+firstSentenceAsBriefFunction</h2>
 <div>
 <p>This is the brief.</p>
 </div>
@@ -553,8 +525,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="noDocFunction">
-noDocFunction<a class="mrdocs-anchor" href="#noDocFunction" aria-label="Permalink">#</a>
-</h2>
+noDocFunction</h2>
 </div>
 <div>
 <h3>
@@ -568,8 +539,7 @@ noDocFunction();</code></pre>
 <div>
 <div>
 <h2 id="recursiveReferenceCopyFunction">
-recursiveReferenceCopyFunction<a class="mrdocs-anchor" href="#recursiveReferenceCopyFunction" aria-label="Permalink">#</a>
-</h2>
+recursiveReferenceCopyFunction</h2>
 <div>
 <p>Final recursive brief</p>
 </div>
@@ -586,8 +556,7 @@ recursiveReferenceCopyFunction();</code></pre>
 <div>
 <div>
 <h2 id="recursiveSourceFunctionA">
-recursiveSourceFunctionA<a class="mrdocs-anchor" href="#recursiveSourceFunctionA" aria-label="Permalink">#</a>
-</h2>
+recursiveSourceFunctionA</h2>
 <div>
 <p>Final recursive brief</p>
 </div>
@@ -604,8 +573,7 @@ recursiveSourceFunctionA();</code></pre>
 <div>
 <div>
 <h2 id="recursiveSourceFunctionB">
-recursiveSourceFunctionB<a class="mrdocs-anchor" href="#recursiveSourceFunctionB" aria-label="Permalink">#</a>
-</h2>
+recursiveSourceFunctionB</h2>
 <div>
 <p>Final recursive brief</p>
 </div>

--- a/test-files/golden-tests/config/auto-brief/no-auto-brief.html
+++ b/test-files/golden-tests/config/auto-brief/no-auto-brief.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -60,8 +59,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="copyBriefFromCopyBrief">
-copyBriefFromCopyBrief<a class="mrdocs-anchor" href="#copyBriefFromCopyBrief" aria-label="Permalink">#</a>
-</h2>
+copyBriefFromCopyBrief</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -78,8 +76,7 @@ copyBriefFromCopyBrief();</code></pre>
 <div>
 <div>
 <h2 id="copyBriefFromExplicitBrief">
-copyBriefFromExplicitBrief<a class="mrdocs-anchor" href="#copyBriefFromExplicitBrief" aria-label="Permalink">#</a>
-</h2>
+copyBriefFromExplicitBrief</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -96,8 +93,7 @@ copyBriefFromExplicitBrief();</code></pre>
 <div>
 <div>
 <h2 id="copyBriefFromFirstSentenceAsBrief">
-copyBriefFromFirstSentenceAsBrief<a class="mrdocs-anchor" href="#copyBriefFromFirstSentenceAsBrief" aria-label="Permalink">#</a>
-</h2>
+copyBriefFromFirstSentenceAsBrief</h2>
 </div>
 <div>
 <h3>
@@ -111,8 +107,7 @@ copyBriefFromFirstSentenceAsBrief();</code></pre>
 <div>
 <div>
 <h2 id="copyBriefFromFirstValid">
-copyBriefFromFirstValid<a class="mrdocs-anchor" href="#copyBriefFromFirstValid" aria-label="Permalink">#</a>
-</h2>
+copyBriefFromFirstValid</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -129,8 +124,7 @@ copyBriefFromFirstValid();</code></pre>
 <div>
 <div>
 <h2 id="copyDetailsFromCopyBrief">
-copyDetailsFromCopyBrief<a class="mrdocs-anchor" href="#copyDetailsFromCopyBrief" aria-label="Permalink">#</a>
-</h2>
+copyDetailsFromCopyBrief</h2>
 <div>
 <p>Details will be copied</p>
 </div>
@@ -147,8 +141,7 @@ copyDetailsFromCopyBrief();</code></pre>
 <div>
 <div>
 <h2 id="copyDetailsFromDocNoBrief">
-copyDetailsFromDocNoBrief<a class="mrdocs-anchor" href="#copyDetailsFromDocNoBrief" aria-label="Permalink">#</a>
-</h2>
+copyDetailsFromDocNoBrief</h2>
 <div>
 <p>Custom brief</p>
 </div>
@@ -165,8 +158,7 @@ copyDetailsFromDocNoBrief();</code></pre>
 <div>
 <div>
 <h2 id="copyDetailsFromExplicitBrief">
-copyDetailsFromExplicitBrief<a class="mrdocs-anchor" href="#copyDetailsFromExplicitBrief" aria-label="Permalink">#</a>
-</h2>
+copyDetailsFromExplicitBrief</h2>
 </div>
 <div>
 <h3>
@@ -185,8 +177,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="copyDetailsFromFirstSentenceAsBrief">
-copyDetailsFromFirstSentenceAsBrief<a class="mrdocs-anchor" href="#copyDetailsFromFirstSentenceAsBrief" aria-label="Permalink">#</a>
-</h2>
+copyDetailsFromFirstSentenceAsBrief</h2>
 </div>
 <div>
 <h3>
@@ -206,8 +197,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="copyDetailsFromNoDoc">
-copyDetailsFromNoDoc<a class="mrdocs-anchor" href="#copyDetailsFromNoDoc" aria-label="Permalink">#</a>
-</h2>
+copyDetailsFromNoDoc</h2>
 <div>
 <p>Custom brief</p>
 </div>
@@ -224,8 +214,7 @@ copyDetailsFromNoDoc();</code></pre>
 <div>
 <div>
 <h2 id="copyDocFromCopyBrief">
-copyDocFromCopyBrief<a class="mrdocs-anchor" href="#copyDocFromCopyBrief" aria-label="Permalink">#</a>
-</h2>
+copyDocFromCopyBrief</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -247,8 +236,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="copyDocFromExplicitBrief">
-copyDocFromExplicitBrief<a class="mrdocs-anchor" href="#copyDocFromExplicitBrief" aria-label="Permalink">#</a>
-</h2>
+copyDocFromExplicitBrief</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -270,8 +258,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="copyDocFromFirstSentenceAsBrief">
-copyDocFromFirstSentenceAsBrief<a class="mrdocs-anchor" href="#copyDocFromFirstSentenceAsBrief" aria-label="Permalink">#</a>
-</h2>
+copyDocFromFirstSentenceAsBrief</h2>
 </div>
 <div>
 <h3>
@@ -291,8 +278,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="docNoBriefFunction">
-docNoBriefFunction<a class="mrdocs-anchor" href="#docNoBriefFunction" aria-label="Permalink">#</a>
-</h2>
+docNoBriefFunction</h2>
 </div>
 <div>
 <h3>
@@ -311,8 +297,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="explicitBriefFunction">
-explicitBriefFunction<a class="mrdocs-anchor" href="#explicitBriefFunction" aria-label="Permalink">#</a>
-</h2>
+explicitBriefFunction</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -334,8 +319,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="explicitBriefFunction2">
-explicitBriefFunction2<a class="mrdocs-anchor" href="#explicitBriefFunction2" aria-label="Permalink">#</a>
-</h2>
+explicitBriefFunction2</h2>
 <div>
 <p>This is the explicit brief.</p>
 </div>
@@ -357,8 +341,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="failCircularReferenceCopyFunction">
-failCircularReferenceCopyFunction<a class="mrdocs-anchor" href="#failCircularReferenceCopyFunction" aria-label="Permalink">#</a>
-</h2>
+failCircularReferenceCopyFunction</h2>
 </div>
 <div>
 <h3>
@@ -372,8 +355,7 @@ failCircularReferenceCopyFunction();</code></pre>
 <div>
 <div>
 <h2 id="failCircularSourceFunctionA">
-failCircularSourceFunctionA<a class="mrdocs-anchor" href="#failCircularSourceFunctionA" aria-label="Permalink">#</a>
-</h2>
+failCircularSourceFunctionA</h2>
 </div>
 <div>
 <h3>
@@ -387,8 +369,7 @@ failCircularSourceFunctionA();</code></pre>
 <div>
 <div>
 <h2 id="failCircularSourceFunctionB">
-failCircularSourceFunctionB<a class="mrdocs-anchor" href="#failCircularSourceFunctionB" aria-label="Permalink">#</a>
-</h2>
+failCircularSourceFunctionB</h2>
 </div>
 <div>
 <h3>
@@ -402,8 +383,7 @@ failCircularSourceFunctionB();</code></pre>
 <div>
 <div>
 <h2 id="failCopyBriefFromDocNoBrief">
-failCopyBriefFromDocNoBrief<a class="mrdocs-anchor" href="#failCopyBriefFromDocNoBrief" aria-label="Permalink">#</a>
-</h2>
+failCopyBriefFromDocNoBrief</h2>
 </div>
 <div>
 <h3>
@@ -417,8 +397,7 @@ failCopyBriefFromDocNoBrief();</code></pre>
 <div>
 <div>
 <h2 id="failCopyBriefFromInvalidReference">
-failCopyBriefFromInvalidReference<a class="mrdocs-anchor" href="#failCopyBriefFromInvalidReference" aria-label="Permalink">#</a>
-</h2>
+failCopyBriefFromInvalidReference</h2>
 </div>
 <div>
 <h3>
@@ -432,8 +411,7 @@ failCopyBriefFromInvalidReference();</code></pre>
 <div>
 <div>
 <h2 id="failCopyBriefFromNoDoc">
-failCopyBriefFromNoDoc<a class="mrdocs-anchor" href="#failCopyBriefFromNoDoc" aria-label="Permalink">#</a>
-</h2>
+failCopyBriefFromNoDoc</h2>
 </div>
 <div>
 <h3>
@@ -447,8 +425,7 @@ failCopyBriefFromNoDoc();</code></pre>
 <div>
 <div>
 <h2 id="failCopyDetailsFromInvalidReference">
-failCopyDetailsFromInvalidReference<a class="mrdocs-anchor" href="#failCopyDetailsFromInvalidReference" aria-label="Permalink">#</a>
-</h2>
+failCopyDetailsFromInvalidReference</h2>
 </div>
 <div>
 <h3>
@@ -462,8 +439,7 @@ failCopyDetailsFromInvalidReference();</code></pre>
 <div>
 <div>
 <h2 id="failCopyDocFromDocNoBrief">
-failCopyDocFromDocNoBrief<a class="mrdocs-anchor" href="#failCopyDocFromDocNoBrief" aria-label="Permalink">#</a>
-</h2>
+failCopyDocFromDocNoBrief</h2>
 </div>
 <div>
 <h3>
@@ -482,8 +458,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="failCopyDocFromInvalidReference">
-failCopyDocFromInvalidReference<a class="mrdocs-anchor" href="#failCopyDocFromInvalidReference" aria-label="Permalink">#</a>
-</h2>
+failCopyDocFromInvalidReference</h2>
 </div>
 <div>
 <h3>
@@ -497,8 +472,7 @@ failCopyDocFromInvalidReference();</code></pre>
 <div>
 <div>
 <h2 id="failCopyDocFromNoDoc">
-failCopyDocFromNoDoc<a class="mrdocs-anchor" href="#failCopyDocFromNoDoc" aria-label="Permalink">#</a>
-</h2>
+failCopyDocFromNoDoc</h2>
 </div>
 <div>
 <h3>
@@ -512,8 +486,7 @@ failCopyDocFromNoDoc();</code></pre>
 <div>
 <div>
 <h2 id="failInvalidReferenceCopyFunctions">
-failInvalidReferenceCopyFunctions<a class="mrdocs-anchor" href="#failInvalidReferenceCopyFunctions" aria-label="Permalink">#</a>
-</h2>
+failInvalidReferenceCopyFunctions</h2>
 </div>
 <div>
 <h3>
@@ -527,8 +500,7 @@ failInvalidReferenceCopyFunctions();</code></pre>
 <div>
 <div>
 <h2 id="firstSentenceAsBriefFunction">
-firstSentenceAsBriefFunction<a class="mrdocs-anchor" href="#firstSentenceAsBriefFunction" aria-label="Permalink">#</a>
-</h2>
+firstSentenceAsBriefFunction</h2>
 </div>
 <div>
 <h3>
@@ -548,8 +520,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="noDocFunction">
-noDocFunction<a class="mrdocs-anchor" href="#noDocFunction" aria-label="Permalink">#</a>
-</h2>
+noDocFunction</h2>
 </div>
 <div>
 <h3>
@@ -563,8 +534,7 @@ noDocFunction();</code></pre>
 <div>
 <div>
 <h2 id="recursiveReferenceCopyFunction">
-recursiveReferenceCopyFunction<a class="mrdocs-anchor" href="#recursiveReferenceCopyFunction" aria-label="Permalink">#</a>
-</h2>
+recursiveReferenceCopyFunction</h2>
 <div>
 <p>Final recursive brief</p>
 </div>
@@ -581,8 +551,7 @@ recursiveReferenceCopyFunction();</code></pre>
 <div>
 <div>
 <h2 id="recursiveSourceFunctionA">
-recursiveSourceFunctionA<a class="mrdocs-anchor" href="#recursiveSourceFunctionA" aria-label="Permalink">#</a>
-</h2>
+recursiveSourceFunctionA</h2>
 <div>
 <p>Final recursive brief</p>
 </div>
@@ -599,8 +568,7 @@ recursiveSourceFunctionA();</code></pre>
 <div>
 <div>
 <h2 id="recursiveSourceFunctionB">
-recursiveSourceFunctionB<a class="mrdocs-anchor" href="#recursiveSourceFunctionB" aria-label="Permalink">#</a>
-</h2>
+recursiveSourceFunctionB</h2>
 <div>
 <p>Final recursive brief</p>
 </div>

--- a/test-files/golden-tests/config/auto-function-metadata/brief-from-function-class.html
+++ b/test-files/golden-tests/config/auto-function-metadata/brief-from-function-class.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A helper tag</p>
 </div>
@@ -50,8 +48,7 @@ Declared in <code>&lt;brief-from-function-class.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X">
-X<a class="mrdocs-anchor" href="#X" aria-label="Permalink">#</a>
-</h2>
+X</h2>
 <div>
 <p>Test class</p>
 </div>
@@ -86,8 +83,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="X-2constructor-08">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-08" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -129,8 +125,7 @@ Declared in <code>&lt;brief-from-function-class.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-2constructor-0e8">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-0e8" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -147,8 +142,7 @@ X() = default;</code></pre>
 <div>
 <div>
 <h2 id="X-2constructor-0e0">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-0e0" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Copy constructor</p>
 </div>
@@ -183,8 +177,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2constructor-06">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-06" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Move constructor</p>
 </div>
@@ -219,8 +212,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2constructor-07">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-07" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Construct from <code>int</code></p>
 </div>
@@ -254,8 +246,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2constructor-0b">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-0b" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Construct from <code>A</code></p>
 </div>
@@ -289,8 +280,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2constructor-00">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-00" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Construct from <code>A</code></p>
 </div>
@@ -324,8 +314,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2destructor">
-X::~X<a class="mrdocs-anchor" href="#X-2destructor" aria-label="Permalink">#</a>
-</h2>
+X::~X</h2>
 <div>
 <p>Destructor</p>
 </div>
@@ -341,8 +330,7 @@ Declared in <code>&lt;brief-from-function-class.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-2conversion-00">
-X::operator A<a class="mrdocs-anchor" href="#X-2conversion-00" aria-label="Permalink">#</a>
-</h2>
+X::operator A</h2>
 <div>
 <p>Conversion to <code>A</code></p>
 </div>
@@ -363,8 +351,7 @@ A helper tag
 <div>
 <div>
 <h2 id="X-2conversion-0b">
-X::operator int<a class="mrdocs-anchor" href="#X-2conversion-0b" aria-label="Permalink">#</a>
-</h2>
+X::operator int</h2>
 <div>
 <p>Conversion to <code>int</code></p>
 </div>

--- a/test-files/golden-tests/config/auto-function-metadata/brief-from-operator.html
+++ b/test-files/golden-tests/config/auto-function-metadata/brief-from-operator.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -46,8 +45,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A helper tag</p>
 </div>
@@ -65,8 +63,7 @@ Declared in <code>&lt;brief-from-operator.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X">
-X<a class="mrdocs-anchor" href="#X" aria-label="Permalink">#</a>
-</h2>
+X</h2>
 <div>
 <p>Test class</p>
 </div>
@@ -99,8 +96,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="X-operator_assign-0a">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-0a" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Assignment operators</p>
 </div>
@@ -130,8 +126,7 @@ Declared in <code>&lt;brief-from-operator.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-operator_assign-06">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-06" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Copy assignment operator</p>
 </div>
@@ -171,8 +166,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_assign-0e">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-0e" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Move assignment operator</p>
 </div>
@@ -212,8 +206,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_assign-0d">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-0d" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Assignment operator</p>
 </div>
@@ -253,8 +246,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_plus_eq">
-X::operator+&#x3D;<a class="mrdocs-anchor" href="#X-operator_plus_eq" aria-label="Permalink">#</a>
-</h2>
+X::operator+&#x3D;</h2>
 <div>
 <p>Addition assignment operator</p>
 </div>
@@ -294,8 +286,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="ostream">
-ostream<a class="mrdocs-anchor" href="#ostream" aria-label="Permalink">#</a>
-</h2>
+ostream</h2>
 <div>
 <p>A dumb ostream class</p>
 </div>
@@ -328,8 +319,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="operator_lshift">
-operator&lt;&lt;<a class="mrdocs-anchor" href="#operator_lshift" aria-label="Permalink">#</a>
-</h2>
+operator&lt;&lt;</h2>
 <div>
 <p>Stream insertion operator</p>
 </div>

--- a/test-files/golden-tests/config/auto-function-metadata/param-from-function-class.html
+++ b/test-files/golden-tests/config/auto-function-metadata/param-from-function-class.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A helper tag</p>
 </div>
@@ -50,8 +48,7 @@ Declared in <code>&lt;param-from-function-class.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X">
-X<a class="mrdocs-anchor" href="#X" aria-label="Permalink">#</a>
-</h2>
+X</h2>
 <div>
 <p>Test class</p>
 </div>
@@ -84,8 +81,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="X-2constructor-08">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-08" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -120,8 +116,7 @@ Declared in <code>&lt;param-from-function-class.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-2constructor-0e">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-0e" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Copy constructor</p>
 </div>
@@ -155,8 +150,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2constructor-06">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-06" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Move constructor</p>
 </div>
@@ -190,8 +184,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2constructor-07">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-07" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Construct from <code>int</code></p>
 </div>
@@ -225,8 +218,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2constructor-0b">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-0b" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Construct from <code>A</code></p>
 </div>
@@ -260,8 +252,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2constructor-00">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-00" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Construct from <code>A</code></p>
 </div>
@@ -295,8 +286,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_assign-0a">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-0a" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Assignment operators</p>
 </div>
@@ -336,8 +326,7 @@ Declared in <code>&lt;param-from-function-class.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-operator_assign-06">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-06" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Copy assignment operator</p>
 </div>
@@ -377,8 +366,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_assign-0e">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-0e" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Move assignment operator</p>
 </div>
@@ -418,8 +406,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_assign-07f">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-07f" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Assignment operator</p>
 </div>
@@ -459,8 +446,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_assign-0d">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-0d" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Assignment operator</p>
 </div>
@@ -500,8 +486,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_assign-07e">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-07e" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Assignment operator</p>
 </div>

--- a/test-files/golden-tests/config/auto-function-metadata/param-from-operator.html
+++ b/test-files/golden-tests/config/auto-function-metadata/param-from-operator.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -48,8 +47,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A helper tag</p>
 </div>
@@ -67,8 +65,7 @@ Declared in <code>&lt;param-from-operator.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X">
-X<a class="mrdocs-anchor" href="#X" aria-label="Permalink">#</a>
-</h2>
+X</h2>
 <div>
 <p>Test class</p>
 </div>
@@ -116,8 +113,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="X-operator_plus">
-X::operator+<a class="mrdocs-anchor" href="#X-operator_plus" aria-label="Permalink">#</a>
-</h2>
+X::operator+</h2>
 <div>
 <p>Addition operator</p>
 </div>
@@ -157,8 +153,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="ostream">
-ostream<a class="mrdocs-anchor" href="#ostream" aria-label="Permalink">#</a>
-</h2>
+ostream</h2>
 <div>
 <p>A dumb ostream class</p>
 </div>
@@ -191,8 +186,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="operator_minus">
-operator-<a class="mrdocs-anchor" href="#operator_minus" aria-label="Permalink">#</a>
-</h2>
+operator-</h2>
 <div>
 <p>Subtraction operator</p>
 </div>
@@ -238,8 +232,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_lshift">
-operator&lt;&lt;<a class="mrdocs-anchor" href="#operator_lshift" aria-label="Permalink">#</a>
-</h2>
+operator&lt;&lt;</h2>
 <div>
 <p>Stream insertion operator</p>
 </div>
@@ -285,8 +278,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_not">
-operator!<a class="mrdocs-anchor" href="#operator_not" aria-label="Permalink">#</a>
-</h2>
+operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>

--- a/test-files/golden-tests/config/auto-function-metadata/returns-from-brief.html
+++ b/test-files/golden-tests/config/auto-function-metadata/returns-from-brief.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="X">
-X<a class="mrdocs-anchor" href="#X" aria-label="Permalink">#</a>
-</h2>
+X</h2>
 <div>
 <p>Test class</p>
 </div>
@@ -65,8 +63,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="X-empty">
-X::empty<a class="mrdocs-anchor" href="#X-empty" aria-label="Permalink">#</a>
-</h2>
+X::empty</h2>
 <div>
 <p>Determines whether the range is empty.</p>
 </div>
@@ -88,8 +85,7 @@ whether the range is empty.
 <div>
 <div>
 <h2 id="X-front">
-X::front<a class="mrdocs-anchor" href="#X-front" aria-label="Permalink">#</a>
-</h2>
+X::front</h2>
 <div>
 <p>Returns the first element of the range.</p>
 </div>
@@ -111,8 +107,7 @@ the first element of the range.
 <div>
 <div>
 <h2 id="X-size">
-X::size<a class="mrdocs-anchor" href="#X-size" aria-label="Permalink">#</a>
-</h2>
+X::size</h2>
 <div>
 <p>Get the range size.</p>
 </div>

--- a/test-files/golden-tests/config/auto-function-metadata/returns-from-return-brief.html
+++ b/test-files/golden-tests/config/auto-function-metadata/returns-from-return-brief.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -44,8 +43,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="R">
-R<a class="mrdocs-anchor" href="#R" aria-label="Permalink">#</a>
-</h2>
+R</h2>
 <div>
 <p>The return type of the function</p>
 </div>
@@ -78,8 +76,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="getR">
-getR<a class="mrdocs-anchor" href="#getR" aria-label="Permalink">#</a>
-</h2>
+getR</h2>
 <div>
 <p>Test function</p>
 </div>

--- a/test-files/golden-tests/config/auto-function-metadata/returns-from-special.html
+++ b/test-files/golden-tests/config/auto-function-metadata/returns-from-special.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -55,8 +54,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A helper class</p>
 </div>
@@ -96,8 +94,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="Undoc">
-Undoc<a class="mrdocs-anchor" href="#Undoc" aria-label="Permalink">#</a>
-</h2>
+Undoc</h2>
 </div>
 <div>
 <h3>
@@ -112,8 +109,7 @@ Declared in <code>&lt;returns-from-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X">
-X<a class="mrdocs-anchor" href="#X" aria-label="Permalink">#</a>
-</h2>
+X</h2>
 <div>
 <p>Test class</p>
 </div>
@@ -157,8 +153,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="X-operator_assign-0a">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-0a" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Assignment operators</p>
 </div>
@@ -183,8 +178,7 @@ Declared in <code>&lt;returns-from-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-operator_assign-0d">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-0d" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Assignment operator</p>
 </div>
@@ -224,8 +218,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_assign-07">
-X::operator&#x3D;<a class="mrdocs-anchor" href="#X-operator_assign-07" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;</h2>
 <div>
 <p>Assignment operator</p>
 </div>
@@ -265,8 +258,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_plus">
-X::operator+<a class="mrdocs-anchor" href="#X-operator_plus" aria-label="Permalink">#</a>
-</h2>
+X::operator+</h2>
 <div>
 <p>Addition operator</p>
 </div>
@@ -306,8 +298,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_ptr">
-X::operator-&gt;<a class="mrdocs-anchor" href="#X-operator_ptr" aria-label="Permalink">#</a>
-</h2>
+X::operator-&gt;</h2>
 <div>
 <p>Member access operator</p>
 </div>
@@ -329,8 +320,7 @@ Pointer to the current object
 <div>
 <div>
 <h2 id="X-2conversion-00">
-X::operator A<a class="mrdocs-anchor" href="#X-2conversion-00" aria-label="Permalink">#</a>
-</h2>
+X::operator A</h2>
 <div>
 <p>Conversion to <code>A</code></p>
 </div>
@@ -351,8 +341,7 @@ A helper class
 <div>
 <div>
 <h2 id="X-2conversion-03">
-X::operator Undoc<a class="mrdocs-anchor" href="#X-2conversion-03" aria-label="Permalink">#</a>
-</h2>
+X::operator Undoc</h2>
 <div>
 <p>Conversion to <code>Undoc</code></p>
 </div>
@@ -373,8 +362,7 @@ The object converted to <code>Undoc</code>
 <div>
 <div>
 <h2 id="X-operator_not">
-X::operator!<a class="mrdocs-anchor" href="#X-operator_not" aria-label="Permalink">#</a>
-</h2>
+X::operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -396,8 +384,7 @@ Return Value</h3>
 <div>
 <div>
 <h2 id="X-operator_eq">
-X::operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#X-operator_eq" aria-label="Permalink">#</a>
-</h2>
+X::operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -437,8 +424,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_not_eq">
-X::operator!&#x3D;<a class="mrdocs-anchor" href="#X-operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+X::operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>
@@ -478,8 +464,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_lt">
-X::operator&lt;<a class="mrdocs-anchor" href="#X-operator_lt" aria-label="Permalink">#</a>
-</h2>
+X::operator&lt;</h2>
 <div>
 <p>Less-than operator</p>
 </div>
@@ -519,8 +504,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_le">
-X::operator&lt;&#x3D;<a class="mrdocs-anchor" href="#X-operator_le" aria-label="Permalink">#</a>
-</h2>
+X::operator&lt;&#x3D;</h2>
 <div>
 <p>Less-than-or-equal operator</p>
 </div>
@@ -560,8 +544,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_gt">
-X::operator&gt;<a class="mrdocs-anchor" href="#X-operator_gt" aria-label="Permalink">#</a>
-</h2>
+X::operator&gt;</h2>
 <div>
 <p>Greater-than operator</p>
 </div>
@@ -601,8 +584,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_ge">
-X::operator&gt;&#x3D;<a class="mrdocs-anchor" href="#X-operator_ge" aria-label="Permalink">#</a>
-</h2>
+X::operator&gt;&#x3D;</h2>
 <div>
 <p>Greater-than-or-equal operator</p>
 </div>
@@ -642,8 +624,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-operator_3way">
-X::operator&lt;&#x3D;&gt;<a class="mrdocs-anchor" href="#X-operator_3way" aria-label="Permalink">#</a>
-</h2>
+X::operator&lt;&#x3D;&gt;</h2>
 <div>
 <p>Three-way comparison operator</p>
 </div>
@@ -683,8 +664,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="ostream">
-ostream<a class="mrdocs-anchor" href="#ostream" aria-label="Permalink">#</a>
-</h2>
+ostream</h2>
 <div>
 <p>A fake output stream</p>
 </div>
@@ -717,8 +697,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="operator_lshift">
-operator&lt;&lt;<a class="mrdocs-anchor" href="#operator_lshift" aria-label="Permalink">#</a>
-</h2>
+operator&lt;&lt;</h2>
 <div>
 <p>Stream insertion operator</p>
 </div>
@@ -764,8 +743,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_not">
-operator!<a class="mrdocs-anchor" href="#operator_not" aria-label="Permalink">#</a>
-</h2>
+operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -805,8 +783,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_eq">
-operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#operator_eq" aria-label="Permalink">#</a>
-</h2>
+operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -852,8 +829,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_not_eq">
-operator!&#x3D;<a class="mrdocs-anchor" href="#operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>
@@ -899,8 +875,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_lt">
-operator&lt;<a class="mrdocs-anchor" href="#operator_lt" aria-label="Permalink">#</a>
-</h2>
+operator&lt;</h2>
 <div>
 <p>Less-than operator</p>
 </div>
@@ -946,8 +921,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_le">
-operator&lt;&#x3D;<a class="mrdocs-anchor" href="#operator_le" aria-label="Permalink">#</a>
-</h2>
+operator&lt;&#x3D;</h2>
 <div>
 <p>Less-than-or-equal operator</p>
 </div>
@@ -993,8 +967,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_gt">
-operator&gt;<a class="mrdocs-anchor" href="#operator_gt" aria-label="Permalink">#</a>
-</h2>
+operator&gt;</h2>
 <div>
 <p>Greater-than operator</p>
 </div>
@@ -1040,8 +1013,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_ge">
-operator&gt;&#x3D;<a class="mrdocs-anchor" href="#operator_ge" aria-label="Permalink">#</a>
-</h2>
+operator&gt;&#x3D;</h2>
 <div>
 <p>Greater-than-or-equal operator</p>
 </div>
@@ -1087,8 +1059,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_3way">
-operator&lt;&#x3D;&gt;<a class="mrdocs-anchor" href="#operator_3way" aria-label="Permalink">#</a>
-</h2>
+operator&lt;&#x3D;&gt;</h2>
 <div>
 <p>Three-way comparison operator</p>
 </div>

--- a/test-files/golden-tests/config/auto-relates/auto-relates.html
+++ b/test-files/golden-tests/config/auto-relates/auto-relates.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -49,8 +48,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A class with non-member functions</p>
 </div>
@@ -88,8 +86,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -106,8 +103,7 @@ f1(<a href="#A">A</a>);</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -124,8 +120,7 @@ f2(<a href="#A">A</a>&);</code></pre>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -142,8 +137,7 @@ f3(<a href="#A">A</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="f4">
-f4<a class="mrdocs-anchor" href="#f4" aria-label="Permalink">#</a>
-</h2>
+f4</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -160,8 +154,7 @@ f4(<a href="#A">A</a>*);</code></pre>
 <div>
 <div>
 <h2 id="f5">
-f5<a class="mrdocs-anchor" href="#f5" aria-label="Permalink">#</a>
-</h2>
+f5</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -178,8 +171,7 @@ f5(<a href="#A">A</a> const*);</code></pre>
 <div>
 <div>
 <h2 id="f6">
-f6<a class="mrdocs-anchor" href="#f6" aria-label="Permalink">#</a>
-</h2>
+f6</h2>
 <div>
 <p>A non-member function of A</p>
 </div>

--- a/test-files/golden-tests/config/auto-relates/derived.html
+++ b/test-files/golden-tests/config/auto-relates/derived.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -52,8 +51,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A concrete implementation for ABase</p>
 </div>
@@ -106,8 +104,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="ABase">
-ABase<a class="mrdocs-anchor" href="#ABase" aria-label="Permalink">#</a>
-</h2>
+ABase</h2>
 <div>
 <p>A base class for non-member functions</p>
 </div>
@@ -163,8 +160,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="AView">
-AView<a class="mrdocs-anchor" href="#AView" aria-label="Permalink">#</a>
-</h2>
+AView</h2>
 <div>
 <p>A view of A</p>
 </div>
@@ -233,8 +229,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="AView2">
-AView2<a class="mrdocs-anchor" href="#AView2" aria-label="Permalink">#</a>
-</h2>
+AView2</h2>
 <div>
 <p>Another view of A</p>
 </div>
@@ -292,8 +287,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>A non-member function of ABase</p>
 </div>
@@ -310,8 +304,7 @@ f1(<a href="#ABase">ABase</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 <div>
 <p>A non-member function of ABase</p>
 </div>
@@ -328,8 +321,7 @@ f2(<a href="#ABase">ABase</a>&);</code></pre>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 <div>
 <p>A non-member function of ABase</p>
 </div>
@@ -346,8 +338,7 @@ f3(<a href="#ABase">ABase</a> const*);</code></pre>
 <div>
 <div>
 <h2 id="f4">
-f4<a class="mrdocs-anchor" href="#f4" aria-label="Permalink">#</a>
-</h2>
+f4</h2>
 <div>
 <p>A non-member function of ABase</p>
 </div>
@@ -364,8 +355,7 @@ f4(<a href="#ABase">ABase</a>*);</code></pre>
 <div>
 <div>
 <h2 id="f5">
-f5<a class="mrdocs-anchor" href="#f5" aria-label="Permalink">#</a>
-</h2>
+f5</h2>
 <div>
 <p>A non-member function of ABase</p>
 </div>
@@ -382,8 +372,7 @@ f5(<a href="#ABase">ABase</a> const*);</code></pre>
 <div>
 <div>
 <h2 id="n">
-n<a class="mrdocs-anchor" href="#n" aria-label="Permalink">#</a>
-</h2>
+n</h2>
 <div>
 <p>A non-member function of ABase only</p>
 </div>

--- a/test-files/golden-tests/config/auto-relates/enum.html
+++ b/test-files/golden-tests/config/auto-relates/enum.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -61,8 +60,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="Result">
-Result<a class="mrdocs-anchor" href="#Result" aria-label="Permalink">#</a>
-</h2>
+Result</h2>
 <div>
 <p>Helper result class</p>
 </div>
@@ -96,8 +94,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="SmallVector">
-SmallVector<a class="mrdocs-anchor" href="#SmallVector" aria-label="Permalink">#</a>
-</h2>
+SmallVector</h2>
 <div>
 <p>Helper result class</p>
 </div>
@@ -133,8 +130,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="E">
-E<a class="mrdocs-anchor" href="#E" aria-label="Permalink">#</a>
-</h2>
+E</h2>
 <div>
 <p>An enum with non-member functions</p>
 </div>
@@ -167,8 +163,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="makeE">
-makeE<a class="mrdocs-anchor" href="#makeE" aria-label="Permalink">#</a>
-</h2>
+makeE</h2>
 <div>
 <p>Function that returns A</p>
 </div>
@@ -190,8 +185,7 @@ An instance of A
 <div>
 <div>
 <h2 id="makeEs">
-makeEs<a class="mrdocs-anchor" href="#makeEs" aria-label="Permalink">#</a>
-</h2>
+makeEs</h2>
 <div>
 <p>Function that returns template on A</p>
 </div>
@@ -213,8 +207,7 @@ A vector of As
 <div>
 <div>
 <h2 id="tryMakeE">
-tryMakeE<a class="mrdocs-anchor" href="#tryMakeE" aria-label="Permalink">#</a>
-</h2>
+tryMakeE</h2>
 <div>
 <p>Function that returns template on A</p>
 </div>

--- a/test-files/golden-tests/config/auto-relates/no-auto-relates.html
+++ b/test-files/golden-tests/config/auto-relates/no-auto-relates.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -49,8 +48,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A class with non-member functions</p>
 </div>
@@ -68,8 +66,7 @@ Declared in <code>&lt;no-auto-relates.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -86,8 +83,7 @@ f1(<a href="#A">A</a>);</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -104,8 +100,7 @@ f2(<a href="#A">A</a>&);</code></pre>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -122,8 +117,7 @@ f3(<a href="#A">A</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="f4">
-f4<a class="mrdocs-anchor" href="#f4" aria-label="Permalink">#</a>
-</h2>
+f4</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -140,8 +134,7 @@ f4(<a href="#A">A</a>*);</code></pre>
 <div>
 <div>
 <h2 id="f5">
-f5<a class="mrdocs-anchor" href="#f5" aria-label="Permalink">#</a>
-</h2>
+f5</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -158,8 +151,7 @@ f5(<a href="#A">A</a> const*);</code></pre>
 <div>
 <div>
 <h2 id="f6">
-f6<a class="mrdocs-anchor" href="#f6" aria-label="Permalink">#</a>
-</h2>
+f6</h2>
 <div>
 <p>A non-member function of A</p>
 </div>

--- a/test-files/golden-tests/config/auto-relates/qualified.html
+++ b/test-files/golden-tests/config/auto-relates/qualified.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -60,8 +59,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N">
-N<a class="mrdocs-anchor" href="#N" aria-label="Permalink">#</a>
-</h2>
+N</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -110,8 +108,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N-M">
-N::M<a class="mrdocs-anchor" href="#N-M" aria-label="Permalink">#</a>
-</h2>
+N::M</h2>
 </div>
 <h2>
 Functions</h2>
@@ -131,8 +128,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N-M-f4">
-N::M::f4<a class="mrdocs-anchor" href="#N-M-f4" aria-label="Permalink">#</a>
-</h2>
+N::M::f4</h2>
 <div>
 <p>A non-member function of ::N::B</p>
 </div>
@@ -149,8 +145,7 @@ f4(<a href="#N-B">N::B</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="N-B">
-N::B<a class="mrdocs-anchor" href="#N-B" aria-label="Permalink">#</a>
-</h2>
+N::B</h2>
 <div>
 <p>A nested class with non-member functions</p>
 </div>
@@ -186,8 +181,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="N-f2">
-N::f2<a class="mrdocs-anchor" href="#N-f2" aria-label="Permalink">#</a>
-</h2>
+N::f2</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -204,8 +198,7 @@ f2(<a href="#A">A</a>&);</code></pre>
 <div>
 <div>
 <h2 id="N-f3">
-N::f3<a class="mrdocs-anchor" href="#N-f3" aria-label="Permalink">#</a>
-</h2>
+N::f3</h2>
 <div>
 <p>A non-member function of B</p>
 </div>
@@ -222,8 +215,7 @@ f3(<a href="#N-B">N::B</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="O">
-O<a class="mrdocs-anchor" href="#O" aria-label="Permalink">#</a>
-</h2>
+O</h2>
 </div>
 <h2>
 Functions</h2>
@@ -243,8 +235,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="O-f6">
-O::f6<a class="mrdocs-anchor" href="#O-f6" aria-label="Permalink">#</a>
-</h2>
+O::f6</h2>
 <div>
 <p>A non-member function of ::N::B</p>
 </div>
@@ -261,8 +252,7 @@ f6(<a href="#N-B">N::B</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A class with non-member functions</p>
 </div>
@@ -296,8 +286,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>A non-member function of A</p>
 </div>
@@ -314,8 +303,7 @@ f1(<a href="#A">A</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="f5">
-f5<a class="mrdocs-anchor" href="#f5" aria-label="Permalink">#</a>
-</h2>
+f5</h2>
 <div>
 <p>A non-member function of ::N::B</p>
 </div>

--- a/test-files/golden-tests/config/auto-relates/remove-friend.html
+++ b/test-files/golden-tests/config/auto-relates/remove-friend.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A record with non-member functions</p>
 </div>
@@ -98,8 +96,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="to_string">
-to_string<a class="mrdocs-anchor" href="#to_string" aria-label="Permalink">#</a>
-</h2>
+to_string</h2>
 <div>
 <p>Non-member function of A</p>
 </div>
@@ -139,8 +136,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_eq">
-operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#operator_eq" aria-label="Permalink">#</a>
-</h2>
+operator&#x3D;&#x3D;</h2>
 <div>
 <p>Friend function not listed as non-member</p>
 </div>

--- a/test-files/golden-tests/config/auto-relates/return-type.html
+++ b/test-files/golden-tests/config/auto-relates/return-type.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -48,8 +47,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A class with non-member functions</p>
 </div>
@@ -84,8 +82,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="Result">
-Result<a class="mrdocs-anchor" href="#Result" aria-label="Permalink">#</a>
-</h2>
+Result</h2>
 <div>
 <p>Helper result class</p>
 </div>
@@ -119,8 +116,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="SmallVector">
-SmallVector<a class="mrdocs-anchor" href="#SmallVector" aria-label="Permalink">#</a>
-</h2>
+SmallVector</h2>
 <div>
 <p>Helper result class</p>
 </div>
@@ -156,8 +152,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="makeA">
-makeA<a class="mrdocs-anchor" href="#makeA" aria-label="Permalink">#</a>
-</h2>
+makeA</h2>
 <div>
 <p>Function that returns A</p>
 </div>
@@ -179,8 +174,7 @@ An instance of A
 <div>
 <div>
 <h2 id="makeAs">
-makeAs<a class="mrdocs-anchor" href="#makeAs" aria-label="Permalink">#</a>
-</h2>
+makeAs</h2>
 <div>
 <p>Function that returns template on A</p>
 </div>
@@ -202,8 +196,7 @@ A vector of As
 <div>
 <div>
 <h2 id="tryMakeA">
-tryMakeA<a class="mrdocs-anchor" href="#tryMakeA" aria-label="Permalink">#</a>
-</h2>
+tryMakeA</h2>
 <div>
 <p>Function that returns template on A</p>
 </div>

--- a/test-files/golden-tests/config/extract-all/no-extract-all.html
+++ b/test-files/golden-tests/config/extract-all/no-extract-all.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -31,8 +30,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="docFunction">
-docFunction<a class="mrdocs-anchor" href="#docFunction" aria-label="Permalink">#</a>
-</h2>
+docFunction</h2>
 <div>
 <p>Documented function</p>
 </div>
@@ -49,8 +47,7 @@ docFunction();</code></pre>
 <div>
 <div>
 <h2 id="sometimesDocFunction">
-sometimesDocFunction<a class="mrdocs-anchor" href="#sometimesDocFunction" aria-label="Permalink">#</a>
-</h2>
+sometimesDocFunction</h2>
 <div>
 <p>Sometimes documented function</p>
 </div>

--- a/test-files/golden-tests/config/extract-empty-namespaces/no-extract-empty-namespaces.html
+++ b/test-files/golden-tests/config/extract-empty-namespaces/no-extract-empty-namespaces.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -67,8 +66,7 @@ Using Namespace Directives</h2>
 <div>
 <div>
 <h2 id="documented_ns">
-documented_ns<a class="mrdocs-anchor" href="#documented_ns" aria-label="Permalink">#</a>
-</h2>
+documented_ns</h2>
 <div>
 <p>Namespace documentation</p>
 </div>
@@ -77,8 +75,7 @@ documented_ns<a class="mrdocs-anchor" href="#documented_ns" aria-label="Permalin
 <div>
 <div>
 <h2 id="mixed_ns">
-mixed_ns<a class="mrdocs-anchor" href="#mixed_ns" aria-label="Permalink">#</a>
-</h2>
+mixed_ns</h2>
 <div>
 <p>Should decay to see-below</p>
 </div>
@@ -101,8 +98,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="mixed_ns-SeeBelowStructA">
-mixed_ns::SeeBelowStructA<a class="mrdocs-anchor" href="#mixed_ns-SeeBelowStructA" aria-label="Permalink">#</a>
-</h2>
+mixed_ns::SeeBelowStructA</h2>
 </div>
 <div>
 <h3>
@@ -117,8 +113,7 @@ Declared in <code>&lt;no-extract-empty-namespaces.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="mixed_regular_ns">
-mixed_regular_ns<a class="mrdocs-anchor" href="#mixed_regular_ns" aria-label="Permalink">#</a>
-</h2>
+mixed_regular_ns</h2>
 <div>
 <p>Should decay to regular</p>
 </div>
@@ -142,8 +137,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="mixed_regular_ns-RegularStructA">
-mixed_regular_ns::RegularStructA<a class="mrdocs-anchor" href="#mixed_regular_ns-RegularStructA" aria-label="Permalink">#</a>
-</h2>
+mixed_regular_ns::RegularStructA</h2>
 </div>
 <div>
 <h3>
@@ -158,8 +152,7 @@ Declared in <code>&lt;no-extract-empty-namespaces.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="mixed_regular_ns-SeeBelowStructB">
-mixed_regular_ns::SeeBelowStructB<a class="mrdocs-anchor" href="#mixed_regular_ns-SeeBelowStructB" aria-label="Permalink">#</a>
-</h2>
+mixed_regular_ns::SeeBelowStructB</h2>
 </div>
 <div>
 <h3>
@@ -174,8 +167,7 @@ Declared in <code>&lt;no-extract-empty-namespaces.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="regular_ns">
-regular_ns<a class="mrdocs-anchor" href="#regular_ns" aria-label="Permalink">#</a>
-</h2>
+regular_ns</h2>
 <div>
 <p>Regular namespace</p>
 </div>
@@ -198,8 +190,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="regular_ns-A">
-regular_ns::A<a class="mrdocs-anchor" href="#regular_ns-A" aria-label="Permalink">#</a>
-</h2>
+regular_ns::A</h2>
 </div>
 <div>
 <h3>
@@ -214,8 +205,7 @@ Declared in <code>&lt;no-extract-empty-namespaces.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="see_below_ns">
-see_below_ns<a class="mrdocs-anchor" href="#see_below_ns" aria-label="Permalink">#</a>
-</h2>
+see_below_ns</h2>
 <div>
 <p>Should decay to see-below</p>
 </div>
@@ -239,8 +229,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="see_below_ns-SeeBelowStructA">
-see_below_ns::SeeBelowStructA<a class="mrdocs-anchor" href="#see_below_ns-SeeBelowStructA" aria-label="Permalink">#</a>
-</h2>
+see_below_ns::SeeBelowStructA</h2>
 </div>
 <div>
 <h3>
@@ -255,8 +244,7 @@ Declared in <code>&lt;no-extract-empty-namespaces.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="see_below_ns-SeeBelowStructB">
-see_below_ns::SeeBelowStructB<a class="mrdocs-anchor" href="#see_below_ns-SeeBelowStructB" aria-label="Permalink">#</a>
-</h2>
+see_below_ns::SeeBelowStructB</h2>
 </div>
 <div>
 <h3>
@@ -271,8 +259,7 @@ Declared in <code>&lt;no-extract-empty-namespaces.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="empty_ns_alias">
-empty_ns_alias<a class="mrdocs-anchor" href="#empty_ns_alias" aria-label="Permalink">#</a>
-</h2>
+empty_ns_alias</h2>
 <div>
 <p>Should still work</p>
 </div>
@@ -288,8 +275,7 @@ Declared in <code>&lt;no-extract-empty-namespaces.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="regular_ns_alias">
-regular_ns_alias<a class="mrdocs-anchor" href="#regular_ns_alias" aria-label="Permalink">#</a>
-</h2>
+regular_ns_alias</h2>
 <div>
 <p>Should work</p>
 </div>

--- a/test-files/golden-tests/config/extract-friends/extract-friends.html
+++ b/test-files/golden-tests/config/extract-friends/extract-friends.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="std">
-std<a class="mrdocs-anchor" href="#std" aria-label="Permalink">#</a>
-</h2>
+std</h2>
 </div>
 <h2>
 Types</h2>
@@ -66,8 +64,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="std-hash-03">
-std::hash<a class="mrdocs-anchor" href="#std-hash-03" aria-label="Permalink">#</a>
-</h2>
+std::hash</h2>
 </div>
 <div>
 <h3>
@@ -83,8 +80,7 @@ class hash;</code></pre>
 <div>
 <div>
 <h2 id="std-hash-08">
-std::hash&lt;A&gt;<a class="mrdocs-anchor" href="#std-hash-08" aria-label="Permalink">#</a>
-</h2>
+std::hash&lt;A&gt;</h2>
 </div>
 <div>
 <h3>
@@ -114,8 +110,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="std-hash-08-operator_call">
-std::hash&lt;A&gt;::operator()<a class="mrdocs-anchor" href="#std-hash-08-operator_call" aria-label="Permalink">#</a>
-</h2>
+std::hash&lt;A&gt;::operator()</h2>
 </div>
 <div>
 <h3>
@@ -129,8 +124,7 @@ operator()(<a href="#A">A</a> const& rhs) const noexcept;</code></pre>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/extract-friends/no-extract-friends.html
+++ b/test-files/golden-tests/config/extract-friends/no-extract-friends.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="std">
-std<a class="mrdocs-anchor" href="#std" aria-label="Permalink">#</a>
-</h2>
+std</h2>
 </div>
 <h2>
 Types</h2>
@@ -66,8 +64,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="std-hash-03">
-std::hash<a class="mrdocs-anchor" href="#std-hash-03" aria-label="Permalink">#</a>
-</h2>
+std::hash</h2>
 </div>
 <div>
 <h3>
@@ -83,8 +80,7 @@ class hash;</code></pre>
 <div>
 <div>
 <h2 id="std-hash-08">
-std::hash&lt;A&gt;<a class="mrdocs-anchor" href="#std-hash-08" aria-label="Permalink">#</a>
-</h2>
+std::hash&lt;A&gt;</h2>
 </div>
 <div>
 <h3>
@@ -114,8 +110,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="std-hash-08-operator_call">
-std::hash&lt;A&gt;::operator()<a class="mrdocs-anchor" href="#std-hash-08-operator_call" aria-label="Permalink">#</a>
-</h2>
+std::hash&lt;A&gt;::operator()</h2>
 </div>
 <div>
 <h3>
@@ -129,8 +124,7 @@ operator()(<a href="#A">A</a> const& rhs) const noexcept;</code></pre>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/extract-implicit-specializations/base.html
+++ b/test-files/golden-tests/config/extract-implicit-specializations/base.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -77,8 +75,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -123,8 +120,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="B-value">
-B::value<a class="mrdocs-anchor" href="#B-value" aria-label="Permalink">#</a>
-</h2>
+B::value</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/extract-implicit-specializations/extract-implicit-specializations.html
+++ b/test-files/golden-tests/config/extract-implicit-specializations/extract-implicit-specializations.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -77,8 +75,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-value">
-A::value<a class="mrdocs-anchor" href="#A-value" aria-label="Permalink">#</a>
-</h2>
+A::value</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +89,7 @@ value();</code></pre>
 <div>
 <div>
 <h2 id="B-00">
-B<a class="mrdocs-anchor" href="#B-00" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -139,8 +135,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="B-00-value">
-B::value<a class="mrdocs-anchor" href="#B-00-value" aria-label="Permalink">#</a>
-</h2>
+B::value</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/extract-implicit-specializations/no-extract-implicit-specializations.html
+++ b/test-files/golden-tests/config/extract-implicit-specializations/no-extract-implicit-specializations.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -77,8 +75,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="B-00">
-B<a class="mrdocs-anchor" href="#B-00" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -124,8 +121,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="B-00-value">
-B::value<a class="mrdocs-anchor" href="#B-00-value" aria-label="Permalink">#</a>
-</h2>
+B::value</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/extract-local-classes/extract-local-classes.html
+++ b/test-files/golden-tests/config/extract-local-classes/extract-local-classes.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="local_class">
-local_class<a class="mrdocs-anchor" href="#local_class" aria-label="Permalink">#</a>
-</h2>
+local_class</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Declared in <code>&lt;extract-local-classes.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="local_struct">
-local_struct<a class="mrdocs-anchor" href="#local_struct" aria-label="Permalink">#</a>
-</h2>
+local_struct</h2>
 </div>
 <div>
 <h3>
@@ -77,8 +74,7 @@ Declared in <code>&lt;extract-local-classes.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="local_function">
-local_function<a class="mrdocs-anchor" href="#local_function" aria-label="Permalink">#</a>
-</h2>
+local_function</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/extract-local-classes/no-extract-local-classes.html
+++ b/test-files/golden-tests/config/extract-local-classes/no-extract-local-classes.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="local_function">
-local_function<a class="mrdocs-anchor" href="#local_function" aria-label="Permalink">#</a>
-</h2>
+local_function</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/extract-private-virtual/extract-private-virtual.html
+++ b/test-files/golden-tests/config/extract-private-virtual/extract-private-virtual.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -74,8 +72,7 @@ Private Member Functions</h2>
 <div>
 <div>
 <h2 id="A-f">
-A::f<a class="mrdocs-anchor" href="#A-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -90,8 +87,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-g">
-A::g<a class="mrdocs-anchor" href="#A-g" aria-label="Permalink">#</a>
-</h2>
+A::g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/extract-private-virtual/no-extract-private-virtual.html
+++ b/test-files/golden-tests/config/extract-private-virtual/no-extract-private-virtual.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -60,8 +58,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-f">
-A::f<a class="mrdocs-anchor" href="#A-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/include-symbols/global-symbol-excluded.html
+++ b/test-files/golden-tests/config/include-symbols/global-symbol-excluded.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -30,8 +29,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="mrdocs">
-mrdocs<a class="mrdocs-anchor" href="#mrdocs" aria-label="Permalink">#</a>
-</h2>
+mrdocs</h2>
 <div>
 <p>Included namespace</p>
 </div>
@@ -54,8 +52,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="mrdocs-Foo">
-mrdocs::Foo<a class="mrdocs-anchor" href="#mrdocs-Foo" aria-label="Permalink">#</a>
-</h2>
+mrdocs::Foo</h2>
 <div>
 <p>Included record</p>
 </div>

--- a/test-files/golden-tests/config/include-symbols/using-external-base-docs.html
+++ b/test-files/golden-tests/config/include-symbols/using-external-base-docs.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 </div>
 

--- a/test-files/golden-tests/config/inherit-base-members/base-overload-set.html
+++ b/test-files/golden-tests/config/inherit-base-members/base-overload-set.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -32,8 +31,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="Base">
-Base<a class="mrdocs-anchor" href="#Base" aria-label="Permalink">#</a>
-</h2>
+Base</h2>
 </div>
 <div>
 <h3>
@@ -94,8 +92,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="Base-foo-04">
-Base::foo<a class="mrdocs-anchor" href="#Base-foo-04" aria-label="Permalink">#</a>
-</h2>
+Base::foo</h2>
 </div>
 <div>
 <h3>
@@ -117,8 +114,7 @@ Declared in <code>&lt;base-overload-set.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Base-foo-0a">
-Base::foo<a class="mrdocs-anchor" href="#Base-foo-0a" aria-label="Permalink">#</a>
-</h2>
+Base::foo</h2>
 </div>
 <div>
 <h3>
@@ -132,8 +128,7 @@ foo();</code></pre>
 <div>
 <div>
 <h2 id="Base-foo-08">
-Base::foo<a class="mrdocs-anchor" href="#Base-foo-08" aria-label="Permalink">#</a>
-</h2>
+Base::foo</h2>
 </div>
 <div>
 <h3>
@@ -147,8 +142,7 @@ foo() const;</code></pre>
 <div>
 <div>
 <h2 id="C">
-C<a class="mrdocs-anchor" href="#C" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>
@@ -193,8 +187,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="ConstBase">
-ConstBase<a class="mrdocs-anchor" href="#ConstBase" aria-label="Permalink">#</a>
-</h2>
+ConstBase</h2>
 </div>
 <div>
 <h3>
@@ -239,8 +232,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="ConstBase-foo">
-ConstBase::foo<a class="mrdocs-anchor" href="#ConstBase-foo" aria-label="Permalink">#</a>
-</h2>
+ConstBase::foo</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/inherit-base-members/copy-dependencies.html
+++ b/test-files/golden-tests/config/inherit-base-members/copy-dependencies.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -34,8 +33,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="base">
-base<a class="mrdocs-anchor" href="#base" aria-label="Permalink">#</a>
-</h2>
+base</h2>
 <div>
 <p>A base class to test inheritance and shadowing</p>
 </div>
@@ -119,8 +117,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="base-base_inherited">
-base::base_inherited<a class="mrdocs-anchor" href="#base-base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -142,8 +139,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-base_shadowed">
-base::base_shadowed<a class="mrdocs-anchor" href="#base-base_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -165,8 +161,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-derived_shadowed">
-base::derived_shadowed<a class="mrdocs-anchor" href="#base-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -188,8 +183,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_base_inherited">
-base::do_base_inherited<a class="mrdocs-anchor" href="#base-do_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::do_base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -211,8 +205,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_base_shadowed">
-base::do_base_shadowed<a class="mrdocs-anchor" href="#base-do_base_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::do_base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -234,8 +227,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_derived_shadowed">
-base::do_derived_shadowed<a class="mrdocs-anchor" href="#base-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::do_derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -257,8 +249,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base_base">
-base_base<a class="mrdocs-anchor" href="#base_base" aria-label="Permalink">#</a>
-</h2>
+base_base</h2>
 <div>
 <p>A second-order base class to test indirect inheritance</p>
 </div>
@@ -307,8 +298,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="base_base-base_base_inherited">
-base_base::base_base_inherited<a class="mrdocs-anchor" href="#base_base-base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base_base::base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -330,8 +320,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="base_base-do_base_base_inherited">
-base_base::do_base_base_inherited<a class="mrdocs-anchor" href="#base_base-do_base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base_base::do_base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -353,8 +342,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="derived">
-derived<a class="mrdocs-anchor" href="#derived" aria-label="Permalink">#</a>
-</h2>
+derived</h2>
 <div>
 <p>A class that derives from base and excluded_base</p>
 </div>
@@ -428,8 +416,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="derived-derived_shadowed">
-derived::derived_shadowed<a class="mrdocs-anchor" href="#derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -451,8 +438,7 @@ A class that derives from base and excluded_base
 <div>
 <div>
 <h2 id="derived-do_derived_shadowed">
-derived::do_derived_shadowed<a class="mrdocs-anchor" href="#derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -474,8 +460,7 @@ A class that derives from base and excluded_base
 <div>
 <div>
 <h2 id="derived-excluded_inherited">
-derived::excluded_inherited<a class="mrdocs-anchor" href="#derived-excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+derived::excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -492,8 +477,7 @@ excluded_inherited();</code></pre>
 <div>
 <div>
 <h2 id="derived-do_excluded_inherited">
-derived::do_excluded_inherited<a class="mrdocs-anchor" href="#derived-do_excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+derived::do_excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -510,8 +494,7 @@ do_excluded_inherited();</code></pre>
 <div>
 <div>
 <h2 id="derived-do_shadowed">
-derived::do_shadowed<a class="mrdocs-anchor" href="#derived-do_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::do_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -528,8 +511,7 @@ do_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="private_derived">
-private_derived<a class="mrdocs-anchor" href="#private_derived" aria-label="Permalink">#</a>
-</h2>
+private_derived</h2>
 <div>
 <p>A class that uses private inheritance only</p>
 </div>
@@ -564,8 +546,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="private_derived-derived_shadowed">
-private_derived::derived_shadowed<a class="mrdocs-anchor" href="#private_derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+private_derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -587,8 +568,7 @@ A class that uses private inheritance only
 <div>
 <div>
 <h2 id="private_derived-do_derived_shadowed">
-private_derived::do_derived_shadowed<a class="mrdocs-anchor" href="#private_derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+private_derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -610,8 +590,7 @@ A class that uses private inheritance only
 <div>
 <div>
 <h2 id="protected_derived">
-protected_derived<a class="mrdocs-anchor" href="#protected_derived" aria-label="Permalink">#</a>
-</h2>
+protected_derived</h2>
 <div>
 <p>A class that should inherit functions as protected.</p>
 </div>
@@ -686,8 +665,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="protected_derived-derived_shadowed">
-protected_derived::derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -709,8 +687,7 @@ A class that should inherit functions as protected.
 <div>
 <div>
 <h2 id="protected_derived-do_derived_shadowed">
-protected_derived::do_derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -732,8 +709,7 @@ A class that should inherit functions as protected.
 <div>
 <div>
 <h2 id="protected_derived-do_excluded_inherited">
-protected_derived::do_excluded_inherited<a class="mrdocs-anchor" href="#protected_derived-do_excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -750,8 +726,7 @@ do_excluded_inherited();</code></pre>
 <div>
 <div>
 <h2 id="protected_derived-do_shadowed">
-protected_derived::do_shadowed<a class="mrdocs-anchor" href="#protected_derived-do_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -768,8 +743,7 @@ do_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="protected_derived-excluded_inherited">
-protected_derived::excluded_inherited<a class="mrdocs-anchor" href="#protected_derived-excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+protected_derived::excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>

--- a/test-files/golden-tests/config/inherit-base-members/copy.html
+++ b/test-files/golden-tests/config/inherit-base-members/copy.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -34,8 +33,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="base">
-base<a class="mrdocs-anchor" href="#base" aria-label="Permalink">#</a>
-</h2>
+base</h2>
 <div>
 <p>A base class to test inheritance and shadowing</p>
 </div>
@@ -119,8 +117,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="base-base_base_inherited">
-base::base_base_inherited<a class="mrdocs-anchor" href="#base-base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -142,8 +139,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="base-base_inherited">
-base::base_inherited<a class="mrdocs-anchor" href="#base-base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -165,8 +161,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-base_shadowed">
-base::base_shadowed<a class="mrdocs-anchor" href="#base-base_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -188,8 +183,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-derived_shadowed">
-base::derived_shadowed<a class="mrdocs-anchor" href="#base-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -211,8 +205,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_base_base_inherited">
-base::do_base_base_inherited<a class="mrdocs-anchor" href="#base-do_base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::do_base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -234,8 +227,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="base-do_base_inherited">
-base::do_base_inherited<a class="mrdocs-anchor" href="#base-do_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::do_base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -257,8 +249,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_base_shadowed">
-base::do_base_shadowed<a class="mrdocs-anchor" href="#base-do_base_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::do_base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -280,8 +271,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_derived_shadowed">
-base::do_derived_shadowed<a class="mrdocs-anchor" href="#base-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::do_derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -303,8 +293,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base_base">
-base_base<a class="mrdocs-anchor" href="#base_base" aria-label="Permalink">#</a>
-</h2>
+base_base</h2>
 <div>
 <p>A second-order base class to test indirect inheritance</p>
 </div>
@@ -353,8 +342,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="base_base-base_base_inherited">
-base_base::base_base_inherited<a class="mrdocs-anchor" href="#base_base-base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base_base::base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -376,8 +364,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="base_base-do_base_base_inherited">
-base_base::do_base_base_inherited<a class="mrdocs-anchor" href="#base_base-do_base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base_base::do_base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -399,8 +386,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="derived">
-derived<a class="mrdocs-anchor" href="#derived" aria-label="Permalink">#</a>
-</h2>
+derived</h2>
 <div>
 <p>A class that derives from base and excluded_base</p>
 </div>
@@ -474,8 +460,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="derived-base_base_inherited">
-derived::base_base_inherited<a class="mrdocs-anchor" href="#derived-base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+derived::base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -497,8 +482,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="derived-base_inherited">
-derived::base_inherited<a class="mrdocs-anchor" href="#derived-base_inherited" aria-label="Permalink">#</a>
-</h2>
+derived::base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -520,8 +504,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="derived-base_shadowed">
-derived::base_shadowed<a class="mrdocs-anchor" href="#derived-base_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -543,8 +526,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="derived-derived_shadowed">
-derived::derived_shadowed<a class="mrdocs-anchor" href="#derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -566,8 +548,7 @@ A class that derives from base and excluded_base
 <div>
 <div>
 <h2 id="derived-do_base_base_inherited">
-derived::do_base_base_inherited<a class="mrdocs-anchor" href="#derived-do_base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+derived::do_base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -589,8 +570,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="derived-do_derived_shadowed-0a">
-derived::do_derived_shadowed<a class="mrdocs-anchor" href="#derived-do_derived_shadowed-0a" aria-label="Permalink">#</a>
-</h2>
+derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -612,8 +592,7 @@ A class that derives from base and excluded_base
 <div>
 <div>
 <h2 id="derived-excluded_inherited">
-derived::excluded_inherited<a class="mrdocs-anchor" href="#derived-excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+derived::excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -630,8 +609,7 @@ excluded_inherited();</code></pre>
 <div>
 <div>
 <h2 id="derived-do_base_inherited">
-derived::do_base_inherited<a class="mrdocs-anchor" href="#derived-do_base_inherited" aria-label="Permalink">#</a>
-</h2>
+derived::do_base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -653,8 +631,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="derived-do_base_shadowed">
-derived::do_base_shadowed<a class="mrdocs-anchor" href="#derived-do_base_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::do_base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -676,8 +653,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="derived-do_derived_shadowed-0d">
-derived::do_derived_shadowed<a class="mrdocs-anchor" href="#derived-do_derived_shadowed-0d" aria-label="Permalink">#</a>
-</h2>
+derived::do_derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -699,8 +675,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="derived-do_excluded_inherited">
-derived::do_excluded_inherited<a class="mrdocs-anchor" href="#derived-do_excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+derived::do_excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -717,8 +692,7 @@ do_excluded_inherited();</code></pre>
 <div>
 <div>
 <h2 id="derived-do_shadowed">
-derived::do_shadowed<a class="mrdocs-anchor" href="#derived-do_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::do_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -735,8 +709,7 @@ do_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="private_derived">
-private_derived<a class="mrdocs-anchor" href="#private_derived" aria-label="Permalink">#</a>
-</h2>
+private_derived</h2>
 <div>
 <p>A class that uses private inheritance only</p>
 </div>
@@ -771,8 +744,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="private_derived-derived_shadowed">
-private_derived::derived_shadowed<a class="mrdocs-anchor" href="#private_derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+private_derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -794,8 +766,7 @@ A class that uses private inheritance only
 <div>
 <div>
 <h2 id="private_derived-do_derived_shadowed">
-private_derived::do_derived_shadowed<a class="mrdocs-anchor" href="#private_derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+private_derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -817,8 +788,7 @@ A class that uses private inheritance only
 <div>
 <div>
 <h2 id="protected_derived">
-protected_derived<a class="mrdocs-anchor" href="#protected_derived" aria-label="Permalink">#</a>
-</h2>
+protected_derived</h2>
 <div>
 <p>A class that should inherit functions as protected.</p>
 </div>
@@ -893,8 +863,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="protected_derived-derived_shadowed-0a">
-protected_derived::derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-derived_shadowed-0a" aria-label="Permalink">#</a>
-</h2>
+protected_derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -916,8 +885,7 @@ A class that should inherit functions as protected.
 <div>
 <div>
 <h2 id="protected_derived-do_derived_shadowed-0e">
-protected_derived::do_derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-do_derived_shadowed-0e" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -939,8 +907,7 @@ A class that should inherit functions as protected.
 <div>
 <div>
 <h2 id="protected_derived-base_base_inherited">
-protected_derived::base_base_inherited<a class="mrdocs-anchor" href="#protected_derived-base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+protected_derived::base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -962,8 +929,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="protected_derived-base_inherited">
-protected_derived::base_inherited<a class="mrdocs-anchor" href="#protected_derived-base_inherited" aria-label="Permalink">#</a>
-</h2>
+protected_derived::base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -985,8 +951,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="protected_derived-base_shadowed">
-protected_derived::base_shadowed<a class="mrdocs-anchor" href="#protected_derived-base_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -1008,8 +973,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="protected_derived-derived_shadowed-0f">
-protected_derived::derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-derived_shadowed-0f" aria-label="Permalink">#</a>
-</h2>
+protected_derived::derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -1031,8 +995,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="protected_derived-do_base_base_inherited">
-protected_derived::do_base_base_inherited<a class="mrdocs-anchor" href="#protected_derived-do_base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -1054,8 +1017,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="protected_derived-do_base_inherited">
-protected_derived::do_base_inherited<a class="mrdocs-anchor" href="#protected_derived-do_base_inherited" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -1077,8 +1039,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="protected_derived-do_base_shadowed">
-protected_derived::do_base_shadowed<a class="mrdocs-anchor" href="#protected_derived-do_base_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -1100,8 +1061,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="protected_derived-do_derived_shadowed-06">
-protected_derived::do_derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-do_derived_shadowed-06" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -1123,8 +1083,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="protected_derived-do_excluded_inherited">
-protected_derived::do_excluded_inherited<a class="mrdocs-anchor" href="#protected_derived-do_excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -1141,8 +1100,7 @@ do_excluded_inherited();</code></pre>
 <div>
 <div>
 <h2 id="protected_derived-do_shadowed">
-protected_derived::do_shadowed<a class="mrdocs-anchor" href="#protected_derived-do_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -1159,8 +1117,7 @@ do_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="protected_derived-excluded_inherited">
-protected_derived::excluded_inherited<a class="mrdocs-anchor" href="#protected_derived-excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+protected_derived::excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>

--- a/test-files/golden-tests/config/inherit-base-members/impl-defined-base.html
+++ b/test-files/golden-tests/config/inherit-base-members/impl-defined-base.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="derived">
-derived<a class="mrdocs-anchor" href="#derived" aria-label="Permalink">#</a>
-</h2>
+derived</h2>
 </div>
 <div>
 <h3>
@@ -77,8 +75,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="derived-do_it">
-derived::do_it<a class="mrdocs-anchor" href="#derived-do_it" aria-label="Permalink">#</a>
-</h2>
+derived::do_it</h2>
 <div>
 <p>Do the thing</p>
 </div>
@@ -95,8 +92,7 @@ do_it();</code></pre>
 <div>
 <div>
 <h2 id="derived-own">
-derived::own<a class="mrdocs-anchor" href="#derived-own" aria-label="Permalink">#</a>
-</h2>
+derived::own</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/inherit-base-members/never.html
+++ b/test-files/golden-tests/config/inherit-base-members/never.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -34,8 +33,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="base">
-base<a class="mrdocs-anchor" href="#base" aria-label="Permalink">#</a>
-</h2>
+base</h2>
 <div>
 <p>A base class to test inheritance and shadowing</p>
 </div>
@@ -117,8 +115,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="base-base_inherited">
-base::base_inherited<a class="mrdocs-anchor" href="#base-base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -140,8 +137,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-base_shadowed">
-base::base_shadowed<a class="mrdocs-anchor" href="#base-base_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -163,8 +159,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-derived_shadowed">
-base::derived_shadowed<a class="mrdocs-anchor" href="#base-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -186,8 +181,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_base_inherited">
-base::do_base_inherited<a class="mrdocs-anchor" href="#base-do_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::do_base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -209,8 +203,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_base_shadowed">
-base::do_base_shadowed<a class="mrdocs-anchor" href="#base-do_base_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::do_base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -232,8 +225,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_derived_shadowed">
-base::do_derived_shadowed<a class="mrdocs-anchor" href="#base-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::do_derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -255,8 +247,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base_base">
-base_base<a class="mrdocs-anchor" href="#base_base" aria-label="Permalink">#</a>
-</h2>
+base_base</h2>
 <div>
 <p>A second-order base class to test indirect inheritance</p>
 </div>
@@ -305,8 +296,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="base_base-base_base_inherited">
-base_base::base_base_inherited<a class="mrdocs-anchor" href="#base_base-base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base_base::base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -328,8 +318,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="base_base-do_base_base_inherited">
-base_base::do_base_base_inherited<a class="mrdocs-anchor" href="#base_base-do_base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base_base::do_base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -351,8 +340,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="derived">
-derived<a class="mrdocs-anchor" href="#derived" aria-label="Permalink">#</a>
-</h2>
+derived</h2>
 <div>
 <p>A class that derives from base and excluded_base</p>
 </div>
@@ -403,8 +391,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="derived-derived_shadowed">
-derived::derived_shadowed<a class="mrdocs-anchor" href="#derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -426,8 +413,7 @@ A class that derives from base and excluded_base
 <div>
 <div>
 <h2 id="derived-do_derived_shadowed">
-derived::do_derived_shadowed<a class="mrdocs-anchor" href="#derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -449,8 +435,7 @@ A class that derives from base and excluded_base
 <div>
 <div>
 <h2 id="private_derived">
-private_derived<a class="mrdocs-anchor" href="#private_derived" aria-label="Permalink">#</a>
-</h2>
+private_derived</h2>
 <div>
 <p>A class that uses private inheritance only</p>
 </div>
@@ -485,8 +470,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="private_derived-derived_shadowed">
-private_derived::derived_shadowed<a class="mrdocs-anchor" href="#private_derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+private_derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -508,8 +492,7 @@ A class that uses private inheritance only
 <div>
 <div>
 <h2 id="private_derived-do_derived_shadowed">
-private_derived::do_derived_shadowed<a class="mrdocs-anchor" href="#private_derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+private_derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -531,8 +514,7 @@ A class that uses private inheritance only
 <div>
 <div>
 <h2 id="protected_derived">
-protected_derived<a class="mrdocs-anchor" href="#protected_derived" aria-label="Permalink">#</a>
-</h2>
+protected_derived</h2>
 <div>
 <p>A class that should inherit functions as protected.</p>
 </div>
@@ -583,8 +565,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="protected_derived-derived_shadowed">
-protected_derived::derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -606,8 +587,7 @@ A class that should inherit functions as protected.
 <div>
 <div>
 <h2 id="protected_derived-do_derived_shadowed">
-protected_derived::do_derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>

--- a/test-files/golden-tests/config/inherit-base-members/reference.html
+++ b/test-files/golden-tests/config/inherit-base-members/reference.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -34,8 +33,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="base">
-base<a class="mrdocs-anchor" href="#base" aria-label="Permalink">#</a>
-</h2>
+base</h2>
 <div>
 <p>A base class to test inheritance and shadowing</p>
 </div>
@@ -119,8 +117,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="base-base_inherited">
-base::base_inherited<a class="mrdocs-anchor" href="#base-base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -142,8 +139,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-base_shadowed">
-base::base_shadowed<a class="mrdocs-anchor" href="#base-base_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -165,8 +161,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-derived_shadowed">
-base::derived_shadowed<a class="mrdocs-anchor" href="#base-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -188,8 +183,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_base_inherited">
-base::do_base_inherited<a class="mrdocs-anchor" href="#base-do_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::do_base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -211,8 +205,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_base_shadowed">
-base::do_base_shadowed<a class="mrdocs-anchor" href="#base-do_base_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::do_base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -234,8 +227,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base-do_derived_shadowed">
-base::do_derived_shadowed<a class="mrdocs-anchor" href="#base-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::do_derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -257,8 +249,7 @@ A base class to test inheritance and shadowing
 <div>
 <div>
 <h2 id="base_base">
-base_base<a class="mrdocs-anchor" href="#base_base" aria-label="Permalink">#</a>
-</h2>
+base_base</h2>
 <div>
 <p>A second-order base class to test indirect inheritance</p>
 </div>
@@ -307,8 +298,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="base_base-base_base_inherited">
-base_base::base_base_inherited<a class="mrdocs-anchor" href="#base_base-base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base_base::base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -330,8 +320,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="base_base-do_base_base_inherited">
-base_base::do_base_base_inherited<a class="mrdocs-anchor" href="#base_base-do_base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base_base::do_base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -353,8 +342,7 @@ A second-order base class to test indirect inheritance
 <div>
 <div>
 <h2 id="derived">
-derived<a class="mrdocs-anchor" href="#derived" aria-label="Permalink">#</a>
-</h2>
+derived</h2>
 <div>
 <p>A class that derives from base and excluded_base</p>
 </div>
@@ -425,8 +413,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="derived-derived_shadowed">
-derived::derived_shadowed<a class="mrdocs-anchor" href="#derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -448,8 +435,7 @@ A class that derives from base and excluded_base
 <div>
 <div>
 <h2 id="derived-do_derived_shadowed">
-derived::do_derived_shadowed<a class="mrdocs-anchor" href="#derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -471,8 +457,7 @@ A class that derives from base and excluded_base
 <div>
 <div>
 <h2 id="private_derived">
-private_derived<a class="mrdocs-anchor" href="#private_derived" aria-label="Permalink">#</a>
-</h2>
+private_derived</h2>
 <div>
 <p>A class that uses private inheritance only</p>
 </div>
@@ -507,8 +492,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="private_derived-derived_shadowed">
-private_derived::derived_shadowed<a class="mrdocs-anchor" href="#private_derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+private_derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -530,8 +514,7 @@ A class that uses private inheritance only
 <div>
 <div>
 <h2 id="private_derived-do_derived_shadowed">
-private_derived::do_derived_shadowed<a class="mrdocs-anchor" href="#private_derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+private_derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -553,8 +536,7 @@ A class that uses private inheritance only
 <div>
 <div>
 <h2 id="protected_derived">
-protected_derived<a class="mrdocs-anchor" href="#protected_derived" aria-label="Permalink">#</a>
-</h2>
+protected_derived</h2>
 <div>
 <p>A class that should inherit functions as protected.</p>
 </div>
@@ -626,8 +608,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="protected_derived-derived_shadowed">
-protected_derived::derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -649,8 +630,7 @@ A class that should inherit functions as protected.
 <div>
 <div>
 <h2 id="protected_derived-do_derived_shadowed">
-protected_derived::do_derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>

--- a/test-files/golden-tests/config/inherit-base-members/see-below-base.html
+++ b/test-files/golden-tests/config/inherit-base-members/see-below-base.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="see_below_ns">
-see_below_ns<a class="mrdocs-anchor" href="#see_below_ns" aria-label="Permalink">#</a>
-</h2>
+see_below_ns</h2>
 </div>
 <h2>
 Types</h2>
@@ -65,8 +63,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="see_below_ns-base_see">
-see_below_ns::base_see<a class="mrdocs-anchor" href="#see_below_ns-base_see" aria-label="Permalink">#</a>
-</h2>
+see_below_ns::base_see</h2>
 </div>
 <div>
 <h3>
@@ -81,8 +78,7 @@ Declared in <code>&lt;see-below-base.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="derived_see">
-derived_see<a class="mrdocs-anchor" href="#derived_see" aria-label="Permalink">#</a>
-</h2>
+derived_see</h2>
 </div>
 <div>
 <h3>
@@ -128,8 +124,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="derived_see-do_other">
-derived_see::do_other<a class="mrdocs-anchor" href="#derived_see-do_other" aria-label="Permalink">#</a>
-</h2>
+derived_see::do_other</h2>
 <div>
 <p>Describes the see-below member</p>
 </div>
@@ -146,8 +141,7 @@ do_other();</code></pre>
 <div>
 <div>
 <h2 id="derived_see-own">
-derived_see::own<a class="mrdocs-anchor" href="#derived_see-own" aria-label="Permalink">#</a>
-</h2>
+derived_see::own</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/inherit-base-members/skip-special.html
+++ b/test-files/golden-tests/config/inherit-base-members/skip-special.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -34,8 +33,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="base">
-base<a class="mrdocs-anchor" href="#base" aria-label="Permalink">#</a>
-</h2>
+base</h2>
 </div>
 <div>
 <h3>
@@ -118,8 +116,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="base-2constructor">
-base::base<a class="mrdocs-anchor" href="#base-2constructor" aria-label="Permalink">#</a>
-</h2>
+base::base</h2>
 <div>
 <p>Constructor should not be inherited</p>
 </div>
@@ -135,8 +132,7 @@ Declared in <code>&lt;skip-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="base-2destructor">
-base::~base<a class="mrdocs-anchor" href="#base-2destructor" aria-label="Permalink">#</a>
-</h2>
+base::~base</h2>
 <div>
 <p>Destructor should not be inherited</p>
 </div>
@@ -152,8 +148,7 @@ Declared in <code>&lt;skip-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="base-base_inherited">
-base::base_inherited<a class="mrdocs-anchor" href="#base-base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -170,8 +165,7 @@ base_inherited();</code></pre>
 <div>
 <div>
 <h2 id="base-base_shadowed">
-base::base_shadowed<a class="mrdocs-anchor" href="#base-base_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -188,8 +182,7 @@ base_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="base-derived_shadowed">
-base::derived_shadowed<a class="mrdocs-anchor" href="#base-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -206,8 +199,7 @@ derived_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="base-do_base_inherited">
-base::do_base_inherited<a class="mrdocs-anchor" href="#base-do_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base::do_base_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -224,8 +216,7 @@ do_base_inherited();</code></pre>
 <div>
 <div>
 <h2 id="base-do_base_shadowed">
-base::do_base_shadowed<a class="mrdocs-anchor" href="#base-do_base_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::do_base_shadowed</h2>
 <div>
 <p>This function should shadow the excluded_base function.</p>
 </div>
@@ -242,8 +233,7 @@ do_base_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="base-do_derived_shadowed">
-base::do_derived_shadowed<a class="mrdocs-anchor" href="#base-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+base::do_derived_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -260,8 +250,7 @@ do_derived_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="base_base">
-base_base<a class="mrdocs-anchor" href="#base_base" aria-label="Permalink">#</a>
-</h2>
+base_base</h2>
 </div>
 <div>
 <h3>
@@ -309,8 +298,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="base_base-2constructor">
-base_base::base_base<a class="mrdocs-anchor" href="#base_base-2constructor" aria-label="Permalink">#</a>
-</h2>
+base_base::base_base</h2>
 <div>
 <p>Constructor should not be inherited</p>
 </div>
@@ -326,8 +314,7 @@ Declared in <code>&lt;skip-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="base_base-2destructor">
-base_base::~base_base<a class="mrdocs-anchor" href="#base_base-2destructor" aria-label="Permalink">#</a>
-</h2>
+base_base::~base_base</h2>
 <div>
 <p>Destructor should not be inherited</p>
 </div>
@@ -343,8 +330,7 @@ Declared in <code>&lt;skip-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="base_base-base_base_inherited">
-base_base::base_base_inherited<a class="mrdocs-anchor" href="#base_base-base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base_base::base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -361,8 +347,7 @@ base_base_inherited();</code></pre>
 <div>
 <div>
 <h2 id="base_base-do_base_base_inherited">
-base_base::do_base_base_inherited<a class="mrdocs-anchor" href="#base_base-do_base_base_inherited" aria-label="Permalink">#</a>
-</h2>
+base_base::do_base_base_inherited</h2>
 <div>
 <p>This function should be indirectly inherited by derived classes.</p>
 </div>
@@ -379,8 +364,7 @@ do_base_base_inherited();</code></pre>
 <div>
 <div>
 <h2 id="derived">
-derived<a class="mrdocs-anchor" href="#derived" aria-label="Permalink">#</a>
-</h2>
+derived</h2>
 </div>
 <div>
 <h3>
@@ -453,8 +437,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="derived-2constructor">
-derived::derived<a class="mrdocs-anchor" href="#derived-2constructor" aria-label="Permalink">#</a>
-</h2>
+derived::derived</h2>
 <div>
 <p>Constructor should not be inherited</p>
 </div>
@@ -470,8 +453,7 @@ Declared in <code>&lt;skip-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="derived-2destructor">
-derived::~derived<a class="mrdocs-anchor" href="#derived-2destructor" aria-label="Permalink">#</a>
-</h2>
+derived::~derived</h2>
 <div>
 <p>Destructor should not be inherited</p>
 </div>
@@ -487,8 +469,7 @@ Declared in <code>&lt;skip-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="derived-derived_shadowed">
-derived::derived_shadowed<a class="mrdocs-anchor" href="#derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -505,8 +486,7 @@ derived_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="derived-do_derived_shadowed">
-derived::do_derived_shadowed<a class="mrdocs-anchor" href="#derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -523,8 +503,7 @@ do_derived_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="derived-excluded_inherited">
-derived::excluded_inherited<a class="mrdocs-anchor" href="#derived-excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+derived::excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -541,8 +520,7 @@ excluded_inherited();</code></pre>
 <div>
 <div>
 <h2 id="derived-do_excluded_inherited">
-derived::do_excluded_inherited<a class="mrdocs-anchor" href="#derived-do_excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+derived::do_excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -559,8 +537,7 @@ do_excluded_inherited();</code></pre>
 <div>
 <div>
 <h2 id="derived-do_shadowed">
-derived::do_shadowed<a class="mrdocs-anchor" href="#derived-do_shadowed" aria-label="Permalink">#</a>
-</h2>
+derived::do_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -577,8 +554,7 @@ do_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="private_derived">
-private_derived<a class="mrdocs-anchor" href="#private_derived" aria-label="Permalink">#</a>
-</h2>
+private_derived</h2>
 </div>
 <div>
 <h3>
@@ -612,8 +588,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="private_derived-2constructor">
-private_derived::private_derived<a class="mrdocs-anchor" href="#private_derived-2constructor" aria-label="Permalink">#</a>
-</h2>
+private_derived::private_derived</h2>
 <div>
 <p>Constructor should not be inherited</p>
 </div>
@@ -629,8 +604,7 @@ Declared in <code>&lt;skip-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="private_derived-2destructor">
-private_derived::~private_derived<a class="mrdocs-anchor" href="#private_derived-2destructor" aria-label="Permalink">#</a>
-</h2>
+private_derived::~private_derived</h2>
 <div>
 <p>Destructor should not be inherited</p>
 </div>
@@ -646,8 +620,7 @@ Declared in <code>&lt;skip-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="private_derived-derived_shadowed">
-private_derived::derived_shadowed<a class="mrdocs-anchor" href="#private_derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+private_derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -664,8 +637,7 @@ derived_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="private_derived-do_derived_shadowed">
-private_derived::do_derived_shadowed<a class="mrdocs-anchor" href="#private_derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+private_derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -682,8 +654,7 @@ do_derived_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="protected_derived">
-protected_derived<a class="mrdocs-anchor" href="#protected_derived" aria-label="Permalink">#</a>
-</h2>
+protected_derived</h2>
 <div>
 <p>Should inherit functions as protected.</p>
 </div>
@@ -760,8 +731,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="protected_derived-2constructor">
-protected_derived::protected_derived<a class="mrdocs-anchor" href="#protected_derived-2constructor" aria-label="Permalink">#</a>
-</h2>
+protected_derived::protected_derived</h2>
 <div>
 <p>Constructor should not be inherited</p>
 </div>
@@ -777,8 +747,7 @@ Declared in <code>&lt;skip-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="protected_derived-2destructor">
-protected_derived::~protected_derived<a class="mrdocs-anchor" href="#protected_derived-2destructor" aria-label="Permalink">#</a>
-</h2>
+protected_derived::~protected_derived</h2>
 <div>
 <p>Destructor should not be inherited</p>
 </div>
@@ -794,8 +763,7 @@ Declared in <code>&lt;skip-special.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="protected_derived-derived_shadowed">
-protected_derived::derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -817,8 +785,7 @@ Should inherit functions as protected.
 <div>
 <div>
 <h2 id="protected_derived-do_derived_shadowed">
-protected_derived::do_derived_shadowed<a class="mrdocs-anchor" href="#protected_derived-do_derived_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_derived_shadowed</h2>
 <div>
 <p>This function should shadow the base class function.</p>
 </div>
@@ -840,8 +807,7 @@ Should inherit functions as protected.
 <div>
 <div>
 <h2 id="protected_derived-do_excluded_inherited">
-protected_derived::do_excluded_inherited<a class="mrdocs-anchor" href="#protected_derived-do_excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>
@@ -858,8 +824,7 @@ do_excluded_inherited();</code></pre>
 <div>
 <div>
 <h2 id="protected_derived-do_shadowed">
-protected_derived::do_shadowed<a class="mrdocs-anchor" href="#protected_derived-do_shadowed" aria-label="Permalink">#</a>
-</h2>
+protected_derived::do_shadowed</h2>
 <div>
 <p>This function should be shadowed by derived classes.</p>
 </div>
@@ -876,8 +841,7 @@ do_shadowed();</code></pre>
 <div>
 <div>
 <h2 id="protected_derived-excluded_inherited">
-protected_derived::excluded_inherited<a class="mrdocs-anchor" href="#protected_derived-excluded_inherited" aria-label="Permalink">#</a>
-</h2>
+protected_derived::excluded_inherited</h2>
 <div>
 <p>This function should be inherited by derived classes.</p>
 </div>

--- a/test-files/golden-tests/config/legible-names/constructor.html
+++ b/test-files/golden-tests/config/legible-names/constructor.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="X">
-X<a class="mrdocs-anchor" href="#X" aria-label="Permalink">#</a>
-</h2>
+X</h2>
 </div>
 <div>
 <h3>
@@ -60,8 +58,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="X-2constructor-08">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-08" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -96,8 +93,7 @@ Declared in <code>&lt;constructor.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-2constructor-0e8">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-0e8" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -113,8 +109,7 @@ Declared in <code>&lt;constructor.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-2constructor-0e0">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-0e0" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Copy constructor</p>
 </div>
@@ -148,8 +143,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2constructor-069">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-069" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Move constructor</p>
 </div>
@@ -183,8 +177,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2constructor-07">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-07" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Construct from <code>int</code></p>
 </div>
@@ -218,8 +211,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="X-2constructor-06f">
-X::X<a class="mrdocs-anchor" href="#X-2constructor-06f" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Construct from <code>double</code></p>
 </div>

--- a/test-files/golden-tests/config/missing-include-prefixes/main.html
+++ b/test-files/golden-tests/config/missing-include-prefixes/main.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -31,8 +30,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -46,8 +44,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="g">
-g<a class="mrdocs-anchor" href="#g" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/missing-include-shims/main.html
+++ b/test-files/golden-tests/config/missing-include-shims/main.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Function satisfied by missing-include-shims</p>
 </div>

--- a/test-files/golden-tests/config/overloads/const-mutable.html
+++ b/test-files/golden-tests/config/overloads/const-mutable.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="C">
-C<a class="mrdocs-anchor" href="#C" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>
@@ -60,8 +58,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="C-foo-0e">
-C::foo<a class="mrdocs-anchor" href="#C-foo-0e" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -83,8 +80,7 @@ Declared in <code>&lt;const-mutable.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C-foo-0b">
-C::foo<a class="mrdocs-anchor" href="#C-foo-0b" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -98,8 +94,7 @@ foo();</code></pre>
 <div>
 <div>
 <h2 id="C-foo-07">
-C::foo<a class="mrdocs-anchor" href="#C-foo-07" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/overloads/visibility.html
+++ b/test-files/golden-tests/config/overloads/visibility.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="C">
-C<a class="mrdocs-anchor" href="#C" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>
@@ -102,8 +100,7 @@ Protected Static Member Functions</h2>
 <div>
 <div>
 <h2 id="C-foo-0e">
-C::foo<a class="mrdocs-anchor" href="#C-foo-0e" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -125,8 +122,7 @@ Declared in <code>&lt;visibility.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C-foo-0b">
-C::foo<a class="mrdocs-anchor" href="#C-foo-0b" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -140,8 +136,7 @@ foo();</code></pre>
 <div>
 <div>
 <h2 id="C-foo-06">
-C::foo<a class="mrdocs-anchor" href="#C-foo-06" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -155,8 +150,7 @@ foo(bool);</code></pre>
 <div>
 <div>
 <h2 id="C-foo-03">
-C::foo<a class="mrdocs-anchor" href="#C-foo-03" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -182,8 +176,7 @@ int
 <div>
 <div>
 <h2 id="C-foo-0fc">
-C::foo<a class="mrdocs-anchor" href="#C-foo-0fc" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -198,8 +191,7 @@ foo(int);</code></pre>
 <div>
 <div>
 <h2 id="C-foo-05">
-C::foo<a class="mrdocs-anchor" href="#C-foo-05" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -216,8 +208,7 @@ foo(
 <div>
 <div>
 <h2 id="C-foo-04c">
-C::foo<a class="mrdocs-anchor" href="#C-foo-04c" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -244,8 +235,7 @@ Declared in <code>&lt;visibility.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C-foo-0a">
-C::foo<a class="mrdocs-anchor" href="#C-foo-0a" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -261,8 +251,7 @@ foo(
 <div>
 <div>
 <h2 id="C-foo-0c">
-C::foo<a class="mrdocs-anchor" href="#C-foo-0c" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -279,8 +268,7 @@ foo(
 <div>
 <div>
 <h2 id="C-foo-048">
-C::foo<a class="mrdocs-anchor" href="#C-foo-048" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -311,8 +299,7 @@ int
 <div>
 <div>
 <h2 id="C-foo-00">
-C::foo<a class="mrdocs-anchor" href="#C-foo-00" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>
@@ -330,8 +317,7 @@ foo(
 <div>
 <div>
 <h2 id="C-foo-0f5">
-C::foo<a class="mrdocs-anchor" href="#C-foo-0f5" aria-label="Permalink">#</a>
-</h2>
+C::foo</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/sfinae/alias.html
+++ b/test-files/golden-tests/config/sfinae/alias.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -46,8 +45,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="enable_if_t">
-enable_if_t<a class="mrdocs-anchor" href="#enable_if_t" aria-label="Permalink">#</a>
-</h2>
+enable_if_t</h2>
 </div>
 <div>
 <h3>
@@ -63,8 +61,7 @@ using enable_if_t = T;</code></pre>
 <div>
 <div>
 <h2 id="if_enable_t">
-if_enable_t<a class="mrdocs-anchor" href="#if_enable_t" aria-label="Permalink">#</a>
-</h2>
+if_enable_t</h2>
 </div>
 <div>
 <h3>
@@ -80,8 +77,7 @@ using if_enable_t = T;</code></pre>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 </div>
 <div>
 <h3>
@@ -97,8 +93,7 @@ requires std::is_class_v&lt;T&gt;;</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/sfinae/redeclare.html
+++ b/test-files/golden-tests/config/sfinae/redeclare.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/sfinae/return-based.html
+++ b/test-files/golden-tests/config/sfinae/return-based.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/show-enum-constants/show-enum-constants-false.html
+++ b/test-files/golden-tests/config/show-enum-constants/show-enum-constants-false.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Enums</h2>
@@ -30,8 +29,7 @@ Enums</h2>
 <div>
 <div>
 <h2 id="Color">
-Color<a class="mrdocs-anchor" href="#Color" aria-label="Permalink">#</a>
-</h2>
+Color</h2>
 <div>
 <p>A simple enum</p>
 </div>

--- a/test-files/golden-tests/config/show-enum-constants/show-enum-constants-true.html
+++ b/test-files/golden-tests/config/show-enum-constants/show-enum-constants-true.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Enums</h2>
@@ -30,8 +29,7 @@ Enums</h2>
 <div>
 <div>
 <h2 id="Color">
-Color<a class="mrdocs-anchor" href="#Color" aria-label="Permalink">#</a>
-</h2>
+Color</h2>
 <div>
 <p>A simple enum</p>
 </div>
@@ -63,8 +61,7 @@ Members</h2>
 <div>
 <div>
 <h2 id="Color-Red">
-Color::Red<a class="mrdocs-anchor" href="#Color-Red" aria-label="Permalink">#</a>
-</h2>
+Color::Red</h2>
 <div>
 <p>The color red</p>
 </div>
@@ -80,8 +77,7 @@ Declared in <code>&lt;show-enum-constants-true.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Color-Green">
-Color::Green<a class="mrdocs-anchor" href="#Color-Green" aria-label="Permalink">#</a>
-</h2>
+Color::Green</h2>
 <div>
 <p>The color green</p>
 </div>
@@ -97,8 +93,7 @@ Declared in <code>&lt;show-enum-constants-true.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Color-Blue">
-Color::Blue<a class="mrdocs-anchor" href="#Color-Blue" aria-label="Permalink">#</a>
-</h2>
+Color::Blue</h2>
 <div>
 <p>The color blue</p>
 </div>

--- a/test-files/golden-tests/config/show-namespaces/show-namespaces.html
+++ b/test-files/golden-tests/config/show-namespaces/show-namespaces.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="A-B-c">
-A::B::c<a class="mrdocs-anchor" href="#A-B-c" aria-label="Permalink">#</a>
-</h2>
+A::B::c</h2>
 </div>
 <div>
 <h3>
@@ -24,8 +23,7 @@ c();</code></pre>
 <div>
 <div>
 <h2 id="A-b">
-A::b<a class="mrdocs-anchor" href="#A-b" aria-label="Permalink">#</a>
-</h2>
+A::b</h2>
 </div>
 <div>
 <h3>
@@ -39,8 +37,7 @@ b();</code></pre>
 <div>
 <div>
 <h2 id="a">
-a<a class="mrdocs-anchor" href="#a" aria-label="Permalink">#</a>
-</h2>
+a</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-location.html
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-location.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="Z">
-Z<a class="mrdocs-anchor" href="#Z" aria-label="Permalink">#</a>
-</h2>
+Z</h2>
 </div>
 <div>
 <h3>
@@ -68,8 +66,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="Z-2constructor-00">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-00" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -92,8 +89,7 @@ Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-06">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-06" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Construct from <code>int</code></p>
 </div>
@@ -127,8 +123,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-2constructor-05">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-05" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -144,8 +139,7 @@ Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2destructor">
-Z::~Z<a class="mrdocs-anchor" href="#Z-2destructor" aria-label="Permalink">#</a>
-</h2>
+Z::~Z</h2>
 <div>
 <p>Destructor</p>
 </div>
@@ -161,8 +155,7 @@ Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-foo">
-Z::foo<a class="mrdocs-anchor" href="#Z-foo" aria-label="Permalink">#</a>
-</h2>
+Z::foo</h2>
 </div>
 <div>
 <h3>
@@ -176,8 +169,7 @@ foo() const;</code></pre>
 <div>
 <div>
 <h2 id="Z-bar">
-Z::bar<a class="mrdocs-anchor" href="#Z-bar" aria-label="Permalink">#</a>
-</h2>
+Z::bar</h2>
 </div>
 <div>
 <h3>
@@ -191,8 +183,7 @@ bar() const;</code></pre>
 <div>
 <div>
 <h2 id="Z-2conversion">
-Z::operator bool<a class="mrdocs-anchor" href="#Z-2conversion" aria-label="Permalink">#</a>
-</h2>
+Z::operator bool</h2>
 <div>
 <p>Conversion to <code>bool</code></p>
 </div>
@@ -213,8 +204,7 @@ The object converted to <code>bool</code>
 <div>
 <div>
 <h2 id="Z-operator_not">
-Z::operator!<a class="mrdocs-anchor" href="#Z-operator_not" aria-label="Permalink">#</a>
-</h2>
+Z::operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -236,8 +226,7 @@ Return Value</h3>
 <div>
 <div>
 <h2 id="Z-operator_eq">
-Z::operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#Z-operator_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -277,8 +266,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_not_eq">
-Z::operator!&#x3D;<a class="mrdocs-anchor" href="#Z-operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>
@@ -318,8 +306,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_3way">
-Z::operator&lt;&#x3D;&gt;<a class="mrdocs-anchor" href="#Z-operator_3way" aria-label="Permalink">#</a>
-</h2>
+Z::operator&lt;&#x3D;&gt;</h2>
 <div>
 <p>Three-way comparison operator</p>
 </div>

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-name.html
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-name.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="Z">
-Z<a class="mrdocs-anchor" href="#Z" aria-label="Permalink">#</a>
-</h2>
+Z</h2>
 </div>
 <div>
 <h3>
@@ -68,8 +66,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="Z-2constructor-00">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-00" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -92,8 +89,7 @@ Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-05">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-05" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -109,8 +105,7 @@ Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-06">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-06" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Construct from <code>int</code></p>
 </div>
@@ -144,8 +139,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-2destructor">
-Z::~Z<a class="mrdocs-anchor" href="#Z-2destructor" aria-label="Permalink">#</a>
-</h2>
+Z::~Z</h2>
 <div>
 <p>Destructor</p>
 </div>
@@ -161,8 +155,7 @@ Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-bar">
-Z::bar<a class="mrdocs-anchor" href="#Z-bar" aria-label="Permalink">#</a>
-</h2>
+Z::bar</h2>
 </div>
 <div>
 <h3>
@@ -176,8 +169,7 @@ bar() const;</code></pre>
 <div>
 <div>
 <h2 id="Z-foo">
-Z::foo<a class="mrdocs-anchor" href="#Z-foo" aria-label="Permalink">#</a>
-</h2>
+Z::foo</h2>
 </div>
 <div>
 <h3>
@@ -191,8 +183,7 @@ foo() const;</code></pre>
 <div>
 <div>
 <h2 id="Z-2conversion">
-Z::operator bool<a class="mrdocs-anchor" href="#Z-2conversion" aria-label="Permalink">#</a>
-</h2>
+Z::operator bool</h2>
 <div>
 <p>Conversion to <code>bool</code></p>
 </div>
@@ -213,8 +204,7 @@ The object converted to <code>bool</code>
 <div>
 <div>
 <h2 id="Z-operator_not">
-Z::operator!<a class="mrdocs-anchor" href="#Z-operator_not" aria-label="Permalink">#</a>
-</h2>
+Z::operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -236,8 +226,7 @@ Return Value</h3>
 <div>
 <div>
 <h2 id="Z-operator_eq">
-Z::operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#Z-operator_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -277,8 +266,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_not_eq">
-Z::operator!&#x3D;<a class="mrdocs-anchor" href="#Z-operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>
@@ -318,8 +306,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_3way">
-Z::operator&lt;&#x3D;&gt;<a class="mrdocs-anchor" href="#Z-operator_3way" aria-label="Permalink">#</a>
-</h2>
+Z::operator&lt;&#x3D;&gt;</h2>
 <div>
 <p>Three-way comparison operator</p>
 </div>

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.html
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -57,8 +56,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="D">
-D<a class="mrdocs-anchor" href="#D" aria-label="Permalink">#</a>
-</h2>
+D</h2>
 </div>
 <div>
 <h3>
@@ -73,8 +71,7 @@ Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C-0f">
-C<a class="mrdocs-anchor" href="#C-0f" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +89,7 @@ struct C;</code></pre>
 <div>
 <div>
 <h2 id="C-0d">
-C&lt;int, char&gt;<a class="mrdocs-anchor" href="#C-0d" aria-label="Permalink">#</a>
-</h2>
+C&lt;int, char&gt;</h2>
 </div>
 <div>
 <h3>
@@ -109,8 +105,7 @@ struct <a href="#C-0f">C</a>&lt;int, char&gt;;</code></pre>
 <div>
 <div>
 <h2 id="C-03">
-C&lt;int&gt;<a class="mrdocs-anchor" href="#C-03" aria-label="Permalink">#</a>
-</h2>
+C&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -126,8 +121,7 @@ struct <a href="#C-0f">C</a>&lt;int&gt;;</code></pre>
 <div>
 <div>
 <h2 id="B-0b">
-B<a class="mrdocs-anchor" href="#B-0b" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -145,8 +139,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="B-04">
-B&lt;int, char&gt;<a class="mrdocs-anchor" href="#B-04" aria-label="Permalink">#</a>
-</h2>
+B&lt;int, char&gt;</h2>
 </div>
 <div>
 <h3>
@@ -162,8 +155,7 @@ struct <a href="#B-0b">B</a>&lt;int, char&gt;;</code></pre>
 <div>
 <div>
 <h2 id="B-05">
-B&lt;int, U&gt;<a class="mrdocs-anchor" href="#B-05" aria-label="Permalink">#</a>
-</h2>
+B&lt;int, U&gt;</h2>
 </div>
 <div>
 <h3>
@@ -179,8 +171,7 @@ struct <a href="#B-0b">B</a>&lt;int, U&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -212,8 +203,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="Z">
-Z<a class="mrdocs-anchor" href="#Z" aria-label="Permalink">#</a>
-</h2>
+Z</h2>
 </div>
 <div>
 <h3>
@@ -249,8 +239,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="Z-2constructor-00">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-00" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -273,8 +262,7 @@ Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-05">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-05" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -290,8 +278,7 @@ Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-06">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-06" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Construct from <code>int</code></p>
 </div>
@@ -325,8 +312,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-2destructor">
-Z::~Z<a class="mrdocs-anchor" href="#Z-2destructor" aria-label="Permalink">#</a>
-</h2>
+Z::~Z</h2>
 <div>
 <p>Destructor</p>
 </div>
@@ -342,8 +328,7 @@ Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-foo">
-Z::foo<a class="mrdocs-anchor" href="#Z-foo" aria-label="Permalink">#</a>
-</h2>
+Z::foo</h2>
 </div>
 <div>
 <h3>
@@ -357,8 +342,7 @@ foo() const;</code></pre>
 <div>
 <div>
 <h2 id="Z-2conversion">
-Z::operator bool<a class="mrdocs-anchor" href="#Z-2conversion" aria-label="Permalink">#</a>
-</h2>
+Z::operator bool</h2>
 <div>
 <p>Conversion to <code>bool</code></p>
 </div>
@@ -379,8 +363,7 @@ The object converted to <code>bool</code>
 <div>
 <div>
 <h2 id="Z-operator_not">
-Z::operator!<a class="mrdocs-anchor" href="#Z-operator_not" aria-label="Permalink">#</a>
-</h2>
+Z::operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -402,8 +385,7 @@ Return Value</h3>
 <div>
 <div>
 <h2 id="Z-operator_eq">
-Z::operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#Z-operator_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -443,8 +425,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_not_eq">
-Z::operator!&#x3D;<a class="mrdocs-anchor" href="#Z-operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>
@@ -484,8 +465,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_3way">
-Z::operator&lt;&#x3D;&gt;<a class="mrdocs-anchor" href="#Z-operator_3way" aria-label="Permalink">#</a>
-</h2>
+Z::operator&lt;&#x3D;&gt;</h2>
 <div>
 <p>Three-way comparison operator</p>
 </div>
@@ -525,8 +505,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="h">
-h<a class="mrdocs-anchor" href="#h" aria-label="Permalink">#</a>
-</h2>
+h</h2>
 </div>
 <div>
 <h3>
@@ -540,8 +519,7 @@ h();</code></pre>
 <div>
 <div>
 <h2 id="g-0f">
-g<a class="mrdocs-anchor" href="#g-0f" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -601,8 +579,7 @@ char
 <div>
 <div>
 <h2 id="g-03c">
-g<a class="mrdocs-anchor" href="#g-03c" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -620,8 +597,7 @@ g(
 <div>
 <div>
 <h2 id="g-0e4">
-g&lt;int&gt;<a class="mrdocs-anchor" href="#g-0e4" aria-label="Permalink">#</a>
-</h2>
+g&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -639,8 +615,7 @@ char
 <div>
 <div>
 <h2 id="g-0a">
-g<a class="mrdocs-anchor" href="#g-0a" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -657,8 +632,7 @@ g(
 <div>
 <div>
 <h2 id="g-03a">
-g<a class="mrdocs-anchor" href="#g-03a" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -674,8 +648,7 @@ g(
 <div>
 <div>
 <h2 id="g-06">
-g<a class="mrdocs-anchor" href="#g-06" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -689,8 +662,7 @@ g(double);</code></pre>
 <div>
 <div>
 <h2 id="g-04">
-g<a class="mrdocs-anchor" href="#g-04" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -704,8 +676,7 @@ g(int);</code></pre>
 <div>
 <div>
 <h2 id="g-0e3">
-g<a class="mrdocs-anchor" href="#g-0e3" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -719,8 +690,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -734,8 +704,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="operator_not">
-operator!<a class="mrdocs-anchor" href="#operator_not" aria-label="Permalink">#</a>
-</h2>
+operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -775,8 +744,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_eq">
-operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#operator_eq" aria-label="Permalink">#</a>
-</h2>
+operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -822,8 +790,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_not_eq">
-operator!&#x3D;<a class="mrdocs-anchor" href="#operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.html
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -57,8 +56,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -90,8 +88,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="B-0b">
-B<a class="mrdocs-anchor" href="#B-0b" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -109,8 +106,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="B-04">
-B&lt;int, char&gt;<a class="mrdocs-anchor" href="#B-04" aria-label="Permalink">#</a>
-</h2>
+B&lt;int, char&gt;</h2>
 </div>
 <div>
 <h3>
@@ -126,8 +122,7 @@ struct <a href="#B-0b">B</a>&lt;int, char&gt;;</code></pre>
 <div>
 <div>
 <h2 id="B-05">
-B&lt;int, U&gt;<a class="mrdocs-anchor" href="#B-05" aria-label="Permalink">#</a>
-</h2>
+B&lt;int, U&gt;</h2>
 </div>
 <div>
 <h3>
@@ -143,8 +138,7 @@ struct <a href="#B-0b">B</a>&lt;int, U&gt;;</code></pre>
 <div>
 <div>
 <h2 id="C-0f">
-C<a class="mrdocs-anchor" href="#C-0f" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>
@@ -162,8 +156,7 @@ struct C;</code></pre>
 <div>
 <div>
 <h2 id="C-03">
-C&lt;int&gt;<a class="mrdocs-anchor" href="#C-03" aria-label="Permalink">#</a>
-</h2>
+C&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -179,8 +172,7 @@ struct <a href="#C-0f">C</a>&lt;int&gt;;</code></pre>
 <div>
 <div>
 <h2 id="C-0d">
-C&lt;int, char&gt;<a class="mrdocs-anchor" href="#C-0d" aria-label="Permalink">#</a>
-</h2>
+C&lt;int, char&gt;</h2>
 </div>
 <div>
 <h3>
@@ -196,8 +188,7 @@ struct <a href="#C-0f">C</a>&lt;int, char&gt;;</code></pre>
 <div>
 <div>
 <h2 id="D">
-D<a class="mrdocs-anchor" href="#D" aria-label="Permalink">#</a>
-</h2>
+D</h2>
 </div>
 <div>
 <h3>
@@ -212,8 +203,7 @@ Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z">
-Z<a class="mrdocs-anchor" href="#Z" aria-label="Permalink">#</a>
-</h2>
+Z</h2>
 </div>
 <div>
 <h3>
@@ -249,8 +239,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="Z-2constructor-00">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-00" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -273,8 +262,7 @@ Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-05">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-05" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -290,8 +278,7 @@ Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-06">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-06" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Construct from <code>int</code></p>
 </div>
@@ -325,8 +312,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-2destructor">
-Z::~Z<a class="mrdocs-anchor" href="#Z-2destructor" aria-label="Permalink">#</a>
-</h2>
+Z::~Z</h2>
 <div>
 <p>Destructor</p>
 </div>
@@ -342,8 +328,7 @@ Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-foo">
-Z::foo<a class="mrdocs-anchor" href="#Z-foo" aria-label="Permalink">#</a>
-</h2>
+Z::foo</h2>
 </div>
 <div>
 <h3>
@@ -357,8 +342,7 @@ foo() const;</code></pre>
 <div>
 <div>
 <h2 id="Z-2conversion">
-Z::operator bool<a class="mrdocs-anchor" href="#Z-2conversion" aria-label="Permalink">#</a>
-</h2>
+Z::operator bool</h2>
 <div>
 <p>Conversion to <code>bool</code></p>
 </div>
@@ -379,8 +363,7 @@ The object converted to <code>bool</code>
 <div>
 <div>
 <h2 id="Z-operator_not">
-Z::operator!<a class="mrdocs-anchor" href="#Z-operator_not" aria-label="Permalink">#</a>
-</h2>
+Z::operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -402,8 +385,7 @@ Return Value</h3>
 <div>
 <div>
 <h2 id="Z-operator_eq">
-Z::operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#Z-operator_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -443,8 +425,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_not_eq">
-Z::operator!&#x3D;<a class="mrdocs-anchor" href="#Z-operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>
@@ -484,8 +465,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_3way">
-Z::operator&lt;&#x3D;&gt;<a class="mrdocs-anchor" href="#Z-operator_3way" aria-label="Permalink">#</a>
-</h2>
+Z::operator&lt;&#x3D;&gt;</h2>
 <div>
 <p>Three-way comparison operator</p>
 </div>
@@ -525,8 +505,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -540,8 +519,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="g-0f">
-g<a class="mrdocs-anchor" href="#g-0f" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -601,8 +579,7 @@ char
 <div>
 <div>
 <h2 id="g-0e3">
-g<a class="mrdocs-anchor" href="#g-0e3" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -616,8 +593,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="g-04">
-g<a class="mrdocs-anchor" href="#g-04" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -631,8 +607,7 @@ g(int);</code></pre>
 <div>
 <div>
 <h2 id="g-06">
-g<a class="mrdocs-anchor" href="#g-06" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -646,8 +621,7 @@ g(double);</code></pre>
 <div>
 <div>
 <h2 id="g-03a">
-g<a class="mrdocs-anchor" href="#g-03a" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -663,8 +637,7 @@ g(
 <div>
 <div>
 <h2 id="g-0a">
-g<a class="mrdocs-anchor" href="#g-0a" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -681,8 +654,7 @@ g(
 <div>
 <div>
 <h2 id="g-03c">
-g<a class="mrdocs-anchor" href="#g-03c" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -700,8 +672,7 @@ g(
 <div>
 <div>
 <h2 id="g-0e4">
-g&lt;int&gt;<a class="mrdocs-anchor" href="#g-0e4" aria-label="Permalink">#</a>
-</h2>
+g&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -719,8 +690,7 @@ char
 <div>
 <div>
 <h2 id="h">
-h<a class="mrdocs-anchor" href="#h" aria-label="Permalink">#</a>
-</h2>
+h</h2>
 </div>
 <div>
 <h3>
@@ -734,8 +704,7 @@ h();</code></pre>
 <div>
 <div>
 <h2 id="operator_not">
-operator!<a class="mrdocs-anchor" href="#operator_not" aria-label="Permalink">#</a>
-</h2>
+operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -775,8 +744,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_eq">
-operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#operator_eq" aria-label="Permalink">#</a>
-</h2>
+operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -822,8 +790,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_not_eq">
-operator!&#x3D;<a class="mrdocs-anchor" href="#operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>

--- a/test-files/golden-tests/config/sort/sort-members.html
+++ b/test-files/golden-tests/config/sort/sort-members.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -57,8 +56,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -90,8 +88,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="B-0b">
-B<a class="mrdocs-anchor" href="#B-0b" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -109,8 +106,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="B-04">
-B&lt;int, char&gt;<a class="mrdocs-anchor" href="#B-04" aria-label="Permalink">#</a>
-</h2>
+B&lt;int, char&gt;</h2>
 </div>
 <div>
 <h3>
@@ -126,8 +122,7 @@ struct <a href="#B-0b">B</a>&lt;int, char&gt;;</code></pre>
 <div>
 <div>
 <h2 id="B-05">
-B&lt;int, U&gt;<a class="mrdocs-anchor" href="#B-05" aria-label="Permalink">#</a>
-</h2>
+B&lt;int, U&gt;</h2>
 </div>
 <div>
 <h3>
@@ -143,8 +138,7 @@ struct <a href="#B-0b">B</a>&lt;int, U&gt;;</code></pre>
 <div>
 <div>
 <h2 id="C-0f">
-C<a class="mrdocs-anchor" href="#C-0f" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>
@@ -162,8 +156,7 @@ struct C;</code></pre>
 <div>
 <div>
 <h2 id="C-03">
-C&lt;int&gt;<a class="mrdocs-anchor" href="#C-03" aria-label="Permalink">#</a>
-</h2>
+C&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -179,8 +172,7 @@ struct <a href="#C-0f">C</a>&lt;int&gt;;</code></pre>
 <div>
 <div>
 <h2 id="C-0d">
-C&lt;int, char&gt;<a class="mrdocs-anchor" href="#C-0d" aria-label="Permalink">#</a>
-</h2>
+C&lt;int, char&gt;</h2>
 </div>
 <div>
 <h3>
@@ -196,8 +188,7 @@ struct <a href="#C-0f">C</a>&lt;int, char&gt;;</code></pre>
 <div>
 <div>
 <h2 id="D">
-D<a class="mrdocs-anchor" href="#D" aria-label="Permalink">#</a>
-</h2>
+D</h2>
 </div>
 <div>
 <h3>
@@ -212,8 +203,7 @@ Declared in <code>&lt;sort-members.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z">
-Z<a class="mrdocs-anchor" href="#Z" aria-label="Permalink">#</a>
-</h2>
+Z</h2>
 </div>
 <div>
 <h3>
@@ -249,8 +239,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="Z-2constructor-00">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-00" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -273,8 +262,7 @@ Declared in <code>&lt;sort-members.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-05">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-05" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -290,8 +278,7 @@ Declared in <code>&lt;sort-members.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-06">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-06" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Construct from <code>int</code></p>
 </div>
@@ -325,8 +312,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-2destructor">
-Z::~Z<a class="mrdocs-anchor" href="#Z-2destructor" aria-label="Permalink">#</a>
-</h2>
+Z::~Z</h2>
 <div>
 <p>Destructor</p>
 </div>
@@ -342,8 +328,7 @@ Declared in <code>&lt;sort-members.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-foo">
-Z::foo<a class="mrdocs-anchor" href="#Z-foo" aria-label="Permalink">#</a>
-</h2>
+Z::foo</h2>
 </div>
 <div>
 <h3>
@@ -357,8 +342,7 @@ foo() const;</code></pre>
 <div>
 <div>
 <h2 id="Z-2conversion">
-Z::operator bool<a class="mrdocs-anchor" href="#Z-2conversion" aria-label="Permalink">#</a>
-</h2>
+Z::operator bool</h2>
 <div>
 <p>Conversion to <code>bool</code></p>
 </div>
@@ -379,8 +363,7 @@ The object converted to <code>bool</code>
 <div>
 <div>
 <h2 id="Z-operator_not">
-Z::operator!<a class="mrdocs-anchor" href="#Z-operator_not" aria-label="Permalink">#</a>
-</h2>
+Z::operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -402,8 +385,7 @@ Return Value</h3>
 <div>
 <div>
 <h2 id="Z-operator_eq">
-Z::operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#Z-operator_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -443,8 +425,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_not_eq">
-Z::operator!&#x3D;<a class="mrdocs-anchor" href="#Z-operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>
@@ -484,8 +465,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_3way">
-Z::operator&lt;&#x3D;&gt;<a class="mrdocs-anchor" href="#Z-operator_3way" aria-label="Permalink">#</a>
-</h2>
+Z::operator&lt;&#x3D;&gt;</h2>
 <div>
 <p>Three-way comparison operator</p>
 </div>
@@ -525,8 +505,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -540,8 +519,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="g-0f">
-g<a class="mrdocs-anchor" href="#g-0f" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -601,8 +579,7 @@ char
 <div>
 <div>
 <h2 id="g-0e3">
-g<a class="mrdocs-anchor" href="#g-0e3" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -616,8 +593,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="g-04">
-g<a class="mrdocs-anchor" href="#g-04" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -631,8 +607,7 @@ g(int);</code></pre>
 <div>
 <div>
 <h2 id="g-06">
-g<a class="mrdocs-anchor" href="#g-06" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -646,8 +621,7 @@ g(double);</code></pre>
 <div>
 <div>
 <h2 id="g-03a">
-g<a class="mrdocs-anchor" href="#g-03a" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -663,8 +637,7 @@ g(
 <div>
 <div>
 <h2 id="g-0a">
-g<a class="mrdocs-anchor" href="#g-0a" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -681,8 +654,7 @@ g(
 <div>
 <div>
 <h2 id="g-03c">
-g<a class="mrdocs-anchor" href="#g-03c" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -700,8 +672,7 @@ g(
 <div>
 <div>
 <h2 id="g-0e4">
-g&lt;int&gt;<a class="mrdocs-anchor" href="#g-0e4" aria-label="Permalink">#</a>
-</h2>
+g&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -719,8 +690,7 @@ char
 <div>
 <div>
 <h2 id="h">
-h<a class="mrdocs-anchor" href="#h" aria-label="Permalink">#</a>
-</h2>
+h</h2>
 </div>
 <div>
 <h3>
@@ -734,8 +704,7 @@ h();</code></pre>
 <div>
 <div>
 <h2 id="operator_not">
-operator!<a class="mrdocs-anchor" href="#operator_not" aria-label="Permalink">#</a>
-</h2>
+operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -775,8 +744,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_eq">
-operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#operator_eq" aria-label="Permalink">#</a>
-</h2>
+operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -822,8 +790,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_not_eq">
-operator!&#x3D;<a class="mrdocs-anchor" href="#operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>

--- a/test-files/golden-tests/config/sort/unordered.html
+++ b/test-files/golden-tests/config/sort/unordered.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -57,8 +56,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="D">
-D<a class="mrdocs-anchor" href="#D" aria-label="Permalink">#</a>
-</h2>
+D</h2>
 </div>
 <div>
 <h3>
@@ -73,8 +71,7 @@ Declared in <code>&lt;unordered.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C-0f">
-C<a class="mrdocs-anchor" href="#C-0f" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +89,7 @@ struct C;</code></pre>
 <div>
 <div>
 <h2 id="C-0d">
-C&lt;int, char&gt;<a class="mrdocs-anchor" href="#C-0d" aria-label="Permalink">#</a>
-</h2>
+C&lt;int, char&gt;</h2>
 </div>
 <div>
 <h3>
@@ -109,8 +105,7 @@ struct <a href="#C-0f">C</a>&lt;int, char&gt;;</code></pre>
 <div>
 <div>
 <h2 id="C-03">
-C&lt;int&gt;<a class="mrdocs-anchor" href="#C-03" aria-label="Permalink">#</a>
-</h2>
+C&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -126,8 +121,7 @@ struct <a href="#C-0f">C</a>&lt;int&gt;;</code></pre>
 <div>
 <div>
 <h2 id="B-0b">
-B<a class="mrdocs-anchor" href="#B-0b" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -145,8 +139,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="B-04">
-B&lt;int, char&gt;<a class="mrdocs-anchor" href="#B-04" aria-label="Permalink">#</a>
-</h2>
+B&lt;int, char&gt;</h2>
 </div>
 <div>
 <h3>
@@ -162,8 +155,7 @@ struct <a href="#B-0b">B</a>&lt;int, char&gt;;</code></pre>
 <div>
 <div>
 <h2 id="B-05">
-B&lt;int, U&gt;<a class="mrdocs-anchor" href="#B-05" aria-label="Permalink">#</a>
-</h2>
+B&lt;int, U&gt;</h2>
 </div>
 <div>
 <h3>
@@ -179,8 +171,7 @@ struct <a href="#B-0b">B</a>&lt;int, U&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -212,8 +203,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="Z">
-Z<a class="mrdocs-anchor" href="#Z" aria-label="Permalink">#</a>
-</h2>
+Z</h2>
 </div>
 <div>
 <h3>
@@ -249,8 +239,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="Z-operator_3way">
-Z::operator&lt;&#x3D;&gt;<a class="mrdocs-anchor" href="#Z-operator_3way" aria-label="Permalink">#</a>
-</h2>
+Z::operator&lt;&#x3D;&gt;</h2>
 <div>
 <p>Three-way comparison operator</p>
 </div>
@@ -290,8 +279,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_not_eq">
-Z::operator!&#x3D;<a class="mrdocs-anchor" href="#Z-operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>
@@ -331,8 +319,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_eq">
-Z::operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#Z-operator_eq" aria-label="Permalink">#</a>
-</h2>
+Z::operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -372,8 +359,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Z-operator_not">
-Z::operator!<a class="mrdocs-anchor" href="#Z-operator_not" aria-label="Permalink">#</a>
-</h2>
+Z::operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -395,8 +381,7 @@ Return Value</h3>
 <div>
 <div>
 <h2 id="Z-2conversion">
-Z::operator bool<a class="mrdocs-anchor" href="#Z-2conversion" aria-label="Permalink">#</a>
-</h2>
+Z::operator bool</h2>
 <div>
 <p>Conversion to <code>bool</code></p>
 </div>
@@ -417,8 +402,7 @@ The object converted to <code>bool</code>
 <div>
 <div>
 <h2 id="Z-foo">
-Z::foo<a class="mrdocs-anchor" href="#Z-foo" aria-label="Permalink">#</a>
-</h2>
+Z::foo</h2>
 </div>
 <div>
 <h3>
@@ -432,8 +416,7 @@ foo() const;</code></pre>
 <div>
 <div>
 <h2 id="Z-2destructor">
-Z::~Z<a class="mrdocs-anchor" href="#Z-2destructor" aria-label="Permalink">#</a>
-</h2>
+Z::~Z</h2>
 <div>
 <p>Destructor</p>
 </div>
@@ -449,8 +432,7 @@ Declared in <code>&lt;unordered.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-00">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-00" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -473,8 +455,7 @@ Declared in <code>&lt;unordered.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-05">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-05" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -490,8 +471,7 @@ Declared in <code>&lt;unordered.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Z-2constructor-06">
-Z::Z<a class="mrdocs-anchor" href="#Z-2constructor-06" aria-label="Permalink">#</a>
-</h2>
+Z::Z</h2>
 <div>
 <p>Construct from <code>int</code></p>
 </div>
@@ -525,8 +505,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_not_eq">
-operator!&#x3D;<a class="mrdocs-anchor" href="#operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+operator!&#x3D;</h2>
 <div>
 <p>Inequality operator</p>
 </div>
@@ -572,8 +551,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_eq">
-operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#operator_eq" aria-label="Permalink">#</a>
-</h2>
+operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -619,8 +597,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_not">
-operator!<a class="mrdocs-anchor" href="#operator_not" aria-label="Permalink">#</a>
-</h2>
+operator!</h2>
 <div>
 <p>Negation operator</p>
 </div>
@@ -660,8 +637,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="h">
-h<a class="mrdocs-anchor" href="#h" aria-label="Permalink">#</a>
-</h2>
+h</h2>
 </div>
 <div>
 <h3>
@@ -675,8 +651,7 @@ h();</code></pre>
 <div>
 <div>
 <h2 id="g-0f">
-g<a class="mrdocs-anchor" href="#g-0f" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -736,8 +711,7 @@ char
 <div>
 <div>
 <h2 id="g-03c">
-g<a class="mrdocs-anchor" href="#g-03c" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -755,8 +729,7 @@ g(
 <div>
 <div>
 <h2 id="g-0e4">
-g&lt;int&gt;<a class="mrdocs-anchor" href="#g-0e4" aria-label="Permalink">#</a>
-</h2>
+g&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -774,8 +747,7 @@ char
 <div>
 <div>
 <h2 id="g-0a">
-g<a class="mrdocs-anchor" href="#g-0a" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -792,8 +764,7 @@ g(
 <div>
 <div>
 <h2 id="g-03a">
-g<a class="mrdocs-anchor" href="#g-03a" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -809,8 +780,7 @@ g(
 <div>
 <div>
 <h2 id="g-06">
-g<a class="mrdocs-anchor" href="#g-06" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -824,8 +794,7 @@ g(double);</code></pre>
 <div>
 <div>
 <h2 id="g-04">
-g<a class="mrdocs-anchor" href="#g-04" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -839,8 +808,7 @@ g(int);</code></pre>
 <div>
 <div>
 <h2 id="g-0e3">
-g<a class="mrdocs-anchor" href="#g-0e3" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -854,8 +822,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/config/stylesheets/default-inline.html
+++ b/test-files/golden-tests/config/stylesheets/default-inline.html
@@ -418,8 +418,7 @@ code.hljs{
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -439,8 +438,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="ns">
-ns<a class="mrdocs-anchor" href="#ns" aria-label="Permalink">#</a>
-</h2>
+ns</h2>
 </div>
 <h2>
 Types</h2>
@@ -460,8 +458,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="ns-Foo">
-ns::Foo<a class="mrdocs-anchor" href="#ns-Foo" aria-label="Permalink">#</a>
-</h2>
+ns::Foo</h2>
 <div>
 <p>Doc for Foo</p>
 </div>
@@ -483,6 +480,11 @@ Declared in <code>&lt;default-inline.cpp&gt;</code></div>
 </footer>
 <script>
 (function(){
+    // Enable anchor visibility (hidden by default for graceful degradation)
+    document.querySelectorAll("a.mrdocs-anchor").forEach(function(el){
+        el.style.visibility = "visible";
+    });
+    // Copy permalink URL to clipboard on anchor click
     document.addEventListener("click", function(e){
         var anchor = e.target.closest && e.target.closest("a.mrdocs-anchor");
         if (!anchor) return;

--- a/test-files/golden-tests/config/stylesheets/inline-custom.html
+++ b/test-files/golden-tests/config/stylesheets/inline-custom.html
@@ -19,8 +19,7 @@ body {
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -40,8 +39,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="ns">
-ns<a class="mrdocs-anchor" href="#ns" aria-label="Permalink">#</a>
-</h2>
+ns</h2>
 </div>
 <h2>
 Types</h2>
@@ -61,8 +59,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="ns-Styled">
-ns::Styled<a class="mrdocs-anchor" href="#ns-Styled" aria-label="Permalink">#</a>
-</h2>
+ns::Styled</h2>
 <div>
 <p>Custom style sample</p>
 </div>

--- a/test-files/golden-tests/config/stylesheets/remote-stylesheet.html
+++ b/test-files/golden-tests/config/stylesheets/remote-stylesheet.html
@@ -10,8 +10,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -31,8 +30,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="ns">
-ns<a class="mrdocs-anchor" href="#ns" aria-label="Permalink">#</a>
-</h2>
+ns</h2>
 </div>
 <h2>
 Types</h2>
@@ -52,8 +50,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="ns-RemoteStyled">
-ns::RemoteStyled<a class="mrdocs-anchor" href="#ns-RemoteStyled" aria-label="Permalink">#</a>
-</h2>
+ns::RemoteStyled</h2>
 <div>
 <p>Uses remote stylesheet</p>
 </div>

--- a/test-files/golden-tests/core/canonical-ordering/canonical_1.html
+++ b/test-files/golden-tests/core/canonical-ordering/canonical_1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -37,8 +36,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -53,8 +51,7 @@ Declared in <code>&lt;canonical_1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -69,8 +66,7 @@ Declared in <code>&lt;canonical_1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Ba">
-Ba<a class="mrdocs-anchor" href="#Ba" aria-label="Permalink">#</a>
-</h2>
+Ba</h2>
 </div>
 <div>
 <h3>
@@ -85,8 +81,7 @@ Declared in <code>&lt;canonical_1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Bx">
-Bx<a class="mrdocs-anchor" href="#Bx" aria-label="Permalink">#</a>
-</h2>
+Bx</h2>
 </div>
 <div>
 <h3>
@@ -101,8 +96,7 @@ Declared in <code>&lt;canonical_1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="a">
-a<a class="mrdocs-anchor" href="#a" aria-label="Permalink">#</a>
-</h2>
+a</h2>
 </div>
 <div>
 <h3>
@@ -117,8 +111,7 @@ Declared in <code>&lt;canonical_1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="b">
-b<a class="mrdocs-anchor" href="#b" aria-label="Permalink">#</a>
-</h2>
+b</h2>
 </div>
 <div>
 <h3>
@@ -133,8 +126,7 @@ Declared in <code>&lt;canonical_1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="bA">
-bA<a class="mrdocs-anchor" href="#bA" aria-label="Permalink">#</a>
-</h2>
+bA</h2>
 </div>
 <div>
 <h3>
@@ -149,8 +141,7 @@ Declared in <code>&lt;canonical_1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="ba">
-ba<a class="mrdocs-anchor" href="#ba" aria-label="Permalink">#</a>
-</h2>
+ba</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/core/empty.html
+++ b/test-files/golden-tests/core/empty.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 </div>
 

--- a/test-files/golden-tests/core/libcxx.html
+++ b/test-files/golden-tests/core/libcxx.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="sqrt">
-sqrt<a class="mrdocs-anchor" href="#sqrt" aria-label="Permalink">#</a>
-</h2>
+sqrt</h2>
 <div>
 <p>Computes the square root of an integral value.</p>
 </div>

--- a/test-files/golden-tests/core/utf-8.html
+++ b/test-files/golden-tests/core/utf-8.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="Христос_воскрес">
-Христос_воскрес<a class="mrdocs-anchor" href="#Христос_воскрес" aria-label="Permalink">#</a>
-</h2>
+Христос_воскрес</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/filters/file/exclude-self.html
+++ b/test-files/golden-tests/filters/file/exclude-self.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 </div>
 

--- a/test-files/golden-tests/filters/file/include-self.html
+++ b/test-files/golden-tests/filters/file/include-self.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -30,8 +29,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="TEST">
-TEST<a class="mrdocs-anchor" href="#TEST" aria-label="Permalink">#</a>
-</h2>
+TEST</h2>
 </div>
 <h2>
 Types</h2>
@@ -51,8 +49,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="TEST-SUCCESS">
-TEST::SUCCESS<a class="mrdocs-anchor" href="#TEST-SUCCESS" aria-label="Permalink">#</a>
-</h2>
+TEST::SUCCESS</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/filters/file/include-symlink.html
+++ b/test-files/golden-tests/filters/file/include-symlink.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>A brief.</p>
 </div>

--- a/test-files/golden-tests/filters/file/subdirectories.html
+++ b/test-files/golden-tests/filters/file/subdirectories.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>A brief.</p>
 </div>

--- a/test-files/golden-tests/filters/file/subdirectories2.html
+++ b/test-files/golden-tests/filters/file/subdirectories2.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>A brief.</p>
 </div>

--- a/test-files/golden-tests/filters/symbol-name/blacklist_0.html
+++ b/test-files/golden-tests/filters/symbol-name/blacklist_0.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -32,8 +31,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="N0">
-N0<a class="mrdocs-anchor" href="#N0" aria-label="Permalink">#</a>
-</h2>
+N0</h2>
 </div>
 <h2>
 Functions</h2>
@@ -53,8 +51,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N0-f0">
-N0::f0<a class="mrdocs-anchor" href="#N0-f0" aria-label="Permalink">#</a>
-</h2>
+N0::f0</h2>
 </div>
 <div>
 <h3>
@@ -68,8 +65,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="N4">
-N4<a class="mrdocs-anchor" href="#N4" aria-label="Permalink">#</a>
-</h2>
+N4</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -90,8 +86,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="N4-N5">
-N4::N5<a class="mrdocs-anchor" href="#N4-N5" aria-label="Permalink">#</a>
-</h2>
+N4::N5</h2>
 </div>
 <h2>
 Functions</h2>
@@ -111,8 +106,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N4-N5-f1">
-N4::N5::f1<a class="mrdocs-anchor" href="#N4-N5-f1" aria-label="Permalink">#</a>
-</h2>
+N4::N5::f1</h2>
 </div>
 <div>
 <h3>
@@ -126,8 +120,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="N4-N6">
-N4::N6<a class="mrdocs-anchor" href="#N4-N6" aria-label="Permalink">#</a>
-</h2>
+N4::N6</h2>
 </div>
 <h2>
 Functions</h2>
@@ -147,8 +140,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N4-N6-f1">
-N4::N6::f1<a class="mrdocs-anchor" href="#N4-N6-f1" aria-label="Permalink">#</a>
-</h2>
+N4::N6::f1</h2>
 </div>
 <div>
 <h3>
@@ -162,8 +154,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="N7">
-N7<a class="mrdocs-anchor" href="#N7" aria-label="Permalink">#</a>
-</h2>
+N7</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -183,8 +174,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="N7-N9">
-N7::N9<a class="mrdocs-anchor" href="#N7-N9" aria-label="Permalink">#</a>
-</h2>
+N7::N9</h2>
 </div>
 <h2>
 Functions</h2>
@@ -204,8 +194,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N7-N9-g0">
-N7::N9::g0<a class="mrdocs-anchor" href="#N7-N9-g0" aria-label="Permalink">#</a>
-</h2>
+N7::N9::g0</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/filters/symbol-name/excluded-base-class.html
+++ b/test-files/golden-tests/filters/symbol-name/excluded-base-class.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -30,8 +29,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Types</h2>
@@ -52,8 +50,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-D">
-A::D<a class="mrdocs-anchor" href="#A-D" aria-label="Permalink">#</a>
-</h2>
+A::D</h2>
 </div>
 <div>
 <h3>
@@ -101,8 +98,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-D-f">
-A::D::f<a class="mrdocs-anchor" href="#A-D-f" aria-label="Permalink">#</a>
-</h2>
+A::D::f</h2>
 </div>
 <div>
 <h3>
@@ -116,8 +112,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-D-g">
-A::D::g<a class="mrdocs-anchor" href="#A-D-g" aria-label="Permalink">#</a>
-</h2>
+A::D::g</h2>
 </div>
 <div>
 <h3>
@@ -132,8 +127,7 @@ g() override;</code></pre>
 <div>
 <div>
 <h2 id="A-D-h">
-A::D::h<a class="mrdocs-anchor" href="#A-D-h" aria-label="Permalink">#</a>
-</h2>
+A::D::h</h2>
 </div>
 <div>
 <h3>
@@ -148,8 +142,7 @@ h() override;</code></pre>
 <div>
 <div>
 <h2 id="A-D-i">
-A::D::i<a class="mrdocs-anchor" href="#A-D-i" aria-label="Permalink">#</a>
-</h2>
+A::D::i</h2>
 </div>
 <div>
 <h3>
@@ -163,8 +156,7 @@ i();</code></pre>
 <div>
 <div>
 <h2 id="A-E">
-A::E<a class="mrdocs-anchor" href="#A-E" aria-label="Permalink">#</a>
-</h2>
+A::E</h2>
 </div>
 <div>
 <h3>
@@ -212,8 +204,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-E-f">
-A::E::f<a class="mrdocs-anchor" href="#A-E-f" aria-label="Permalink">#</a>
-</h2>
+A::E::f</h2>
 </div>
 <div>
 <h3>
@@ -227,8 +218,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-E-g">
-A::E::g<a class="mrdocs-anchor" href="#A-E-g" aria-label="Permalink">#</a>
-</h2>
+A::E::g</h2>
 </div>
 <div>
 <h3>
@@ -243,8 +233,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="A-E-h">
-A::E::h<a class="mrdocs-anchor" href="#A-E-h" aria-label="Permalink">#</a>
-</h2>
+A::E::h</h2>
 </div>
 <div>
 <h3>
@@ -259,8 +248,7 @@ h() override;</code></pre>
 <div>
 <div>
 <h2 id="A-E-i">
-A::E::i<a class="mrdocs-anchor" href="#A-E-i" aria-label="Permalink">#</a>
-</h2>
+A::E::i</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/filters/symbol-name/excluded-namespace-alias.html
+++ b/test-files/golden-tests/filters/symbol-name/excluded-namespace-alias.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -30,8 +29,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -51,8 +49,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="B-U">
-B::U<a class="mrdocs-anchor" href="#B-U" aria-label="Permalink">#</a>
-</h2>
+B::U</h2>
 </div>
 <h2>
 Namespace Aliases</h2>
@@ -72,8 +69,7 @@ Namespace Aliases</h2>
 <div>
 <div>
 <h2 id="B-U-E">
-B::U::E<a class="mrdocs-anchor" href="#B-U-E" aria-label="Permalink">#</a>
-</h2>
+B::U::E</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/filters/symbol-name/extraction-mode.html
+++ b/test-files/golden-tests/filters/symbol-name/extraction-mode.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -79,8 +78,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="regular_ns">
-regular_ns<a class="mrdocs-anchor" href="#regular_ns" aria-label="Permalink">#</a>
-</h2>
+regular_ns</h2>
 <div>
 <p>A regular namespace with different filters for members</p>
 </div>
@@ -121,8 +119,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="regular_ns-regular">
-regular_ns::regular<a class="mrdocs-anchor" href="#regular_ns-regular" aria-label="Permalink">#</a>
-</h2>
+regular_ns::regular</h2>
 <div>
 <p>A symbol that passes the filters</p>
 </div>
@@ -174,8 +171,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="regular_ns-regular-also_regular">
-regular_ns::regular::also_regular<a class="mrdocs-anchor" href="#regular_ns-regular-also_regular" aria-label="Permalink">#</a>
-</h2>
+regular_ns::regular::also_regular</h2>
 <div>
 <p>Child of a regular symbol extracted as regular</p>
 </div>
@@ -207,8 +203,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="regular_ns-regular-also_regular-regular_as_well">
-regular_ns::regular::also_regular::regular_as_well<a class="mrdocs-anchor" href="#regular_ns-regular-also_regular-regular_as_well" aria-label="Permalink">#</a>
-</h2>
+regular_ns::regular::also_regular::regular_as_well</h2>
 <div>
 <p>Grandchild of a regular symbol extracted as regular</p>
 </div>
@@ -226,8 +221,7 @@ Declared in <code>&lt;extraction-mode.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="regular_ns-see_below">
-regular_ns::see_below<a class="mrdocs-anchor" href="#regular_ns-see_below" aria-label="Permalink">#</a>
-</h2>
+regular_ns::see_below</h2>
 <div>
 <p>A symbol that passes the see-below filter</p>
 </div>
@@ -250,8 +244,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="regular_ns-get_dependency">
-regular_ns::get_dependency<a class="mrdocs-anchor" href="#regular_ns-get_dependency" aria-label="Permalink">#</a>
-</h2>
+regular_ns::get_dependency</h2>
 <div>
 <p>A function to get an excluded symbol</p>
 </div>
@@ -273,8 +266,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="regular_ns-get_implementation_defined">
-regular_ns::get_implementation_defined<a class="mrdocs-anchor" href="#regular_ns-get_implementation_defined" aria-label="Permalink">#</a>
-</h2>
+regular_ns::get_implementation_defined</h2>
 <div>
 <p>A function to get an implementation-defined symbol</p>
 </div>
@@ -302,8 +294,7 @@ A symbol that passes the implementation-defined filter
 <div>
 <div>
 <h2 id="regular_ns-get_regular">
-regular_ns::get_regular<a class="mrdocs-anchor" href="#regular_ns-get_regular" aria-label="Permalink">#</a>
-</h2>
+regular_ns::get_regular</h2>
 <div>
 <p>A function to get a regular symbol</p>
 </div>
@@ -330,8 +321,7 @@ A symbol that passes the filters
 <div>
 <div>
 <h2 id="regular_ns-get_see_below">
-regular_ns::get_see_below<a class="mrdocs-anchor" href="#regular_ns-get_see_below" aria-label="Permalink">#</a>
-</h2>
+regular_ns::get_see_below</h2>
 <div>
 <p>A function to get a see-below symbol</p>
 </div>
@@ -358,8 +348,7 @@ A symbol that passes the see-below filter
 <div>
 <div>
 <h2 id="see_below_ns">
-see_below_ns<a class="mrdocs-anchor" href="#see_below_ns" aria-label="Permalink">#</a>
-</h2>
+see_below_ns</h2>
 <div>
 <p>A see-below namespace</p>
 </div>
@@ -404,8 +393,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="see_below_ns-regular">
-see_below_ns::regular<a class="mrdocs-anchor" href="#see_below_ns-regular" aria-label="Permalink">#</a>
-</h2>
+see_below_ns::regular</h2>
 <div>
 <p>Regular symbol in a see-below namespace</p>
 </div>
@@ -428,8 +416,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="see_below_ns-see_below">
-see_below_ns::see_below<a class="mrdocs-anchor" href="#see_below_ns-see_below" aria-label="Permalink">#</a>
-</h2>
+see_below_ns::see_below</h2>
 <div>
 <p>See-below symbol in a see-below namespace</p>
 </div>
@@ -452,8 +439,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="see_below_ns-get_dependency">
-see_below_ns::get_dependency<a class="mrdocs-anchor" href="#see_below_ns-get_dependency" aria-label="Permalink">#</a>
-</h2>
+see_below_ns::get_dependency</h2>
 <div>
 <p>A function to get a dependency symbol in a see-below namespace</p>
 </div>
@@ -476,8 +462,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="see_below_ns-get_implementation_defined">
-see_below_ns::get_implementation_defined<a class="mrdocs-anchor" href="#see_below_ns-get_implementation_defined" aria-label="Permalink">#</a>
-</h2>
+see_below_ns::get_implementation_defined</h2>
 <div>
 <p>A function to get an implementation-defined symbol in a see-below namespace</p>
 </div>
@@ -505,8 +490,7 @@ Implementation-defined symbol in a see-below namespace
 <div>
 <div>
 <h2 id="dependency_ns_alias">
-dependency_ns_alias<a class="mrdocs-anchor" href="#dependency_ns_alias" aria-label="Permalink">#</a>
-</h2>
+dependency_ns_alias</h2>
 <div>
 <p>Namespace alias to form the dependency on dependency_ns</p>
 </div>
@@ -522,8 +506,7 @@ Declared in <code>&lt;extraction-mode.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="implementation_defined_ns_alias">
-implementation_defined_ns_alias<a class="mrdocs-anchor" href="#implementation_defined_ns_alias" aria-label="Permalink">#</a>
-</h2>
+implementation_defined_ns_alias</h2>
 <div>
 <p>Namespace alias to form a dependency on the implementation-defined namespace</p>
 </div>
@@ -539,8 +522,7 @@ Declared in <code>&lt;extraction-mode.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="see_below_ns_alias">
-see_below_ns_alias<a class="mrdocs-anchor" href="#see_below_ns_alias" aria-label="Permalink">#</a>
-</h2>
+see_below_ns_alias</h2>
 <div>
 <p>Namespace alias to form a dependency on the see-below namespace</p>
 </div>
@@ -561,8 +543,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="regular">
-regular<a class="mrdocs-anchor" href="#regular" aria-label="Permalink">#</a>
-</h2>
+regular</h2>
 <div>
 <p>A regular symbol in the global namespace</p>
 </div>
@@ -614,8 +595,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="regular-also_regular">
-regular::also_regular<a class="mrdocs-anchor" href="#regular-also_regular" aria-label="Permalink">#</a>
-</h2>
+regular::also_regular</h2>
 <div>
 <p>Child of a regular symbol: should be traversed as usual</p>
 </div>
@@ -647,8 +627,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="regular-also_regular-regular_as_well">
-regular::also_regular::regular_as_well<a class="mrdocs-anchor" href="#regular-also_regular-regular_as_well" aria-label="Permalink">#</a>
-</h2>
+regular::also_regular::regular_as_well</h2>
 <div>
 <p>Grandchild of a regular symbol: should be traversed as usual</p>
 </div>
@@ -666,8 +645,7 @@ Declared in <code>&lt;extraction-mode.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="see_below">
-see_below<a class="mrdocs-anchor" href="#see_below" aria-label="Permalink">#</a>
-</h2>
+see_below</h2>
 <div>
 <p>A see-below symbol in the global namespace</p>
 </div>
@@ -691,8 +669,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="get_dependency">
-get_dependency<a class="mrdocs-anchor" href="#get_dependency" aria-label="Permalink">#</a>
-</h2>
+get_dependency</h2>
 <div>
 <p>A function to get a dependency symbol on the global namespace</p>
 </div>
@@ -714,8 +691,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="get_implementation_defined">
-get_implementation_defined<a class="mrdocs-anchor" href="#get_implementation_defined" aria-label="Permalink">#</a>
-</h2>
+get_implementation_defined</h2>
 <div>
 <p>A function to get an implementation-defined symbol in the global namespace</p>
 </div>
@@ -743,8 +719,7 @@ An implementation-defined symbol in the global namespace
 <div>
 <div>
 <h2 id="get_regular">
-get_regular<a class="mrdocs-anchor" href="#get_regular" aria-label="Permalink">#</a>
-</h2>
+get_regular</h2>
 <div>
 <p>A function to get a regular symbol in the global namespace</p>
 </div>
@@ -771,8 +746,7 @@ A regular symbol in the global namespace
 <div>
 <div>
 <h2 id="get_see_below">
-get_see_below<a class="mrdocs-anchor" href="#get_see_below" aria-label="Permalink">#</a>
-</h2>
+get_see_below</h2>
 <div>
 <p>A function to get a see-below symbol in the global namespace</p>
 </div>

--- a/test-files/golden-tests/filters/symbol-name/impl-defined-member.html
+++ b/test-files/golden-tests/filters/symbol-name/impl-defined-member.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -45,8 +44,7 @@ Variables</h2>
 <div>
 <div>
 <h2 id="regular">
-regular<a class="mrdocs-anchor" href="#regular" aria-label="Permalink">#</a>
-</h2>
+regular</h2>
 </div>
 <h2>
 Types</h2>
@@ -66,8 +64,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="regular-absolute_uri_rule_t">
-regular::absolute_uri_rule_t<a class="mrdocs-anchor" href="#regular-absolute_uri_rule_t" aria-label="Permalink">#</a>
-</h2>
+regular::absolute_uri_rule_t</h2>
 </div>
 <div>
 <h3>
@@ -82,8 +79,7 @@ Declared in <code>&lt;impl-defined-member.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="absolute_uri_rule">
-absolute_uri_rule<a class="mrdocs-anchor" href="#absolute_uri_rule" aria-label="Permalink">#</a>
-</h2>
+absolute_uri_rule</h2>
 </div>
 <div>
 <h3>
@@ -96,8 +92,7 @@ Declared in <code>&lt;impl-defined-member.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="regular_absolute_uri_rule">
-regular_absolute_uri_rule<a class="mrdocs-anchor" href="#regular_absolute_uri_rule" aria-label="Permalink">#</a>
-</h2>
+regular_absolute_uri_rule</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/filters/symbol-name/whitelist_0.html
+++ b/test-files/golden-tests/filters/symbol-name/whitelist_0.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -46,8 +45,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="N0">
-N0<a class="mrdocs-anchor" href="#N0" aria-label="Permalink">#</a>
-</h2>
+N0</h2>
 <div>
 <p>This namespace should extracted because it&#x27;s implied by <code>N0::f0_WL</code></p>
 </div>
@@ -70,8 +68,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N0-f0_WL">
-N0::f0_WL<a class="mrdocs-anchor" href="#N0-f0_WL" aria-label="Permalink">#</a>
-</h2>
+N0::f0_WL</h2>
 <div>
 <p>This function should be included because it matches <code>N0::f0_WL</code></p>
 </div>
@@ -88,8 +85,7 @@ f0_WL();</code></pre>
 <div>
 <div>
 <h2 id="N1">
-N1<a class="mrdocs-anchor" href="#N1" aria-label="Permalink">#</a>
-</h2>
+N1</h2>
 <div>
 <p>This namespace should extracted because it&#x27;s implied by <code>N1::N3_WL</code> and <code>N1::N4::f1_WL</code></p>
 </div>
@@ -113,8 +109,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="N1-N3_WL">
-N1::N3_WL<a class="mrdocs-anchor" href="#N1-N3_WL" aria-label="Permalink">#</a>
-</h2>
+N1::N3_WL</h2>
 <div>
 <p>This namespace should extracted because it&#x27;s explicitly included by <code>N1::N3_WL</code></p>
 </div>
@@ -137,8 +132,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N1-N3_WL-f1_WL">
-N1::N3_WL::f1_WL<a class="mrdocs-anchor" href="#N1-N3_WL-f1_WL" aria-label="Permalink">#</a>
-</h2>
+N1::N3_WL::f1_WL</h2>
 <div>
 <p>This function should extracted because the namespace <code>N1::N3_WL</code> is included as a literal.</p>
 </div>
@@ -155,8 +149,7 @@ f1_WL();</code></pre>
 <div>
 <div>
 <h2 id="N1-N4">
-N1::N4<a class="mrdocs-anchor" href="#N1-N4" aria-label="Permalink">#</a>
-</h2>
+N1::N4</h2>
 <div>
 <p>This namespace should extracted because it&#x27;s implied by <code>N1::N4::f1_WL</code></p>
 </div>
@@ -179,8 +172,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N1-N4-f1_WL">
-N1::N4::f1_WL<a class="mrdocs-anchor" href="#N1-N4-f1_WL" aria-label="Permalink">#</a>
-</h2>
+N1::N4::f1_WL</h2>
 <div>
 <p>This function should extracted because it matches <code>N1::N4::f1_WL</code></p>
 </div>
@@ -197,8 +189,7 @@ f1_WL();</code></pre>
 <div>
 <div>
 <h2 id="N5">
-N5<a class="mrdocs-anchor" href="#N5" aria-label="Permalink">#</a>
-</h2>
+N5</h2>
 <div>
 <p>This namespace should extracted because it&#x27;s implied by <code>N5::N6::*7</code></p>
 </div>
@@ -221,8 +212,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="N5-N6">
-N5::N6<a class="mrdocs-anchor" href="#N5-N6" aria-label="Permalink">#</a>
-</h2>
+N5::N6</h2>
 <div>
 <p>This namespace should extracted because it&#x27;s implied by <code>N5::N6::*7</code></p>
 </div>
@@ -246,8 +236,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="N5-N6-M7">
-N5::N6::M7<a class="mrdocs-anchor" href="#N5-N6-M7" aria-label="Permalink">#</a>
-</h2>
+N5::N6::M7</h2>
 <div>
 <p>This namespace should be included because it matches <code>N5::N6::*7</code></p>
 </div>
@@ -270,8 +259,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N5-N6-M7-f2_WL">
-N5::N6::M7::f2_WL<a class="mrdocs-anchor" href="#N5-N6-M7-f2_WL" aria-label="Permalink">#</a>
-</h2>
+N5::N6::M7::f2_WL</h2>
 <div>
 <p>This function should be included because it&#x27;s a member of <code>M7</code>, which matches <code>N5::N6::*7</code></p>
 </div>
@@ -288,8 +276,7 @@ f2_WL();</code></pre>
 <div>
 <div>
 <h2 id="N5-N6-N7">
-N5::N6::N7<a class="mrdocs-anchor" href="#N5-N6-N7" aria-label="Permalink">#</a>
-</h2>
+N5::N6::N7</h2>
 <div>
 <p>This namespace should be included because it matches <code>N5::N6::*7</code></p>
 </div>
@@ -312,8 +299,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N5-N6-N7-f2_WL">
-N5::N6::N7::f2_WL<a class="mrdocs-anchor" href="#N5-N6-N7-f2_WL" aria-label="Permalink">#</a>
-</h2>
+N5::N6::N7::f2_WL</h2>
 <div>
 <p>This function should be included because it&#x27;s a member of <code>N7</code>, which matches <code>N5::N6::*7</code></p>
 </div>
@@ -330,8 +316,7 @@ f2_WL();</code></pre>
 <div>
 <div>
 <h2 id="C">
-C<a class="mrdocs-anchor" href="#C" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 <div>
 <p>This namespace should be included because it strictly matches <code>C</code></p>
 </div>
@@ -377,8 +362,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="C-D">
-C::D<a class="mrdocs-anchor" href="#C-D" aria-label="Permalink">#</a>
-</h2>
+C::D</h2>
 <div>
 <p>This struct should be included because it&#x27;s a member of <code>C</code></p>
 </div>
@@ -410,8 +394,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="C-D-f1_WL">
-C::D::f1_WL<a class="mrdocs-anchor" href="#C-D-f1_WL" aria-label="Permalink">#</a>
-</h2>
+C::D::f1_WL</h2>
 <div>
 <p>This function should be included because it&#x27;s a member of <code>D</code></p>
 </div>
@@ -428,8 +411,7 @@ f1_WL();</code></pre>
 <div>
 <div>
 <h2 id="C-f0_WL">
-C::f0_WL<a class="mrdocs-anchor" href="#C-f0_WL" aria-label="Permalink">#</a>
-</h2>
+C::f0_WL</h2>
 <div>
 <p>This function should be included because it&#x27;s a member of <code>C</code></p>
 </div>

--- a/test-files/golden-tests/filters/symbol-type/nested-private-template.html
+++ b/test-files/golden-tests/filters/symbol-type/nested-private-template.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="range">
-range<a class="mrdocs-anchor" href="#range" aria-label="Permalink">#</a>
-</h2>
+range</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +60,7 @@ Private Types</h2>
 <div>
 <div>
 <h2 id="range-impl-0e">
-range::impl<a class="mrdocs-anchor" href="#range-impl-0e" aria-label="Permalink">#</a>
-</h2>
+range::impl</h2>
 </div>
 <div>
 <h3>
@@ -81,8 +78,7 @@ struct impl;</code></pre>
 <div>
 <div>
 <h2 id="range-impl-00">
-range::impl&lt;R, false&gt;<a class="mrdocs-anchor" href="#range-impl-00" aria-label="Permalink">#</a>
-</h2>
+range::impl&lt;R, false&gt;</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/javadoc/brief/brief-1.html
+++ b/test-files/golden-tests/javadoc/brief/brief-1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -31,8 +30,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f5">
-f5<a class="mrdocs-anchor" href="#f5" aria-label="Permalink">#</a>
-</h2>
+f5</h2>
 <div>
 <p>brief bold it continues to the line.</p>
 </div>
@@ -49,8 +47,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="f6">
-f6<a class="mrdocs-anchor" href="#f6" aria-label="Permalink">#</a>
-</h2>
+f6</h2>
 <div>
 <p>brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/brief/brief-2.html
+++ b/test-files/golden-tests/javadoc/brief/brief-2.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -35,8 +34,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>brief</p>
 </div>
@@ -53,8 +51,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 <div>
 <p>brief</p>
 </div>
@@ -71,8 +68,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 <div>
 <p>brief</p>
 </div>
@@ -89,8 +85,7 @@ f3();</code></pre>
 <div>
 <div>
 <h2 id="f4">
-f4<a class="mrdocs-anchor" href="#f4" aria-label="Permalink">#</a>
-</h2>
+f4</h2>
 <div>
 <p>brief x</p>
 </div>
@@ -112,8 +107,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="f5">
-f5<a class="mrdocs-anchor" href="#f5" aria-label="Permalink">#</a>
-</h2>
+f5</h2>
 <div>
 <p>brief</p>
 </div>
@@ -130,8 +124,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="f6">
-f6<a class="mrdocs-anchor" href="#f6" aria-label="Permalink">#</a>
-</h2>
+f6</h2>
 <div>
 <p>brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/brief/brief-3.html
+++ b/test-files/golden-tests/javadoc/brief/brief-3.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f-0c">
-f<a class="mrdocs-anchor" href="#f-0c" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p><code>f</code> overloads</p>
 </div>
@@ -66,8 +64,7 @@ Declared in <code>&lt;brief-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="f-06">
-f<a class="mrdocs-anchor" href="#f-06" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Integer overload.</p>
 </div>
@@ -89,8 +86,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="f-0f">
-f<a class="mrdocs-anchor" href="#f-0f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Integer overload.</p>
 </div>
@@ -107,8 +103,7 @@ f(double);</code></pre>
 <div>
 <div>
 <h2 id="f-07">
-f<a class="mrdocs-anchor" href="#f-07" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>C string overload.</p>
 </div>
@@ -130,8 +125,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="f-0b">
-f<a class="mrdocs-anchor" href="#f-0b" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>C string overload.</p>
 </div>

--- a/test-files/golden-tests/javadoc/brief/brief-4.html
+++ b/test-files/golden-tests/javadoc/brief/brief-4.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -33,8 +32,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 </div>
 <div>
 <h3>
@@ -48,8 +46,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 </div>
 <div>
 <h3>
@@ -63,8 +60,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 </div>
 <div>
 <h3>
@@ -78,8 +74,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/javadoc/brief/brief-5.html
+++ b/test-files/golden-tests/javadoc/brief/brief-5.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -35,8 +34,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 <div>
 <p>brief</p>
 </div>
@@ -53,8 +51,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 </div>
 <div>
 <h3>
@@ -68,8 +65,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 </div>
 <div>
 <h3>
@@ -83,8 +79,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 <div>
 <p>brief</p>
 </div>
@@ -101,8 +96,7 @@ f3();</code></pre>
 <div>
 <div>
 <h2 id="f4">
-f4<a class="mrdocs-anchor" href="#f4" aria-label="Permalink">#</a>
-</h2>
+f4</h2>
 <div>
 <p>brief</p>
 </div>
@@ -119,8 +113,7 @@ f4();</code></pre>
 <div>
 <div>
 <h2 id="f5">
-f5<a class="mrdocs-anchor" href="#f5" aria-label="Permalink">#</a>
-</h2>
+f5</h2>
 <div>
 <p>brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/brief/brief-6.html
+++ b/test-files/golden-tests/javadoc/brief/brief-6.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 <div>
 <p>brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/code/code.html
+++ b/test-files/golden-tests/javadoc/code/code.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/copybrief/copybrief.html
+++ b/test-files/golden-tests/javadoc/copybrief/copybrief.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -32,8 +31,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>brief1</p>
 </div>
@@ -50,8 +48,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 <div>
 <p>brief1</p>
 </div>
@@ -68,8 +65,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 <div>
 <p>brief1</p>
 </div>

--- a/test-files/golden-tests/javadoc/copydetails/copydetails.html
+++ b/test-files/golden-tests/javadoc/copydetails/copydetails.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -32,8 +31,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="dest">
-dest<a class="mrdocs-anchor" href="#dest" aria-label="Permalink">#</a>
-</h2>
+dest</h2>
 <div>
 <p>Destination doc function</p>
 </div>
@@ -131,8 +129,7 @@ See Also</h3>
 <div>
 <div>
 <h2 id="destOverride">
-destOverride<a class="mrdocs-anchor" href="#destOverride" aria-label="Permalink">#</a>
-</h2>
+destOverride</h2>
 <div>
 <p>Destination doc function</p>
 </div>
@@ -259,8 +256,7 @@ See Also</h3>
 <div>
 <div>
 <h2 id="source">
-source<a class="mrdocs-anchor" href="#source" aria-label="Permalink">#</a>
-</h2>
+source</h2>
 <div>
 <p>Source doc function</p>
 </div>

--- a/test-files/golden-tests/javadoc/copydoc/conversion.html
+++ b/test-files/golden-tests/javadoc/copydoc/conversion.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -32,8 +31,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -64,8 +62,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-operator_assign-04">
-A::operator&#x3D;<a class="mrdocs-anchor" href="#A-operator_assign-04" aria-label="Permalink">#</a>
-</h2>
+A::operator&#x3D;</h2>
 <div>
 <p>Convert a string to A</p>
 </div>
@@ -113,8 +110,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-operator_assign-08">
-A::operator&#x3D;<a class="mrdocs-anchor" href="#A-operator_assign-08" aria-label="Permalink">#</a>
-</h2>
+A::operator&#x3D;</h2>
 <div>
 <p>Convert a string to A</p>
 </div>
@@ -154,8 +150,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-operator_assign-00">
-A::operator&#x3D;<a class="mrdocs-anchor" href="#A-operator_assign-00" aria-label="Permalink">#</a>
-</h2>
+A::operator&#x3D;</h2>
 <div>
 <p>Convert a string to A</p>
 </div>
@@ -195,8 +190,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-2conversion-02">
-A::operator string_type<a class="mrdocs-anchor" href="#A-2conversion-02" aria-label="Permalink">#</a>
-</h2>
+A::operator string_type</h2>
 <div>
 <p>Convert A to a string</p>
 </div>
@@ -217,8 +211,7 @@ A string representation of A
 <div>
 <div>
 <h2 id="A-2conversion-00">
-A::operator string_view_type<a class="mrdocs-anchor" href="#A-2conversion-00" aria-label="Permalink">#</a>
-</h2>
+A::operator string_view_type</h2>
 <div>
 <p>Convert A to a string</p>
 </div>
@@ -239,8 +232,7 @@ A string representation of A
 <div>
 <div>
 <h2 id="string_type">
-string_type<a class="mrdocs-anchor" href="#string_type" aria-label="Permalink">#</a>
-</h2>
+string_type</h2>
 </div>
 <div>
 <h3>
@@ -255,8 +247,7 @@ Declared in <code>&lt;conversion.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="string_view_type">
-string_view_type<a class="mrdocs-anchor" href="#string_view_type" aria-label="Permalink">#</a>
-</h2>
+string_view_type</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/javadoc/copydoc/decay-params.html
+++ b/test-files/golden-tests/javadoc/copydoc/decay-params.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -31,8 +30,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="bar">
-bar<a class="mrdocs-anchor" href="#bar" aria-label="Permalink">#</a>
-</h2>
+bar</h2>
 <div>
 <p>Brief from <code>foo()</code></p>
 </div>
@@ -78,8 +76,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="foo-02">
-foo<a class="mrdocs-anchor" href="#foo-02" aria-label="Permalink">#</a>
-</h2>
+foo</h2>
 <div>
 <p><code>foo</code> overloads</p>
 </div>
@@ -133,8 +130,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="foo-0c">
-foo<a class="mrdocs-anchor" href="#foo-0c" aria-label="Permalink">#</a>
-</h2>
+foo</h2>
 <div>
 <p>We should not copy this doc</p>
 </div>
@@ -156,8 +152,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="foo-01">
-foo<a class="mrdocs-anchor" href="#foo-01" aria-label="Permalink">#</a>
-</h2>
+foo</h2>
 <div>
 <p>We should not copy this doc</p>
 </div>
@@ -197,8 +192,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="foo-0e">
-foo<a class="mrdocs-anchor" href="#foo-0e" aria-label="Permalink">#</a>
-</h2>
+foo</h2>
 <div>
 <p>Brief from <code>foo()</code></p>
 </div>

--- a/test-files/golden-tests/javadoc/copydoc/fundamental.html
+++ b/test-files/golden-tests/javadoc/copydoc/fundamental.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -32,8 +31,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f-0c">
-f<a class="mrdocs-anchor" href="#f-0c" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p><code>f</code> overloads</p>
 </div>
@@ -76,8 +74,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f-06">
-f<a class="mrdocs-anchor" href="#f-06" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Fail</p>
 </div>
@@ -112,8 +109,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f-04">
-f<a class="mrdocs-anchor" href="#f-04" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Brief</p>
 </div>
@@ -153,8 +149,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g">
-g<a class="mrdocs-anchor" href="#g" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 <div>
 <p>Brief</p>
 </div>
@@ -194,8 +189,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="h">
-h<a class="mrdocs-anchor" href="#h" aria-label="Permalink">#</a>
-</h2>
+h</h2>
 <div>
 <p>Brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/copydoc/no-param.html
+++ b/test-files/golden-tests/javadoc/copydoc/no-param.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -32,8 +31,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="copyFromNoParam">
-copyFromNoParam<a class="mrdocs-anchor" href="#copyFromNoParam" aria-label="Permalink">#</a>
-</h2>
+copyFromNoParam</h2>
 <div>
 <p>Brief from <code>foo()</code></p>
 </div>
@@ -62,8 +60,7 @@ A boolean value.
 <div>
 <div>
 <h2 id="copyfromOverloads">
-copyfromOverloads<a class="mrdocs-anchor" href="#copyfromOverloads" aria-label="Permalink">#</a>
-</h2>
+copyfromOverloads</h2>
 <div>
 <p>Brief from <code>foo()</code></p>
 </div>
@@ -91,8 +88,7 @@ A boolean value.
 <div>
 <div>
 <h2 id="foo-02">
-foo<a class="mrdocs-anchor" href="#foo-02" aria-label="Permalink">#</a>
-</h2>
+foo</h2>
 <div>
 <p>Brief from <code>foo()</code></p>
 </div>
@@ -142,8 +138,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="foo-0c">
-foo<a class="mrdocs-anchor" href="#foo-0c" aria-label="Permalink">#</a>
-</h2>
+foo</h2>
 <div>
 <p>Brief from <code>foo()</code></p>
 </div>
@@ -171,8 +166,7 @@ A boolean value.
 <div>
 <div>
 <h2 id="foo-0a">
-foo<a class="mrdocs-anchor" href="#foo-0a" aria-label="Permalink">#</a>
-</h2>
+foo</h2>
 <div>
 <p>Brief from <code>foo()</code></p>
 </div>

--- a/test-files/golden-tests/javadoc/copydoc/operator-param.html
+++ b/test-files/golden-tests/javadoc/copydoc/operator-param.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -60,8 +58,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-operator_call-08">
-A::operator()<a class="mrdocs-anchor" href="#A-operator_call-08" aria-label="Permalink">#</a>
-</h2>
+A::operator()</h2>
 <div>
 <p>Return true if ch is in the character set.</p>
 </div>
@@ -111,8 +108,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-operator_call-0f">
-A::operator()<a class="mrdocs-anchor" href="#A-operator_call-0f" aria-label="Permalink">#</a>
-</h2>
+A::operator()</h2>
 <div>
 <p>Return true if ch is in the character set.</p>
 </div>
@@ -158,8 +154,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-operator_call-0b">
-A::operator()<a class="mrdocs-anchor" href="#A-operator_call-0b" aria-label="Permalink">#</a>
-</h2>
+A::operator()</h2>
 <div>
 <p>Return true if ch is in the character set.</p>
 </div>

--- a/test-files/golden-tests/javadoc/copydoc/param-types.html
+++ b/test-files/golden-tests/javadoc/copydoc/param-types.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -74,8 +73,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="N">
-N<a class="mrdocs-anchor" href="#N" aria-label="Permalink">#</a>
-</h2>
+N</h2>
 <div>
 <p>Namespace to test qualified identifier parameters.</p>
 </div>
@@ -98,8 +96,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="N-M">
-N::M<a class="mrdocs-anchor" href="#N-M" aria-label="Permalink">#</a>
-</h2>
+N::M</h2>
 <div>
 <p>Namespace to test qualified identifier parameters.</p>
 </div>
@@ -122,8 +119,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="N-M-Q">
-N::M::Q<a class="mrdocs-anchor" href="#N-M-Q" aria-label="Permalink">#</a>
-</h2>
+N::M::Q</h2>
 <div>
 <p>Struct to test qualified identifier parameters.</p>
 </div>
@@ -156,8 +152,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>Struct to test explicit object member functions.</p>
 </div>
@@ -205,8 +200,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="A-f">
-A::f<a class="mrdocs-anchor" href="#A-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>Reference member function.</p>
 </div>
@@ -247,8 +241,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-g">
-A::g<a class="mrdocs-anchor" href="#A-g" aria-label="Permalink">#</a>
-</h2>
+A::g</h2>
 <div>
 <p>Reference member function.</p>
 </div>
@@ -294,8 +287,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="paramType">
-paramType<a class="mrdocs-anchor" href="#paramType" aria-label="Permalink">#</a>
-</h2>
+paramType</h2>
 <div>
 <p>Struct used to vary the parameter type.</p>
 </div>
@@ -337,8 +329,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="testEnum">
-testEnum<a class="mrdocs-anchor" href="#testEnum" aria-label="Permalink">#</a>
-</h2>
+testEnum</h2>
 </div>
 <div>
 <h3>
@@ -366,8 +357,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="f-0c7">
-f<a class="mrdocs-anchor" href="#f-0c7" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p><code>f</code> overloads</p>
 </div>
@@ -450,8 +440,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f-0b3">
-f<a class="mrdocs-anchor" href="#f-0b3" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Reference function.</p>
 </div>
@@ -473,8 +462,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="f-00">
-f<a class="mrdocs-anchor" href="#f-00" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Reference function.</p>
 </div>
@@ -515,8 +503,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f-08c">
-f<a class="mrdocs-anchor" href="#f-08c" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Reference function.</p>
 </div>
@@ -557,8 +544,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f-012">
-f<a class="mrdocs-anchor" href="#f-012" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Variadic function</p>
 </div>
@@ -599,8 +585,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f-0c1">
-f<a class="mrdocs-anchor" href="#f-0c1" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Non-variadic function</p>
 </div>
@@ -641,8 +626,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f-03">
-f<a class="mrdocs-anchor" href="#f-03" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>struct param function</p>
 </div>
@@ -683,8 +667,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f-04">
-f<a class="mrdocs-anchor" href="#f-04" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Decltype function</p>
 </div>
@@ -725,8 +708,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f-0b5">
-f<a class="mrdocs-anchor" href="#f-0b5" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>struct param function</p>
 </div>
@@ -767,8 +749,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f-010">
-f<a class="mrdocs-anchor" href="#f-010" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Enum param function</p>
 </div>
@@ -809,8 +790,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f-081">
-f<a class="mrdocs-anchor" href="#f-081" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Qualified identifier param function</p>
 </div>
@@ -851,8 +831,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g-0f">
-g<a class="mrdocs-anchor" href="#g-0f" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 <div>
 <p><code>g</code> overloads</p>
 </div>
@@ -926,8 +905,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g-05">
-g<a class="mrdocs-anchor" href="#g-05" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 <div>
 <p>struct param function</p>
 </div>
@@ -967,8 +945,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g-09c">
-g<a class="mrdocs-anchor" href="#g-09c" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 <div>
 <p>Qualified identifier param function</p>
 </div>
@@ -1008,8 +985,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g-0b">
-g<a class="mrdocs-anchor" href="#g-0b" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 <div>
 <p>Auto function</p>
 </div>
@@ -1049,8 +1025,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g-04c">
-g<a class="mrdocs-anchor" href="#g-04c" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 <div>
 <p>Enum param function</p>
 </div>
@@ -1090,8 +1065,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g-096">
-g<a class="mrdocs-anchor" href="#g-096" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 <div>
 <p>Variadic function</p>
 </div>
@@ -1131,8 +1105,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g-04a">
-g<a class="mrdocs-anchor" href="#g-04a" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 <div>
 <p>Non-variadic function</p>
 </div>
@@ -1172,8 +1145,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g-0c">
-g<a class="mrdocs-anchor" href="#g-0c" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 <div>
 <p>Decltype function</p>
 </div>

--- a/test-files/golden-tests/javadoc/copydoc/qualified.html
+++ b/test-files/golden-tests/javadoc/copydoc/qualified.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="N">
-N<a class="mrdocs-anchor" href="#N" aria-label="Permalink">#</a>
-</h2>
+N</h2>
 </div>
 <h2>
 Types</h2>
@@ -65,8 +63,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="N-A">
-N::A<a class="mrdocs-anchor" href="#N-A" aria-label="Permalink">#</a>
-</h2>
+N::A</h2>
 </div>
 <div>
 <h3>
@@ -111,8 +108,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="N-A-B">
-N::A::B<a class="mrdocs-anchor" href="#N-A-B" aria-label="Permalink">#</a>
-</h2>
+N::A::B</h2>
 </div>
 <div>
 <h3>
@@ -127,8 +123,7 @@ Declared in <code>&lt;qualified.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="N-A-f-05">
-N::A::f<a class="mrdocs-anchor" href="#N-A-f-05" aria-label="Permalink">#</a>
-</h2>
+N::A::f</h2>
 <div>
 <p>Reference function</p>
 </div>
@@ -201,8 +196,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-f-0a">
-N::A::f<a class="mrdocs-anchor" href="#N-A-f-0a" aria-label="Permalink">#</a>
-</h2>
+N::A::f</h2>
 <div>
 <p>Reference function</p>
 </div>
@@ -242,8 +236,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-f-0b">
-N::A::f<a class="mrdocs-anchor" href="#N-A-f-0b" aria-label="Permalink">#</a>
-</h2>
+N::A::f</h2>
 <div>
 <p>Reference function</p>
 </div>
@@ -283,8 +276,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-f-0e">
-N::A::f<a class="mrdocs-anchor" href="#N-A-f-0e" aria-label="Permalink">#</a>
-</h2>
+N::A::f</h2>
 <div>
 <p>Reference function</p>
 </div>
@@ -324,8 +316,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-f-00">
-N::A::f<a class="mrdocs-anchor" href="#N-A-f-00" aria-label="Permalink">#</a>
-</h2>
+N::A::f</h2>
 <div>
 <p>Reference function</p>
 </div>
@@ -365,8 +356,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-f-02">
-N::A::f<a class="mrdocs-anchor" href="#N-A-f-02" aria-label="Permalink">#</a>
-</h2>
+N::A::f</h2>
 <div>
 <p>Reference function</p>
 </div>
@@ -406,8 +396,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-f-092">
-N::A::f<a class="mrdocs-anchor" href="#N-A-f-092" aria-label="Permalink">#</a>
-</h2>
+N::A::f</h2>
 <div>
 <p>Reference function</p>
 </div>
@@ -447,8 +436,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-f-097">
-N::A::f<a class="mrdocs-anchor" href="#N-A-f-097" aria-label="Permalink">#</a>
-</h2>
+N::A::f</h2>
 <div>
 <p>Reference function</p>
 </div>
@@ -488,8 +476,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-f-07">
-N::A::f<a class="mrdocs-anchor" href="#N-A-f-07" aria-label="Permalink">#</a>
-</h2>
+N::A::f</h2>
 <div>
 <p>Reference function</p>
 </div>
@@ -529,8 +516,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-g-06e">
-N::A::g<a class="mrdocs-anchor" href="#N-A-g-06e" aria-label="Permalink">#</a>
-</h2>
+N::A::g</h2>
 <div>
 <p><code>g</code> overloads</p>
 </div>
@@ -573,8 +559,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-g-0a">
-N::A::g<a class="mrdocs-anchor" href="#N-A-g-0a" aria-label="Permalink">#</a>
-</h2>
+N::A::g</h2>
 <div>
 <p>Reference function</p>
 </div>
@@ -614,8 +599,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-g-06c">
-N::A::g<a class="mrdocs-anchor" href="#N-A-g-06c" aria-label="Permalink">#</a>
-</h2>
+N::A::g</h2>
 <div>
 <p>Fail</p>
 </div>
@@ -655,8 +639,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-h-05">
-N::A::h<a class="mrdocs-anchor" href="#N-A-h-05" aria-label="Permalink">#</a>
-</h2>
+N::A::h</h2>
 <div>
 <p><code>h</code> overloads</p>
 </div>
@@ -699,8 +682,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-h-0f">
-N::A::h<a class="mrdocs-anchor" href="#N-A-h-0f" aria-label="Permalink">#</a>
-</h2>
+N::A::h</h2>
 <div>
 <p>Reference function</p>
 </div>
@@ -740,8 +722,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="N-A-h-06">
-N::A::h<a class="mrdocs-anchor" href="#N-A-h-06" aria-label="Permalink">#</a>
-</h2>
+N::A::h</h2>
 <div>
 <p>Fail</p>
 </div>
@@ -781,8 +762,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="param_t">
-param_t<a class="mrdocs-anchor" href="#param_t" aria-label="Permalink">#</a>
-</h2>
+param_t</h2>
 <div>
 <p>Helper class for distinct parameter types</p>
 </div>

--- a/test-files/golden-tests/javadoc/copydoc/qualifiers.html
+++ b/test-files/golden-tests/javadoc/copydoc/qualifiers.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -79,8 +77,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-const_iterator">
-A::const_iterator<a class="mrdocs-anchor" href="#A-const_iterator" aria-label="Permalink">#</a>
-</h2>
+A::const_iterator</h2>
 </div>
 <div>
 <h3>
@@ -95,8 +92,7 @@ Declared in <code>&lt;qualifiers.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-iterator">
-A::iterator<a class="mrdocs-anchor" href="#A-iterator" aria-label="Permalink">#</a>
-</h2>
+A::iterator</h2>
 </div>
 <div>
 <h3>
@@ -111,8 +107,7 @@ Declared in <code>&lt;qualifiers.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-begin-03">
-A::begin<a class="mrdocs-anchor" href="#A-begin-03" aria-label="Permalink">#</a>
-</h2>
+A::begin</h2>
 <div>
 <p><code>begin</code> overloads</p>
 </div>
@@ -145,8 +140,7 @@ Return Value</h3>
 <div>
 <div>
 <h2 id="A-begin-06">
-A::begin<a class="mrdocs-anchor" href="#A-begin-06" aria-label="Permalink">#</a>
-</h2>
+A::begin</h2>
 <div>
 <p>Returns an iterator to the beginning</p>
 </div>
@@ -173,8 +167,7 @@ Iterator to the first element.
 <div>
 <div>
 <h2 id="A-begin-0c">
-A::begin<a class="mrdocs-anchor" href="#A-begin-0c" aria-label="Permalink">#</a>
-</h2>
+A::begin</h2>
 <div>
 <p>Return a const iterator to the beginning</p>
 </div>
@@ -201,8 +194,7 @@ Const iterator to the first element.
 <div>
 <div>
 <h2 id="A-cbegin">
-A::cbegin<a class="mrdocs-anchor" href="#A-cbegin" aria-label="Permalink">#</a>
-</h2>
+A::cbegin</h2>
 <div>
 <p>Return a const iterator to the beginning</p>
 </div>
@@ -229,8 +221,7 @@ Const iterator to the first element.
 <div>
 <div>
 <h2 id="A-crvalue">
-A::crvalue<a class="mrdocs-anchor" href="#A-crvalue" aria-label="Permalink">#</a>
-</h2>
+A::crvalue</h2>
 <div>
 <p>An const rvalue reference to A</p>
 </div>
@@ -252,8 +243,7 @@ A reference to A
 <div>
 <div>
 <h2 id="A-ref-05f">
-A::ref<a class="mrdocs-anchor" href="#A-ref-05f" aria-label="Permalink">#</a>
-</h2>
+A::ref</h2>
 <div>
 <p><code>ref</code> overloads</p>
 </div>
@@ -293,8 +283,7 @@ A reference to A
 <div>
 <div>
 <h2 id="A-ref-051">
-A::ref<a class="mrdocs-anchor" href="#A-ref-051" aria-label="Permalink">#</a>
-</h2>
+A::ref</h2>
 <div>
 <p>An lvalue reference to A</p>
 </div>
@@ -316,8 +305,7 @@ A reference to A
 <div>
 <div>
 <h2 id="A-ref-0e">
-A::ref<a class="mrdocs-anchor" href="#A-ref-0e" aria-label="Permalink">#</a>
-</h2>
+A::ref</h2>
 <div>
 <p>An rvalue reference to A</p>
 </div>
@@ -339,8 +327,7 @@ A reference to A
 <div>
 <div>
 <h2 id="A-ref-04">
-A::ref<a class="mrdocs-anchor" href="#A-ref-04" aria-label="Permalink">#</a>
-</h2>
+A::ref</h2>
 <div>
 <p>An const lvalue reference to A</p>
 </div>
@@ -362,8 +349,7 @@ A reference to A
 <div>
 <div>
 <h2 id="A-ref-07">
-A::ref<a class="mrdocs-anchor" href="#A-ref-07" aria-label="Permalink">#</a>
-</h2>
+A::ref</h2>
 <div>
 <p>An const rvalue reference to A</p>
 </div>
@@ -385,8 +371,7 @@ A reference to A
 <div>
 <div>
 <h2 id="A-rvalue">
-A::rvalue<a class="mrdocs-anchor" href="#A-rvalue" aria-label="Permalink">#</a>
-</h2>
+A::rvalue</h2>
 <div>
 <p>An rvalue reference to A</p>
 </div>

--- a/test-files/golden-tests/javadoc/copydoc/template-arguments.html
+++ b/test-files/golden-tests/javadoc/copydoc/template-arguments.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -30,8 +29,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Types</h2>
@@ -63,8 +61,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-BInt">
-A::BInt<a class="mrdocs-anchor" href="#A-BInt" aria-label="Permalink">#</a>
-</h2>
+A::BInt</h2>
 <div>
 <p>Specialization of B for int.</p>
 </div>
@@ -80,8 +77,7 @@ Declared in <code>&lt;template-arguments.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-BInt2">
-A::BInt2<a class="mrdocs-anchor" href="#A-BInt2" aria-label="Permalink">#</a>
-</h2>
+A::BInt2</h2>
 <div>
 <p>Specialization of B for int with value 2.</p>
 </div>
@@ -97,8 +93,7 @@ Declared in <code>&lt;template-arguments.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-B_t">
-A::B_t<a class="mrdocs-anchor" href="#A-B_t" aria-label="Permalink">#</a>
-</h2>
+A::B_t</h2>
 <div>
 <p>Main class template for B.</p>
 </div>
@@ -135,8 +130,7 @@ Template Parameters</h3>
 <div>
 <div>
 <h2 id="A-CDTrue">
-A::CDTrue<a class="mrdocs-anchor" href="#A-CDTrue" aria-label="Permalink">#</a>
-</h2>
+A::CDTrue</h2>
 <div>
 <p>Specialization of C for D with true.</p>
 </div>
@@ -152,8 +146,7 @@ Declared in <code>&lt;template-arguments.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-CIntTrue">
-A::CIntTrue<a class="mrdocs-anchor" href="#A-CIntTrue" aria-label="Permalink">#</a>
-</h2>
+A::CIntTrue</h2>
 <div>
 <p>Specialization of C for D with true.</p>
 </div>
@@ -169,8 +162,7 @@ Declared in <code>&lt;template-arguments.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-C_t">
-A::C_t<a class="mrdocs-anchor" href="#A-C_t" aria-label="Permalink">#</a>
-</h2>
+A::C_t</h2>
 <div>
 <p>Main class template for C.</p>
 </div>
@@ -207,8 +199,7 @@ Template Parameters</h3>
 <div>
 <div>
 <h2 id="A-B-08">
-A::B<a class="mrdocs-anchor" href="#A-B-08" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 <div>
 <p>Main class template for B.</p>
 </div>
@@ -251,8 +242,7 @@ Template Parameters</h3>
 <div>
 <div>
 <h2 id="A-B-09">
-A::B&lt;int&gt;<a class="mrdocs-anchor" href="#A-B-09" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;int&gt;</h2>
 <div>
 <p>Specialization of B for int.</p>
 </div>
@@ -271,8 +261,7 @@ struct <a href="#A-B-08">B</a>&lt;int&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-B-0c">
-A::B&lt;int, 2&gt;<a class="mrdocs-anchor" href="#A-B-0c" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;int, 2&gt;</h2>
 <div>
 <p>Specialization of B for int with value 2.</p>
 </div>
@@ -291,8 +280,7 @@ struct <a href="#A-B-08">B</a>&lt;int, 2&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-C-05">
-A::C<a class="mrdocs-anchor" href="#A-C-05" aria-label="Permalink">#</a>
-</h2>
+A::C</h2>
 <div>
 <p>Main class template for C.</p>
 </div>
@@ -335,8 +323,7 @@ Template Parameters</h3>
 <div>
 <div>
 <h2 id="A-C-0f">
-A::C&lt;D, true&gt;<a class="mrdocs-anchor" href="#A-C-0f" aria-label="Permalink">#</a>
-</h2>
+A::C&lt;D, true&gt;</h2>
 <div>
 <p>Specialization of C for D with true.</p>
 </div>
@@ -355,8 +342,7 @@ struct <a href="#A-C-05">C</a>&lt;<a href="#A-D">D</a>, true&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-C-0c">
-A::C&lt;int, true&gt;<a class="mrdocs-anchor" href="#A-C-0c" aria-label="Permalink">#</a>
-</h2>
+A::C&lt;int, true&gt;</h2>
 <div>
 <p>Specialization of C for int with true.</p>
 </div>
@@ -375,8 +361,7 @@ struct <a href="#A-C-05">C</a>&lt;int, true&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-D">
-A::D<a class="mrdocs-anchor" href="#A-D" aria-label="Permalink">#</a>
-</h2>
+A::D</h2>
 <div>
 <p>Helper struct D.</p>
 </div>

--- a/test-files/golden-tests/javadoc/inline/styled.html
+++ b/test-files/golden-tests/javadoc/inline/styled.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>Brief for A</p>
 </div>
@@ -69,8 +67,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-compare">
-A::compare<a class="mrdocs-anchor" href="#A-compare" aria-label="Permalink">#</a>
-</h2>
+A::compare</h2>
 <div>
 <p>Compare function</p>
 </div>

--- a/test-files/golden-tests/javadoc/link/link.html
+++ b/test-files/golden-tests/javadoc/link/link.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>A function with a link</p>
 </div>

--- a/test-files/golden-tests/javadoc/lists/li.html
+++ b/test-files/golden-tests/javadoc/lists/li.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>A function</p>
 </div>

--- a/test-files/golden-tests/javadoc/lists/listitem.html
+++ b/test-files/golden-tests/javadoc/lists/listitem.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -33,8 +32,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 </div>
 <div>
 <h3>
@@ -55,8 +53,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 </div>
 <div>
 <h3>
@@ -79,8 +76,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 <div>
 <p>brief</p>
 </div>
@@ -106,8 +102,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 <div>
 <p>brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/paragraph/par-1.html
+++ b/test-files/golden-tests/javadoc/paragraph/par-1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -33,8 +32,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>Brief</p>
 </div>
@@ -58,8 +56,7 @@ void f1();
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 <div>
 <p>Brief</p>
 </div>
@@ -83,8 +80,7 @@ void f2();
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 <div>
 <p>Brief</p>
 </div>
@@ -107,8 +103,7 @@ void f3();
 <div>
 <div>
 <h2 id="f4">
-f4<a class="mrdocs-anchor" href="#f4" aria-label="Permalink">#</a>
-</h2>
+f4</h2>
 <div>
 <p>Brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/paragraph/para-1.html
+++ b/test-files/golden-tests/javadoc/paragraph/para-1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -33,8 +32,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 </div>
 <div>
 <h3>
@@ -48,8 +46,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 </div>
 <div>
 <h3>
@@ -63,8 +60,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 </div>
 <div>
 <h3>
@@ -78,8 +74,7 @@ f3();</code></pre>
 <div>
 <div>
 <h2 id="f4">
-f4<a class="mrdocs-anchor" href="#f4" aria-label="Permalink">#</a>
-</h2>
+f4</h2>
 <div>
 <p>brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/paragraph/para-2.html
+++ b/test-files/golden-tests/javadoc/paragraph/para-2.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/paragraph/para-3.html
+++ b/test-files/golden-tests/javadoc/paragraph/para-3.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="my_function">
-my_function<a class="mrdocs-anchor" href="#my_function" aria-label="Permalink">#</a>
-</h2>
+my_function</h2>
 <div>
 <p>A function</p>
 </div>

--- a/test-files/golden-tests/javadoc/param/param-1.html
+++ b/test-files/golden-tests/javadoc/param/param-1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -34,8 +33,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 </div>
 <div>
 <h3>
@@ -67,8 +65,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 </div>
 <div>
 <h3>
@@ -100,8 +97,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 </div>
 <div>
 <h3>
@@ -133,8 +129,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 </div>
 <div>
 <h3>
@@ -166,8 +161,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="f4">
-f4<a class="mrdocs-anchor" href="#f4" aria-label="Permalink">#</a>
-</h2>
+f4</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/javadoc/param/param-direction.html
+++ b/test-files/golden-tests/javadoc/param/param-direction.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -39,8 +38,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -72,8 +70,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g">
-g<a class="mrdocs-anchor" href="#g" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -111,8 +108,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="h">
-h<a class="mrdocs-anchor" href="#h" aria-label="Permalink">#</a>
-</h2>
+h</h2>
 </div>
 <div>
 <h3>
@@ -150,8 +146,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="i">
-i<a class="mrdocs-anchor" href="#i" aria-label="Permalink">#</a>
-</h2>
+i</h2>
 </div>
 <div>
 <h3>
@@ -189,8 +184,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="j">
-j<a class="mrdocs-anchor" href="#j" aria-label="Permalink">#</a>
-</h2>
+j</h2>
 </div>
 <div>
 <h3>
@@ -228,8 +222,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="k">
-k<a class="mrdocs-anchor" href="#k" aria-label="Permalink">#</a>
-</h2>
+k</h2>
 </div>
 <div>
 <h3>
@@ -272,8 +265,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="l">
-l<a class="mrdocs-anchor" href="#l" aria-label="Permalink">#</a>
-</h2>
+l</h2>
 </div>
 <div>
 <h3>
@@ -317,8 +309,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="m">
-m<a class="mrdocs-anchor" href="#m" aria-label="Permalink">#</a>
-</h2>
+m</h2>
 </div>
 <div>
 <h3>
@@ -356,8 +347,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="n">
-n<a class="mrdocs-anchor" href="#n" aria-label="Permalink">#</a>
-</h2>
+n</h2>
 </div>
 <div>
 <h3>
@@ -389,8 +379,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="o">
-o<a class="mrdocs-anchor" href="#o" aria-label="Permalink">#</a>
-</h2>
+o</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/javadoc/param/param-duplicate.html
+++ b/test-files/golden-tests/javadoc/param/param-duplicate.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -35,8 +34,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 <div>
 <p>f0 brief</p>
 </div>
@@ -61,8 +59,7 @@ Return Value</h3>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>f1 brief</p>
 </div>
@@ -87,8 +84,7 @@ Return Value</h3>
 <div>
 <div>
 <h2 id="g0">
-g0<a class="mrdocs-anchor" href="#g0" aria-label="Permalink">#</a>
-</h2>
+g0</h2>
 <div>
 <p>g0 brief</p>
 </div>
@@ -127,8 +123,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g1">
-g1<a class="mrdocs-anchor" href="#g1" aria-label="Permalink">#</a>
-</h2>
+g1</h2>
 <div>
 <p>g1 brief</p>
 </div>
@@ -167,8 +162,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="h0">
-h0<a class="mrdocs-anchor" href="#h0" aria-label="Permalink">#</a>
-</h2>
+h0</h2>
 <div>
 <p>h0 brief</p>
 </div>
@@ -208,8 +202,7 @@ Template Parameters</h3>
 <div>
 <div>
 <h2 id="h1">
-h1<a class="mrdocs-anchor" href="#h1" aria-label="Permalink">#</a>
-</h2>
+h1</h2>
 <div>
 <p>h1 brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/param/param.html
+++ b/test-files/golden-tests/javadoc/param/param.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -33,8 +32,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -66,8 +64,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="g">
-g<a class="mrdocs-anchor" href="#g" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -105,8 +102,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="h">
-h<a class="mrdocs-anchor" href="#h" aria-label="Permalink">#</a>
-</h2>
+h</h2>
 </div>
 <div>
 <h3>
@@ -149,8 +145,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="i">
-i<a class="mrdocs-anchor" href="#i" aria-label="Permalink">#</a>
-</h2>
+i</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/javadoc/pre/pre-post.html
+++ b/test-files/golden-tests/javadoc/pre/pre-post.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/javadoc/ref/broken-ref.html
+++ b/test-files/golden-tests/javadoc/ref/broken-ref.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -31,8 +30,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 </div>
 <div>
 <h3>
@@ -46,8 +44,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>See <a href="#f0"><code>f0</code></a></p>
 </div>

--- a/test-files/golden-tests/javadoc/ref/parent_context.html
+++ b/test-files/golden-tests/javadoc/ref/parent_context.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -30,8 +29,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="boost">
-boost<a class="mrdocs-anchor" href="#boost" aria-label="Permalink">#</a>
-</h2>
+boost</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -51,8 +49,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="boost-openmethod">
-boost::openmethod<a class="mrdocs-anchor" href="#boost-openmethod" aria-label="Permalink">#</a>
-</h2>
+boost::openmethod</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -86,8 +83,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="boost-openmethod-policies">
-boost::openmethod::policies<a class="mrdocs-anchor" href="#boost-openmethod-policies" aria-label="Permalink">#</a>
-</h2>
+boost::openmethod::policies</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -107,8 +103,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="boost-openmethod-policies-runtime_checks">
-boost::openmethod::policies::runtime_checks<a class="mrdocs-anchor" href="#boost-openmethod-policies-runtime_checks" aria-label="Permalink">#</a>
-</h2>
+boost::openmethod::policies::runtime_checks</h2>
 </div>
 <h2>
 Types</h2>
@@ -128,8 +123,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="boost-openmethod-policies-runtime_checks-runtime_checks">
-boost::openmethod::policies::runtime_checks::runtime_checks<a class="mrdocs-anchor" href="#boost-openmethod-policies-runtime_checks-runtime_checks" aria-label="Permalink">#</a>
-</h2>
+boost::openmethod::policies::runtime_checks::runtime_checks</h2>
 <div>
 <p>Documentation with ref to final_virtual_ptr</p>
 </div>
@@ -152,8 +146,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="boost-openmethod-final_virtual_ptr-04">
-boost::openmethod::final_virtual_ptr<a class="mrdocs-anchor" href="#boost-openmethod-final_virtual_ptr-04" aria-label="Permalink">#</a>
-</h2>
+boost::openmethod::final_virtual_ptr</h2>
 </div>
 <div>
 <h3>
@@ -179,8 +172,7 @@ auto
 <div>
 <div>
 <h2 id="boost-openmethod-final_virtual_ptr-08">
-boost::openmethod::final_virtual_ptr<a class="mrdocs-anchor" href="#boost-openmethod-final_virtual_ptr-08" aria-label="Permalink">#</a>
-</h2>
+boost::openmethod::final_virtual_ptr</h2>
 </div>
 <div>
 <h3>
@@ -195,8 +187,7 @@ final_virtual_ptr(Arg&& obj);</code></pre>
 <div>
 <div>
 <h2 id="boost-openmethod-final_virtual_ptr-03">
-boost::openmethod::final_virtual_ptr<a class="mrdocs-anchor" href="#boost-openmethod-final_virtual_ptr-03" aria-label="Permalink">#</a>
-</h2>
+boost::openmethod::final_virtual_ptr</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/javadoc/ref/punctuation.html
+++ b/test-files/golden-tests/javadoc/ref/punctuation.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -32,8 +31,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 </div>
 <div>
 <h3>
@@ -47,8 +45,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +59,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 <div>
 <p>See <a href="#f0"><code>f0</code></a>, <a href="#f1"><code>f1</code></a>.</p>
 </div>

--- a/test-files/golden-tests/javadoc/ref/ref.html
+++ b/test-files/golden-tests/javadoc/ref/ref.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -60,8 +59,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Types</h2>
@@ -97,8 +95,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A-B">
-A::B<a class="mrdocs-anchor" href="#A-B" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 <div>
 <p>See <a href="#A-f1"><code>f1</code></a></p>
 </div>
@@ -137,8 +134,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-B-f2">
-A::B::f2<a class="mrdocs-anchor" href="#A-B-f2" aria-label="Permalink">#</a>
-</h2>
+A::B::f2</h2>
 </div>
 <div>
 <h3>
@@ -152,8 +148,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="A-C">
-A::C<a class="mrdocs-anchor" href="#A-C" aria-label="Permalink">#</a>
-</h2>
+A::C</h2>
 </div>
 <div>
 <h3>
@@ -199,8 +194,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="A-C-f3">
-A::C::f3<a class="mrdocs-anchor" href="#A-C-f3" aria-label="Permalink">#</a>
-</h2>
+A::C::f3</h2>
 </div>
 <div>
 <h3>
@@ -214,8 +208,7 @@ f3();</code></pre>
 <div>
 <div>
 <h2 id="A-C-f4">
-A::C::f4<a class="mrdocs-anchor" href="#A-C-f4" aria-label="Permalink">#</a>
-</h2>
+A::C::f4</h2>
 </div>
 <div>
 <h3>
@@ -229,8 +222,7 @@ f4();</code></pre>
 <div>
 <div>
 <h2 id="A-D">
-A::D<a class="mrdocs-anchor" href="#A-D" aria-label="Permalink">#</a>
-</h2>
+A::D</h2>
 </div>
 <div>
 <h3>
@@ -290,8 +282,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-D-E">
-A::D::E<a class="mrdocs-anchor" href="#A-D-E" aria-label="Permalink">#</a>
-</h2>
+A::D::E</h2>
 <div>
 <p>See <a href="#A-C-f3"><code>f3</code></a></p>
 </div>
@@ -315,8 +306,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="A-D-f4">
-A::D::f4<a class="mrdocs-anchor" href="#A-D-f4" aria-label="Permalink">#</a>
-</h2>
+A::D::f4</h2>
 </div>
 <div>
 <h3>
@@ -330,8 +320,7 @@ f4();</code></pre>
 <div>
 <div>
 <h2 id="A-f1">
-A::f1<a class="mrdocs-anchor" href="#A-f1" aria-label="Permalink">#</a>
-</h2>
+A::f1</h2>
 <div>
 <p>See <a href="#f0"><code>f0</code></a></p>
 </div>
@@ -353,8 +342,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="F">
-F<a class="mrdocs-anchor" href="#F" aria-label="Permalink">#</a>
-</h2>
+F</h2>
 </div>
 <div>
 <h3>
@@ -421,8 +409,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="F-operator_assign">
-F::operator&#x3D;<a class="mrdocs-anchor" href="#F-operator_assign" aria-label="Permalink">#</a>
-</h2>
+F::operator&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -436,8 +423,7 @@ operator&#x3D;(<a href="#F">F</a>& other);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_mod">
-F::operator%<a class="mrdocs-anchor" href="#F-operator_mod" aria-label="Permalink">#</a>
-</h2>
+F::operator%</h2>
 </div>
 <div>
 <h3>
@@ -451,8 +437,7 @@ operator%(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_mod_eq">
-F::operator%&#x3D;<a class="mrdocs-anchor" href="#F-operator_mod_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator%&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -466,8 +451,7 @@ operator%&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_bitand">
-F::operator&amp;<a class="mrdocs-anchor" href="#F-operator_bitand" aria-label="Permalink">#</a>
-</h2>
+F::operator&amp;</h2>
 </div>
 <div>
 <h3>
@@ -481,8 +465,7 @@ operator&amp;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_and">
-F::operator&amp;&amp;<a class="mrdocs-anchor" href="#F-operator_and" aria-label="Permalink">#</a>
-</h2>
+F::operator&amp;&amp;</h2>
 </div>
 <div>
 <h3>
@@ -496,8 +479,7 @@ operator&amp;&amp;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_and_eq">
-F::operator&amp;&#x3D;<a class="mrdocs-anchor" href="#F-operator_and_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator&amp;&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -511,8 +493,7 @@ operator&amp;&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_call">
-F::operator()<a class="mrdocs-anchor" href="#F-operator_call" aria-label="Permalink">#</a>
-</h2>
+F::operator()</h2>
 </div>
 <div>
 <h3>
@@ -526,8 +507,7 @@ operator()(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_star">
-F::operator*<a class="mrdocs-anchor" href="#F-operator_star" aria-label="Permalink">#</a>
-</h2>
+F::operator*</h2>
 </div>
 <div>
 <h3>
@@ -541,8 +521,7 @@ operator*(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_star_eq">
-F::operator*&#x3D;<a class="mrdocs-anchor" href="#F-operator_star_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator*&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -556,8 +535,7 @@ operator*&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_plus">
-F::operator+<a class="mrdocs-anchor" href="#F-operator_plus" aria-label="Permalink">#</a>
-</h2>
+F::operator+</h2>
 </div>
 <div>
 <h3>
@@ -571,8 +549,7 @@ operator+(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_inc">
-F::operator++<a class="mrdocs-anchor" href="#F-operator_inc" aria-label="Permalink">#</a>
-</h2>
+F::operator++</h2>
 </div>
 <div>
 <h3>
@@ -586,8 +563,7 @@ operator++();</code></pre>
 <div>
 <div>
 <h2 id="F-operator_plus_eq">
-F::operator+&#x3D;<a class="mrdocs-anchor" href="#F-operator_plus_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator+&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -601,8 +577,7 @@ operator+&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_comma">
-F::operator,<a class="mrdocs-anchor" href="#F-operator_comma" aria-label="Permalink">#</a>
-</h2>
+F::operator,</h2>
 </div>
 <div>
 <h3>
@@ -616,8 +591,7 @@ operator,(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_minus">
-F::operator-<a class="mrdocs-anchor" href="#F-operator_minus" aria-label="Permalink">#</a>
-</h2>
+F::operator-</h2>
 </div>
 <div>
 <h3>
@@ -631,8 +605,7 @@ operator-(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_dec">
-F::operator--<a class="mrdocs-anchor" href="#F-operator_dec" aria-label="Permalink">#</a>
-</h2>
+F::operator--</h2>
 </div>
 <div>
 <h3>
@@ -646,8 +619,7 @@ operator--();</code></pre>
 <div>
 <div>
 <h2 id="F-operator_minus_eq">
-F::operator-&#x3D;<a class="mrdocs-anchor" href="#F-operator_minus_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator-&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -661,8 +633,7 @@ operator-&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_ptr">
-F::operator-&gt;<a class="mrdocs-anchor" href="#F-operator_ptr" aria-label="Permalink">#</a>
-</h2>
+F::operator-&gt;</h2>
 </div>
 <div>
 <h3>
@@ -676,8 +647,7 @@ operator-&gt;();</code></pre>
 <div>
 <div>
 <h2 id="F-operator_ptrmem">
-F::operator-&gt;*<a class="mrdocs-anchor" href="#F-operator_ptrmem" aria-label="Permalink">#</a>
-</h2>
+F::operator-&gt;*</h2>
 </div>
 <div>
 <h3>
@@ -691,8 +661,7 @@ operator-&gt;*(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_slash">
-F::operator/<a class="mrdocs-anchor" href="#F-operator_slash" aria-label="Permalink">#</a>
-</h2>
+F::operator/</h2>
 </div>
 <div>
 <h3>
@@ -706,8 +675,7 @@ operator/(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_slash_eq">
-F::operator/&#x3D;<a class="mrdocs-anchor" href="#F-operator_slash_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator/&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -721,8 +689,7 @@ operator/&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_lshift_eq">
-F::operator&lt;&lt;&#x3D;<a class="mrdocs-anchor" href="#F-operator_lshift_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator&lt;&lt;&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -736,8 +703,7 @@ operator&lt;&lt;&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_rshift">
-F::operator&gt;&gt;<a class="mrdocs-anchor" href="#F-operator_rshift" aria-label="Permalink">#</a>
-</h2>
+F::operator&gt;&gt;</h2>
 </div>
 <div>
 <h3>
@@ -751,8 +717,7 @@ operator&gt;&gt;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_rshift_eq">
-F::operator&gt;&gt;&#x3D;<a class="mrdocs-anchor" href="#F-operator_rshift_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator&gt;&gt;&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -766,8 +731,7 @@ operator&gt;&gt;&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_subs">
-F::operator[]<a class="mrdocs-anchor" href="#F-operator_subs" aria-label="Permalink">#</a>
-</h2>
+F::operator[]</h2>
 </div>
 <div>
 <h3>
@@ -781,8 +745,7 @@ operator[](<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_xor">
-F::operator^<a class="mrdocs-anchor" href="#F-operator_xor" aria-label="Permalink">#</a>
-</h2>
+F::operator^</h2>
 </div>
 <div>
 <h3>
@@ -796,8 +759,7 @@ operator^(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_xor_eq">
-F::operator^&#x3D;<a class="mrdocs-anchor" href="#F-operator_xor_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator^&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -811,8 +773,7 @@ operator^&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_bitor">
-F::operator|<a class="mrdocs-anchor" href="#F-operator_bitor" aria-label="Permalink">#</a>
-</h2>
+F::operator|</h2>
 </div>
 <div>
 <h3>
@@ -826,8 +787,7 @@ operator|(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_or_eq">
-F::operator|&#x3D;<a class="mrdocs-anchor" href="#F-operator_or_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator|&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -841,8 +801,7 @@ operator|&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_or">
-F::operator||<a class="mrdocs-anchor" href="#F-operator_or" aria-label="Permalink">#</a>
-</h2>
+F::operator||</h2>
 </div>
 <div>
 <h3>
@@ -856,8 +815,7 @@ operator||(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_bitnot">
-F::operator~<a class="mrdocs-anchor" href="#F-operator_bitnot" aria-label="Permalink">#</a>
-</h2>
+F::operator~</h2>
 </div>
 <div>
 <h3>
@@ -871,8 +829,7 @@ operator~();</code></pre>
 <div>
 <div>
 <h2 id="F-operator_lshift">
-F::operator&lt;&lt;<a class="mrdocs-anchor" href="#F-operator_lshift" aria-label="Permalink">#</a>
-</h2>
+F::operator&lt;&lt;</h2>
 </div>
 <div>
 <h3>
@@ -886,8 +843,7 @@ operator&lt;&lt;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_not">
-F::operator!<a class="mrdocs-anchor" href="#F-operator_not" aria-label="Permalink">#</a>
-</h2>
+F::operator!</h2>
 </div>
 <div>
 <h3>
@@ -901,8 +857,7 @@ operator!();</code></pre>
 <div>
 <div>
 <h2 id="F-operator_eq">
-F::operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#F-operator_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator&#x3D;&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -916,8 +871,7 @@ operator&#x3D;&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_not_eq">
-F::operator!&#x3D;<a class="mrdocs-anchor" href="#F-operator_not_eq" aria-label="Permalink">#</a>
-</h2>
+F::operator!&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -931,8 +885,7 @@ operator!&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_lt">
-F::operator&lt;<a class="mrdocs-anchor" href="#F-operator_lt" aria-label="Permalink">#</a>
-</h2>
+F::operator&lt;</h2>
 </div>
 <div>
 <h3>
@@ -946,8 +899,7 @@ operator&lt;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_le">
-F::operator&lt;&#x3D;<a class="mrdocs-anchor" href="#F-operator_le" aria-label="Permalink">#</a>
-</h2>
+F::operator&lt;&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -961,8 +913,7 @@ operator&lt;&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_gt">
-F::operator&gt;<a class="mrdocs-anchor" href="#F-operator_gt" aria-label="Permalink">#</a>
-</h2>
+F::operator&gt;</h2>
 </div>
 <div>
 <h3>
@@ -976,8 +927,7 @@ operator&gt;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_ge">
-F::operator&gt;&#x3D;<a class="mrdocs-anchor" href="#F-operator_ge" aria-label="Permalink">#</a>
-</h2>
+F::operator&gt;&#x3D;</h2>
 </div>
 <div>
 <h3>
@@ -991,8 +941,7 @@ operator&gt;&#x3D;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="F-operator_3way">
-F::operator&lt;&#x3D;&gt;<a class="mrdocs-anchor" href="#F-operator_3way" aria-label="Permalink">#</a>
-</h2>
+F::operator&lt;&#x3D;&gt;</h2>
 </div>
 <div>
 <h3>
@@ -1006,8 +955,7 @@ operator&lt;&#x3D;&gt;(<a href="#F">F</a>& rhs);</code></pre>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 </div>
 <div>
 <h3>
@@ -1021,8 +969,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="f5">
-f5<a class="mrdocs-anchor" href="#f5" aria-label="Permalink">#</a>
-</h2>
+f5</h2>
 <div>
 <p>See <a href="#A-f1"><code>A::f1</code></a></p>
 </div>
@@ -1044,8 +991,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="f6">
-f6<a class="mrdocs-anchor" href="#f6" aria-label="Permalink">#</a>
-</h2>
+f6</h2>
 <div>
 <p>See <a href="#F-operator_bitnot"><code>F::operator~</code></a></p>
 </div>

--- a/test-files/golden-tests/javadoc/relates/relates.html
+++ b/test-files/golden-tests/javadoc/relates/relates.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>A brief for A.</p>
 </div>
@@ -79,8 +77,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 <div>
 <p>A brief for B</p>
 </div>
@@ -98,8 +95,7 @@ Declared in <code>&lt;relates.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>A brief for f.</p>
 </div>

--- a/test-files/golden-tests/javadoc/returns/returns.html
+++ b/test-files/golden-tests/javadoc/returns/returns.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="pair">
-pair<a class="mrdocs-anchor" href="#pair" aria-label="Permalink">#</a>
-</h2>
+pair</h2>
 </div>
 <div>
 <h3>
@@ -94,8 +92,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="pair-first">
-pair::first<a class="mrdocs-anchor" href="#pair-first" aria-label="Permalink">#</a>
-</h2>
+pair::first</h2>
 </div>
 <div>
 <h3>
@@ -108,8 +105,7 @@ Declared in <code>&lt;returns.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="pair-second">
-pair::second<a class="mrdocs-anchor" href="#pair-second" aria-label="Permalink">#</a>
-</h2>
+pair::second</h2>
 </div>
 <div>
 <h3>
@@ -122,8 +118,7 @@ Declared in <code>&lt;returns.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>A function with a single return value.</p>
 </div>
@@ -145,8 +140,7 @@ The return value of the function.
 <div>
 <div>
 <h2 id="g">
-g<a class="mrdocs-anchor" href="#g" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 <div>
 <p>A function with multiple return values.</p>
 </div>

--- a/test-files/golden-tests/javadoc/throw/throw.html
+++ b/test-files/golden-tests/javadoc/throw/throw.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>brief</p>
 </div>

--- a/test-files/golden-tests/javadoc/tparam/tparam-1.html
+++ b/test-files/golden-tests/javadoc/tparam/tparam-1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -31,8 +30,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 </div>
 <div>
 <h3>
@@ -65,8 +63,7 @@ Template Parameters</h3>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>brief</p>
 </div>

--- a/test-files/golden-tests/snippets/distance.html
+++ b/test-files/golden-tests/snippets/distance.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="distance">
-distance<a class="mrdocs-anchor" href="#distance" aria-label="Permalink">#</a>
-</h2>
+distance</h2>
 <div>
 <p>Return the distance between two points</p>
 </div>

--- a/test-files/golden-tests/snippets/is_prime.html
+++ b/test-files/golden-tests/snippets/is_prime.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="is_prime">
-is_prime<a class="mrdocs-anchor" href="#is_prime" aria-label="Permalink">#</a>
-</h2>
+is_prime</h2>
 <div>
 <p>Return true if a number is prime.</p>
 </div>

--- a/test-files/golden-tests/snippets/sqrt.html
+++ b/test-files/golden-tests/snippets/sqrt.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="sqrt">
-sqrt<a class="mrdocs-anchor" href="#sqrt" aria-label="Permalink">#</a>
-</h2>
+sqrt</h2>
 <div>
 <p>Computes the square root of an integral value.</p>
 </div>

--- a/test-files/golden-tests/snippets/terminate.html
+++ b/test-files/golden-tests/snippets/terminate.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="terminate">
-terminate<a class="mrdocs-anchor" href="#terminate" aria-label="Permalink">#</a>
-</h2>
+terminate</h2>
 <div>
 <p>Exit the program.</p>
 </div>

--- a/test-files/golden-tests/symbols/concept/concept.html
+++ b/test-files/golden-tests/symbols/concept/concept.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -58,8 +57,7 @@ Concepts</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -74,8 +72,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="x">
-x<a class="mrdocs-anchor" href="#x" aria-label="Permalink">#</a>
-</h2>
+x</h2>
 </div>
 <div>
 <h3>
@@ -88,8 +85,7 @@ Declared in <code>&lt;concept.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C">
-C<a class="mrdocs-anchor" href="#C" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/concept/requires-clause.html
+++ b/test-files/golden-tests/symbols/concept/requires-clause.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -46,8 +45,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A-09">
-A<a class="mrdocs-anchor" href="#A-09" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -64,8 +62,7 @@ struct A;</code></pre>
 <div>
 <div>
 <h2 id="A-01">
-A<a class="mrdocs-anchor" href="#A-01" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -82,8 +79,7 @@ struct A;</code></pre>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -99,8 +95,7 @@ requires (sizeof(U) &#x3D;&#x3D; 2);</code></pre>
 <div>
 <div>
 <h2 id="g-0f49">
-g<a class="mrdocs-anchor" href="#g-0f49" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -133,8 +128,7 @@ void
 <div>
 <div>
 <h2 id="g-0d">
-g<a class="mrdocs-anchor" href="#g-0d" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -150,8 +144,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="g-0f4d">
-g<a class="mrdocs-anchor" href="#g-0f4d" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -167,8 +160,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="g-0b">
-g<a class="mrdocs-anchor" href="#g-0b" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/enum/enum.html
+++ b/test-files/golden-tests/symbols/enum/enum.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Enums</h2>
@@ -33,8 +32,7 @@ Enums</h2>
 <div>
 <div>
 <h2 id="E0">
-E0<a class="mrdocs-anchor" href="#E0" aria-label="Permalink">#</a>
-</h2>
+E0</h2>
 <div>
 <p>E0 brief.</p>
 </div>
@@ -70,8 +68,7 @@ Members</h2>
 <div>
 <div>
 <h2 id="E1">
-E1<a class="mrdocs-anchor" href="#E1" aria-label="Permalink">#</a>
-</h2>
+E1</h2>
 </div>
 <div>
 <h3>
@@ -99,8 +96,7 @@ Members</h2>
 <div>
 <div>
 <h2 id="E2">
-E2<a class="mrdocs-anchor" href="#E2" aria-label="Permalink">#</a>
-</h2>
+E2</h2>
 <div>
 <p>E2 brief.</p>
 </div>
@@ -136,8 +132,7 @@ Members</h2>
 <div>
 <div>
 <h2 id="E3">
-E3<a class="mrdocs-anchor" href="#E3" aria-label="Permalink">#</a>
-</h2>
+E3</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/attributes-2.html
+++ b/test-files/golden-tests/symbols/function/attributes-2.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/attributes_1.html
+++ b/test-files/golden-tests/symbols/function/attributes_1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/auto.html
+++ b/test-files/golden-tests/symbols/function/auto.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>A function that uses auto</p>
 </div>

--- a/test-files/golden-tests/symbols/function/explicit-conv-operator.html
+++ b/test-files/golden-tests/symbols/function/explicit-conv-operator.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -33,8 +32,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="Explicit">
-Explicit<a class="mrdocs-anchor" href="#Explicit" aria-label="Permalink">#</a>
-</h2>
+Explicit</h2>
 </div>
 <div>
 <h3>
@@ -63,8 +61,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="Explicit-2conversion">
-Explicit::operator bool<a class="mrdocs-anchor" href="#Explicit-2conversion" aria-label="Permalink">#</a>
-</h2>
+Explicit::operator bool</h2>
 <div>
 <p>Conversion to <code>bool</code></p>
 </div>
@@ -86,8 +83,7 @@ The object converted to <code>bool</code>
 <div>
 <div>
 <h2 id="ExplicitExpression">
-ExplicitExpression<a class="mrdocs-anchor" href="#ExplicitExpression" aria-label="Permalink">#</a>
-</h2>
+ExplicitExpression</h2>
 </div>
 <div>
 <h3>
@@ -117,8 +113,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="ExplicitExpression-2conversion">
-ExplicitExpression::operator bool<a class="mrdocs-anchor" href="#ExplicitExpression-2conversion" aria-label="Permalink">#</a>
-</h2>
+ExplicitExpression::operator bool</h2>
 <div>
 <p>Conversion to <code>bool</code></p>
 </div>
@@ -140,8 +135,7 @@ The object converted to <code>bool</code>
 <div>
 <div>
 <h2 id="ExplicitFalse">
-ExplicitFalse<a class="mrdocs-anchor" href="#ExplicitFalse" aria-label="Permalink">#</a>
-</h2>
+ExplicitFalse</h2>
 </div>
 <div>
 <h3>
@@ -170,8 +164,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="ExplicitFalse-2conversion">
-ExplicitFalse::operator bool<a class="mrdocs-anchor" href="#ExplicitFalse-2conversion" aria-label="Permalink">#</a>
-</h2>
+ExplicitFalse::operator bool</h2>
 <div>
 <p>Conversion to <code>bool</code></p>
 </div>
@@ -193,8 +186,7 @@ The object converted to <code>bool</code>
 <div>
 <div>
 <h2 id="ExplicitTrue">
-ExplicitTrue<a class="mrdocs-anchor" href="#ExplicitTrue" aria-label="Permalink">#</a>
-</h2>
+ExplicitTrue</h2>
 </div>
 <div>
 <h3>
@@ -223,8 +215,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="ExplicitTrue-2conversion">
-ExplicitTrue::operator bool<a class="mrdocs-anchor" href="#ExplicitTrue-2conversion" aria-label="Permalink">#</a>
-</h2>
+ExplicitTrue::operator bool</h2>
 <div>
 <p>Conversion to <code>bool</code></p>
 </div>

--- a/test-files/golden-tests/symbols/function/explicit-ctor.html
+++ b/test-files/golden-tests/symbols/function/explicit-ctor.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -33,8 +32,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="Explicit">
-Explicit<a class="mrdocs-anchor" href="#Explicit" aria-label="Permalink">#</a>
-</h2>
+Explicit</h2>
 </div>
 <div>
 <h3>
@@ -63,8 +61,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="Explicit-2constructor-04">
-Explicit::Explicit<a class="mrdocs-anchor" href="#Explicit-2constructor-04" aria-label="Permalink">#</a>
-</h2>
+Explicit::Explicit</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -101,8 +98,7 @@ Declared in <code>&lt;explicit-ctor.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Explicit-2constructor-02">
-Explicit::Explicit<a class="mrdocs-anchor" href="#Explicit-2constructor-02" aria-label="Permalink">#</a>
-</h2>
+Explicit::Explicit</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -119,8 +115,7 @@ Explicit();</code></pre>
 <div>
 <div>
 <h2 id="Explicit-2constructor-00">
-Explicit::Explicit<a class="mrdocs-anchor" href="#Explicit-2constructor-00" aria-label="Permalink">#</a>
-</h2>
+Explicit::Explicit</h2>
 <div>
 <p>Copy constructor</p>
 </div>
@@ -155,8 +150,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Explicit-2constructor-0b">
-Explicit::Explicit<a class="mrdocs-anchor" href="#Explicit-2constructor-0b" aria-label="Permalink">#</a>
-</h2>
+Explicit::Explicit</h2>
 <div>
 <p>Move constructor</p>
 </div>
@@ -191,8 +185,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="Explicit-2constructor-03">
-Explicit::Explicit<a class="mrdocs-anchor" href="#Explicit-2constructor-03" aria-label="Permalink">#</a>
-</h2>
+Explicit::Explicit</h2>
 <div>
 <p>Constructor</p>
 </div>
@@ -211,8 +204,7 @@ Explicit(
 <div>
 <div>
 <h2 id="ExplicitExpression">
-ExplicitExpression<a class="mrdocs-anchor" href="#ExplicitExpression" aria-label="Permalink">#</a>
-</h2>
+ExplicitExpression</h2>
 </div>
 <div>
 <h3>
@@ -242,8 +234,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="ExplicitExpression-2constructor-07">
-ExplicitExpression::ExplicitExpression<a class="mrdocs-anchor" href="#ExplicitExpression-2constructor-07" aria-label="Permalink">#</a>
-</h2>
+ExplicitExpression::ExplicitExpression</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -280,8 +271,7 @@ Declared in <code>&lt;explicit-ctor.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="ExplicitExpression-2constructor-0b">
-ExplicitExpression::ExplicitExpression<a class="mrdocs-anchor" href="#ExplicitExpression-2constructor-0b" aria-label="Permalink">#</a>
-</h2>
+ExplicitExpression::ExplicitExpression</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -298,8 +288,7 @@ ExplicitExpression();</code></pre>
 <div>
 <div>
 <h2 id="ExplicitExpression-2constructor-04">
-ExplicitExpression::ExplicitExpression<a class="mrdocs-anchor" href="#ExplicitExpression-2constructor-04" aria-label="Permalink">#</a>
-</h2>
+ExplicitExpression::ExplicitExpression</h2>
 <div>
 <p>Copy constructor</p>
 </div>
@@ -334,8 +323,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="ExplicitExpression-2constructor-08">
-ExplicitExpression::ExplicitExpression<a class="mrdocs-anchor" href="#ExplicitExpression-2constructor-08" aria-label="Permalink">#</a>
-</h2>
+ExplicitExpression::ExplicitExpression</h2>
 <div>
 <p>Move constructor</p>
 </div>
@@ -370,8 +358,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="ExplicitExpression-2constructor-02">
-ExplicitExpression::ExplicitExpression<a class="mrdocs-anchor" href="#ExplicitExpression-2constructor-02" aria-label="Permalink">#</a>
-</h2>
+ExplicitExpression::ExplicitExpression</h2>
 <div>
 <p>Constructor</p>
 </div>
@@ -390,8 +377,7 @@ ExplicitExpression(
 <div>
 <div>
 <h2 id="ExplicitFalse">
-ExplicitFalse<a class="mrdocs-anchor" href="#ExplicitFalse" aria-label="Permalink">#</a>
-</h2>
+ExplicitFalse</h2>
 </div>
 <div>
 <h3>
@@ -420,8 +406,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="ExplicitFalse-2constructor-07">
-ExplicitFalse::ExplicitFalse<a class="mrdocs-anchor" href="#ExplicitFalse-2constructor-07" aria-label="Permalink">#</a>
-</h2>
+ExplicitFalse::ExplicitFalse</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -458,8 +443,7 @@ Declared in <code>&lt;explicit-ctor.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="ExplicitFalse-2constructor-01">
-ExplicitFalse::ExplicitFalse<a class="mrdocs-anchor" href="#ExplicitFalse-2constructor-01" aria-label="Permalink">#</a>
-</h2>
+ExplicitFalse::ExplicitFalse</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -476,8 +460,7 @@ ExplicitFalse();</code></pre>
 <div>
 <div>
 <h2 id="ExplicitFalse-2constructor-08">
-ExplicitFalse::ExplicitFalse<a class="mrdocs-anchor" href="#ExplicitFalse-2constructor-08" aria-label="Permalink">#</a>
-</h2>
+ExplicitFalse::ExplicitFalse</h2>
 <div>
 <p>Copy constructor</p>
 </div>
@@ -512,8 +495,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="ExplicitFalse-2constructor-0a">
-ExplicitFalse::ExplicitFalse<a class="mrdocs-anchor" href="#ExplicitFalse-2constructor-0a" aria-label="Permalink">#</a>
-</h2>
+ExplicitFalse::ExplicitFalse</h2>
 <div>
 <p>Move constructor</p>
 </div>
@@ -548,8 +530,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="ExplicitFalse-2constructor-04">
-ExplicitFalse::ExplicitFalse<a class="mrdocs-anchor" href="#ExplicitFalse-2constructor-04" aria-label="Permalink">#</a>
-</h2>
+ExplicitFalse::ExplicitFalse</h2>
 <div>
 <p>Constructor</p>
 </div>
@@ -568,8 +549,7 @@ ExplicitFalse(
 <div>
 <div>
 <h2 id="ExplicitTrue">
-ExplicitTrue<a class="mrdocs-anchor" href="#ExplicitTrue" aria-label="Permalink">#</a>
-</h2>
+ExplicitTrue</h2>
 </div>
 <div>
 <h3>
@@ -598,8 +578,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="ExplicitTrue-2constructor-01">
-ExplicitTrue::ExplicitTrue<a class="mrdocs-anchor" href="#ExplicitTrue-2constructor-01" aria-label="Permalink">#</a>
-</h2>
+ExplicitTrue::ExplicitTrue</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -636,8 +615,7 @@ Declared in <code>&lt;explicit-ctor.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="ExplicitTrue-2constructor-0d">
-ExplicitTrue::ExplicitTrue<a class="mrdocs-anchor" href="#ExplicitTrue-2constructor-0d" aria-label="Permalink">#</a>
-</h2>
+ExplicitTrue::ExplicitTrue</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -654,8 +632,7 @@ ExplicitTrue();</code></pre>
 <div>
 <div>
 <h2 id="ExplicitTrue-2constructor-04">
-ExplicitTrue::ExplicitTrue<a class="mrdocs-anchor" href="#ExplicitTrue-2constructor-04" aria-label="Permalink">#</a>
-</h2>
+ExplicitTrue::ExplicitTrue</h2>
 <div>
 <p>Copy constructor</p>
 </div>
@@ -690,8 +667,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="ExplicitTrue-2constructor-08">
-ExplicitTrue::ExplicitTrue<a class="mrdocs-anchor" href="#ExplicitTrue-2constructor-08" aria-label="Permalink">#</a>
-</h2>
+ExplicitTrue::ExplicitTrue</h2>
 <div>
 <p>Move constructor</p>
 </div>
@@ -726,8 +702,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="ExplicitTrue-2constructor-05">
-ExplicitTrue::ExplicitTrue<a class="mrdocs-anchor" href="#ExplicitTrue-2constructor-05" aria-label="Permalink">#</a>
-</h2>
+ExplicitTrue::ExplicitTrue</h2>
 <div>
 <p>Constructor</p>
 </div>

--- a/test-files/golden-tests/symbols/function/explicit-object-parameter.html
+++ b/test-files/golden-tests/symbols/function/explicit-object-parameter.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="Optional">
-Optional<a class="mrdocs-anchor" href="#Optional" aria-label="Permalink">#</a>
-</h2>
+Optional</h2>
 </div>
 <div>
 <h3>
@@ -60,8 +58,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="Optional-value-0c">
-Optional::value<a class="mrdocs-anchor" href="#Optional-value-0c" aria-label="Permalink">#</a>
-</h2>
+Optional::value</h2>
 </div>
 <div>
 <h3>
@@ -89,8 +86,7 @@ auto&&
 <div>
 <div>
 <h2 id="Optional-value-05">
-Optional::value<a class="mrdocs-anchor" href="#Optional-value-05" aria-label="Permalink">#</a>
-</h2>
+Optional::value</h2>
 </div>
 <div>
 <h3>
@@ -106,8 +102,7 @@ value(this Self&& self);</code></pre>
 <div>
 <div>
 <h2 id="Optional-value-06">
-Optional::value<a class="mrdocs-anchor" href="#Optional-value-06" aria-label="Permalink">#</a>
-</h2>
+Optional::value</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/function-parm-decay.html
+++ b/test-files/golden-tests/symbols/function/function-parm-decay.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -48,8 +47,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +60,7 @@ Declared in <code>&lt;function-parm-decay.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U">
-U<a class="mrdocs-anchor" href="#U" aria-label="Permalink">#</a>
-</h2>
+U</h2>
 </div>
 <div>
 <h3>
@@ -76,8 +73,7 @@ Declared in <code>&lt;function-parm-decay.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -91,8 +87,7 @@ f(int const x);</code></pre>
 <div>
 <div>
 <h2 id="g">
-g<a class="mrdocs-anchor" href="#g" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -106,8 +101,7 @@ g(int* x);</code></pre>
 <div>
 <div>
 <h2 id="h">
-h<a class="mrdocs-anchor" href="#h" aria-label="Permalink">#</a>
-</h2>
+h</h2>
 </div>
 <div>
 <h3>
@@ -121,8 +115,7 @@ h(int x(bool));</code></pre>
 <div>
 <div>
 <h2 id="i">
-i<a class="mrdocs-anchor" href="#i" aria-label="Permalink">#</a>
-</h2>
+i</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/function-template-template.html
+++ b/test-files/golden-tests/symbols/function/function-template-template.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/function-template.html
+++ b/test-files/golden-tests/symbols/function/function-template.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -41,8 +40,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 </div>
 <div>
 <h3>
@@ -57,8 +55,7 @@ f0(int x);</code></pre>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 </div>
 <div>
 <h3>
@@ -73,8 +70,7 @@ f1(T t);</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 </div>
 <div>
 <h3>
@@ -89,8 +85,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 </div>
 <div>
 <h3>
@@ -107,8 +102,7 @@ f3();</code></pre>
 <div>
 <div>
 <h2 id="g0">
-g0<a class="mrdocs-anchor" href="#g0" aria-label="Permalink">#</a>
-</h2>
+g0</h2>
 </div>
 <div>
 <h3>
@@ -123,8 +117,7 @@ g0(int x);</code></pre>
 <div>
 <div>
 <h2 id="g1">
-g1<a class="mrdocs-anchor" href="#g1" aria-label="Permalink">#</a>
-</h2>
+g1</h2>
 </div>
 <div>
 <h3>
@@ -139,8 +132,7 @@ g1();</code></pre>
 <div>
 <div>
 <h2 id="g2">
-g2<a class="mrdocs-anchor" href="#g2" aria-label="Permalink">#</a>
-</h2>
+g2</h2>
 </div>
 <div>
 <h3>
@@ -157,8 +149,7 @@ g2();</code></pre>
 <div>
 <div>
 <h2 id="h0">
-h0<a class="mrdocs-anchor" href="#h0" aria-label="Permalink">#</a>
-</h2>
+h0</h2>
 </div>
 <div>
 <h3>
@@ -172,8 +163,7 @@ h0(auto x);</code></pre>
 <div>
 <div>
 <h2 id="h1">
-h1<a class="mrdocs-anchor" href="#h1" aria-label="Permalink">#</a>
-</h2>
+h1</h2>
 </div>
 <div>
 <h3>
@@ -189,8 +179,7 @@ h1(
 <div>
 <div>
 <h2 id="i">
-i<a class="mrdocs-anchor" href="#i" aria-label="Permalink">#</a>
-</h2>
+i</h2>
 </div>
 <div>
 <h3>
@@ -207,8 +196,7 @@ i();</code></pre>
 <div>
 <div>
 <h2 id="j0">
-j0<a class="mrdocs-anchor" href="#j0" aria-label="Permalink">#</a>
-</h2>
+j0</h2>
 </div>
 <div>
 <h3>
@@ -223,8 +211,7 @@ j0();</code></pre>
 <div>
 <div>
 <h2 id="j1">
-j1<a class="mrdocs-anchor" href="#j1" aria-label="Permalink">#</a>
-</h2>
+j1</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/function-tparm-decay.html
+++ b/test-files/golden-tests/symbols/function/function-tparm-decay.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -48,8 +47,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +60,7 @@ Declared in <code>&lt;function-tparm-decay.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U">
-U<a class="mrdocs-anchor" href="#U" aria-label="Permalink">#</a>
-</h2>
+U</h2>
 </div>
 <div>
 <h3>
@@ -76,8 +73,7 @@ Declared in <code>&lt;function-tparm-decay.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +88,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="g">
-g<a class="mrdocs-anchor" href="#g" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>
@@ -108,8 +103,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="h">
-h<a class="mrdocs-anchor" href="#h" aria-label="Permalink">#</a>
-</h2>
+h</h2>
 </div>
 <div>
 <h3>
@@ -124,8 +118,7 @@ h();</code></pre>
 <div>
 <div>
 <h2 id="i">
-i<a class="mrdocs-anchor" href="#i" aria-label="Permalink">#</a>
-</h2>
+i</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/mem-fn.html
+++ b/test-files/golden-tests/symbols/function/mem-fn.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -47,8 +46,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="T01">
-T01<a class="mrdocs-anchor" href="#T01" aria-label="Permalink">#</a>
-</h2>
+T01</h2>
 </div>
 <div>
 <h3>
@@ -77,8 +75,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T01-f">
-T01::f<a class="mrdocs-anchor" href="#T01-f" aria-label="Permalink">#</a>
-</h2>
+T01::f</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +89,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="T02">
-T02<a class="mrdocs-anchor" href="#T02" aria-label="Permalink">#</a>
-</h2>
+T02</h2>
 </div>
 <div>
 <h3>
@@ -122,8 +118,7 @@ Static Member Functions</h2>
 <div>
 <div>
 <h2 id="T02-f">
-T02::f<a class="mrdocs-anchor" href="#T02-f" aria-label="Permalink">#</a>
-</h2>
+T02::f</h2>
 </div>
 <div>
 <h3>
@@ -138,8 +133,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="T03">
-T03<a class="mrdocs-anchor" href="#T03" aria-label="Permalink">#</a>
-</h2>
+T03</h2>
 </div>
 <div>
 <h3>
@@ -168,8 +162,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T03-f">
-T03::f<a class="mrdocs-anchor" href="#T03-f" aria-label="Permalink">#</a>
-</h2>
+T03::f</h2>
 </div>
 <div>
 <h3>
@@ -183,8 +176,7 @@ f() &amp;;</code></pre>
 <div>
 <div>
 <h2 id="T04">
-T04<a class="mrdocs-anchor" href="#T04" aria-label="Permalink">#</a>
-</h2>
+T04</h2>
 </div>
 <div>
 <h3>
@@ -213,8 +205,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T04-f">
-T04::f<a class="mrdocs-anchor" href="#T04-f" aria-label="Permalink">#</a>
-</h2>
+T04::f</h2>
 </div>
 <div>
 <h3>
@@ -228,8 +219,7 @@ f() &amp;&amp;;</code></pre>
 <div>
 <div>
 <h2 id="T05">
-T05<a class="mrdocs-anchor" href="#T05" aria-label="Permalink">#</a>
-</h2>
+T05</h2>
 </div>
 <div>
 <h3>
@@ -258,8 +248,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T05-f">
-T05::f<a class="mrdocs-anchor" href="#T05-f" aria-label="Permalink">#</a>
-</h2>
+T05::f</h2>
 </div>
 <div>
 <h3>
@@ -273,8 +262,7 @@ f() const;</code></pre>
 <div>
 <div>
 <h2 id="T06">
-T06<a class="mrdocs-anchor" href="#T06" aria-label="Permalink">#</a>
-</h2>
+T06</h2>
 </div>
 <div>
 <h3>
@@ -303,8 +291,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T06-f">
-T06::f<a class="mrdocs-anchor" href="#T06-f" aria-label="Permalink">#</a>
-</h2>
+T06::f</h2>
 </div>
 <div>
 <h3>
@@ -319,8 +306,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="T08">
-T08<a class="mrdocs-anchor" href="#T08" aria-label="Permalink">#</a>
-</h2>
+T08</h2>
 </div>
 <div>
 <h3>
@@ -349,8 +335,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T08-f">
-T08::f<a class="mrdocs-anchor" href="#T08-f" aria-label="Permalink">#</a>
-</h2>
+T08::f</h2>
 </div>
 <div>
 <h3>
@@ -364,8 +349,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="T09">
-T09<a class="mrdocs-anchor" href="#T09" aria-label="Permalink">#</a>
-</h2>
+T09</h2>
 </div>
 <div>
 <h3>
@@ -394,8 +378,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T09-f">
-T09::f<a class="mrdocs-anchor" href="#T09-f" aria-label="Permalink">#</a>
-</h2>
+T09::f</h2>
 </div>
 <div>
 <h3>
@@ -409,8 +392,7 @@ f() noexcept;</code></pre>
 <div>
 <div>
 <h2 id="T10">
-T10<a class="mrdocs-anchor" href="#T10" aria-label="Permalink">#</a>
-</h2>
+T10</h2>
 </div>
 <div>
 <h3>
@@ -439,8 +421,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T10-f">
-T10::f<a class="mrdocs-anchor" href="#T10-f" aria-label="Permalink">#</a>
-</h2>
+T10::f</h2>
 </div>
 <div>
 <h3>
@@ -454,8 +435,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="T11">
-T11<a class="mrdocs-anchor" href="#T11" aria-label="Permalink">#</a>
-</h2>
+T11</h2>
 </div>
 <div>
 <h3>
@@ -484,8 +464,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T11-f">
-T11::f<a class="mrdocs-anchor" href="#T11-f" aria-label="Permalink">#</a>
-</h2>
+T11::f</h2>
 </div>
 <div>
 <h3>
@@ -499,8 +478,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="T12">
-T12<a class="mrdocs-anchor" href="#T12" aria-label="Permalink">#</a>
-</h2>
+T12</h2>
 </div>
 <div>
 <h3>
@@ -529,8 +507,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T12-f">
-T12::f<a class="mrdocs-anchor" href="#T12-f" aria-label="Permalink">#</a>
-</h2>
+T12::f</h2>
 </div>
 <div>
 <h3>
@@ -544,8 +521,7 @@ f(...);</code></pre>
 <div>
 <div>
 <h2 id="T13">
-T13<a class="mrdocs-anchor" href="#T13" aria-label="Permalink">#</a>
-</h2>
+T13</h2>
 </div>
 <div>
 <h3>
@@ -574,8 +550,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T13-f">
-T13::f<a class="mrdocs-anchor" href="#T13-f" aria-label="Permalink">#</a>
-</h2>
+T13::f</h2>
 </div>
 <div>
 <h3>
@@ -590,8 +565,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="T14">
-T14<a class="mrdocs-anchor" href="#T14" aria-label="Permalink">#</a>
-</h2>
+T14</h2>
 </div>
 <div>
 <h3>
@@ -636,8 +610,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="T14-f">
-T14::f<a class="mrdocs-anchor" href="#T14-f" aria-label="Permalink">#</a>
-</h2>
+T14::f</h2>
 </div>
 <div>
 <h3>
@@ -652,8 +625,7 @@ f() = 0;</code></pre>
 <div>
 <div>
 <h2 id="T15">
-T15<a class="mrdocs-anchor" href="#T15" aria-label="Permalink">#</a>
-</h2>
+T15</h2>
 </div>
 <div>
 <h3>
@@ -682,8 +654,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T15-f">
-T15::f<a class="mrdocs-anchor" href="#T15-f" aria-label="Permalink">#</a>
-</h2>
+T15::f</h2>
 </div>
 <div>
 <h3>
@@ -697,8 +668,7 @@ f() volatile;</code></pre>
 <div>
 <div>
 <h2 id="T16">
-T16<a class="mrdocs-anchor" href="#T16" aria-label="Permalink">#</a>
-</h2>
+T16</h2>
 </div>
 <div>
 <h3>
@@ -727,8 +697,7 @@ Static Member Functions</h2>
 <div>
 <div>
 <h2 id="T16-f">
-T16::f<a class="mrdocs-anchor" href="#T16-f" aria-label="Permalink">#</a>
-</h2>
+T16::f</h2>
 </div>
 <div>
 <h3>
@@ -743,8 +712,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="T17">
-T17<a class="mrdocs-anchor" href="#T17" aria-label="Permalink">#</a>
-</h2>
+T17</h2>
 </div>
 <div>
 <h3>
@@ -789,8 +757,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T17-f">
-T17::f<a class="mrdocs-anchor" href="#T17-f" aria-label="Permalink">#</a>
-</h2>
+T17::f</h2>
 </div>
 <div>
 <h3>
@@ -805,8 +772,7 @@ f() override;</code></pre>
 <div>
 <div>
 <h2 id="U">
-U<a class="mrdocs-anchor" href="#U" aria-label="Permalink">#</a>
-</h2>
+U</h2>
 </div>
 <div>
 <h3>
@@ -866,8 +832,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="U-f1">
-U::f1<a class="mrdocs-anchor" href="#U-f1" aria-label="Permalink">#</a>
-</h2>
+U::f1</h2>
 </div>
 <div>
 <h3>
@@ -882,8 +847,7 @@ f1(...) const volatile noexcept;</code></pre>
 <div>
 <div>
 <h2 id="U-f3">
-U::f3<a class="mrdocs-anchor" href="#U-f3" aria-label="Permalink">#</a>
-</h2>
+U::f3</h2>
 </div>
 <div>
 <h3>
@@ -898,8 +862,7 @@ f3() const volatile noexcept = 0;</code></pre>
 <div>
 <div>
 <h2 id="U-f2">
-U::f2<a class="mrdocs-anchor" href="#U-f2" aria-label="Permalink">#</a>
-</h2>
+U::f2</h2>
 </div>
 <div>
 <h3>
@@ -915,8 +878,7 @@ f2() noexcept;</code></pre>
 <div>
 <div>
 <h2 id="V">
-V<a class="mrdocs-anchor" href="#V" aria-label="Permalink">#</a>
-</h2>
+V</h2>
 </div>
 <div>
 <h3>
@@ -976,8 +938,7 @@ Static Member Functions</h2>
 <div>
 <div>
 <h2 id="V-f3">
-V::f3<a class="mrdocs-anchor" href="#V-f3" aria-label="Permalink">#</a>
-</h2>
+V::f3</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/merge-params.html
+++ b/test-files/golden-tests/symbols/function/merge-params.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Function</p>
 </div>

--- a/test-files/golden-tests/symbols/function/merge-tparams.html
+++ b/test-files/golden-tests/symbols/function/merge-tparams.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Function</p>
 </div>

--- a/test-files/golden-tests/symbols/function/noreturn.html
+++ b/test-files/golden-tests/symbols/function/noreturn.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -44,8 +43,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -107,8 +105,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="T-f3">
-T::f3<a class="mrdocs-anchor" href="#T-f3" aria-label="Permalink">#</a>
-</h2>
+T::f3</h2>
 </div>
 <div>
 <h3>
@@ -123,8 +120,7 @@ f3();</code></pre>
 <div>
 <div>
 <h2 id="T-f2">
-T::f2<a class="mrdocs-anchor" href="#T-f2" aria-label="Permalink">#</a>
-</h2>
+T::f2</h2>
 </div>
 <div>
 <h3>
@@ -140,8 +136,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/overloaded-op-1.html
+++ b/test-files/golden-tests/symbols/function/overloaded-op-1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -60,8 +58,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T-operator_plus">
-T::operator+<a class="mrdocs-anchor" href="#T-operator_plus" aria-label="Permalink">#</a>
-</h2>
+T::operator+</h2>
 <div>
 <p>Unary plus operator</p>
 </div>

--- a/test-files/golden-tests/symbols/function/overloaded-op-2.html
+++ b/test-files/golden-tests/symbols/function/overloaded-op-2.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -60,8 +58,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="T-operator_plus">
-T::operator+<a class="mrdocs-anchor" href="#T-operator_plus" aria-label="Permalink">#</a>
-</h2>
+T::operator+</h2>
 <div>
 <p>Addition operator</p>
 </div>

--- a/test-files/golden-tests/symbols/function/pack-expansion.html
+++ b/test-files/golden-tests/symbols/function/pack-expansion.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -35,8 +34,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="by_const_ref">
-by_const_ref<a class="mrdocs-anchor" href="#by_const_ref" aria-label="Permalink">#</a>
-</h2>
+by_const_ref</h2>
 </div>
 <div>
 <h3>
@@ -51,8 +49,7 @@ by_const_ref(Ts const&... args);</code></pre>
 <div>
 <div>
 <h2 id="by_pointer">
-by_pointer<a class="mrdocs-anchor" href="#by_pointer" aria-label="Permalink">#</a>
-</h2>
+by_pointer</h2>
 </div>
 <div>
 <h3>
@@ -67,8 +64,7 @@ by_pointer(Ts*... args);</code></pre>
 <div>
 <div>
 <h2 id="by_ref">
-by_ref<a class="mrdocs-anchor" href="#by_ref" aria-label="Permalink">#</a>
-</h2>
+by_ref</h2>
 </div>
 <div>
 <h3>
@@ -83,8 +79,7 @@ by_ref(Ts&... args);</code></pre>
 <div>
 <div>
 <h2 id="by_value">
-by_value<a class="mrdocs-anchor" href="#by_value" aria-label="Permalink">#</a>
-</h2>
+by_value</h2>
 </div>
 <div>
 <h3>
@@ -99,8 +94,7 @@ by_value(Ts... args);</code></pre>
 <div>
 <div>
 <h2 id="forward_all">
-forward_all<a class="mrdocs-anchor" href="#forward_all" aria-label="Permalink">#</a>
-</h2>
+forward_all</h2>
 </div>
 <div>
 <h3>
@@ -115,8 +109,7 @@ forward_all(Args&&... args);</code></pre>
 <div>
 <div>
 <h2 id="make_ptr">
-make_ptr<a class="mrdocs-anchor" href="#make_ptr" aria-label="Permalink">#</a>
-</h2>
+make_ptr</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/qualified-params.html
+++ b/test-files/golden-tests/symbols/function/qualified-params.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="M">
-M<a class="mrdocs-anchor" href="#M" aria-label="Permalink">#</a>
-</h2>
+M</h2>
 </div>
 <h2>
 Types</h2>
@@ -66,8 +64,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="M-D">
-M::D<a class="mrdocs-anchor" href="#M-D" aria-label="Permalink">#</a>
-</h2>
+M::D</h2>
 </div>
 <div>
 <h3>
@@ -82,8 +79,7 @@ Declared in <code>&lt;qualified-params.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="N">
-N<a class="mrdocs-anchor" href="#N" aria-label="Permalink">#</a>
-</h2>
+N</h2>
 </div>
 <h2>
 Types</h2>
@@ -103,8 +99,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="N-C">
-N::C<a class="mrdocs-anchor" href="#N-C" aria-label="Permalink">#</a>
-</h2>
+N::C</h2>
 </div>
 <div>
 <h3>
@@ -119,8 +114,7 @@ Declared in <code>&lt;qualified-params.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="foo">
-foo<a class="mrdocs-anchor" href="#foo" aria-label="Permalink">#</a>
-</h2>
+foo</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/sfinae.html
+++ b/test-files/golden-tests/symbols/function/sfinae.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -70,8 +69,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <h2>
 Types</h2>
@@ -91,8 +89,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="B-C">
-B::C<a class="mrdocs-anchor" href="#B-C" aria-label="Permalink">#</a>
-</h2>
+B::C</h2>
 </div>
 <div>
 <h3>
@@ -122,8 +119,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="A-09">
-A<a class="mrdocs-anchor" href="#A-09" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>The partial specialization of A is enabled via a template parameter</p>
 </div>
@@ -144,8 +140,7 @@ class A;</code></pre>
 <div>
 <div>
 <h2 id="A-07">
-A&lt;T&gt;<a class="mrdocs-anchor" href="#A-07" aria-label="Permalink">#</a>
-</h2>
+A&lt;T&gt;</h2>
 <div>
 <p>Specialization for integral types</p>
 </div>
@@ -165,8 +160,7 @@ class <a href="#A-09">A</a>&lt;T&gt;;</code></pre>
 <div>
 <div>
 <h2 id="S-02">
-S<a class="mrdocs-anchor" href="#S-02" aria-label="Permalink">#</a>
-</h2>
+S</h2>
 <div>
 <p>SFINAE with std::void_t</p>
 </div>
@@ -201,8 +195,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S-02-store">
-S::store<a class="mrdocs-anchor" href="#S-02-store" aria-label="Permalink">#</a>
-</h2>
+S::store</h2>
 </div>
 <div>
 <h3>
@@ -216,8 +209,7 @@ store(void const*);</code></pre>
 <div>
 <div>
 <h2 id="S-08">
-S&lt;T, std::void_t&lt;T::a::b&gt;&gt;<a class="mrdocs-anchor" href="#S-08" aria-label="Permalink">#</a>
-</h2>
+S&lt;T, std::void_t&lt;T::a::b&gt;&gt;</h2>
 <div>
 <p>SFINAE with std::void_t</p>
 </div>
@@ -250,8 +242,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S-08-store">
-S&lt;T, std::void_t&lt;T::a::b&gt;&gt;::store<a class="mrdocs-anchor" href="#S-08-store" aria-label="Permalink">#</a>
-</h2>
+S&lt;T, std::void_t&lt;T::a::b&gt;&gt;::store</h2>
 </div>
 <div>
 <h3>
@@ -265,8 +256,7 @@ store(void const*);</code></pre>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 <div>
 <p>Enabled via return type</p>
 </div>
@@ -285,8 +275,7 @@ requires std::is_integral_v&lt;T&gt;;</code></pre>
 <div>
 <div>
 <h2 id="f10">
-f10<a class="mrdocs-anchor" href="#f10" aria-label="Permalink">#</a>
-</h2>
+f10</h2>
 <div>
 <p>Enabled via type template parameter</p>
 </div>
@@ -312,8 +301,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 <div>
 <p>Enabling a specified return type</p>
 </div>
@@ -332,8 +320,7 @@ requires std::is_integral_v&lt;T&gt;;</code></pre>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 <div>
 <p>Enabling a specified return type in another namespace</p>
 </div>
@@ -352,8 +339,7 @@ requires std::is_integral_v&lt;T&gt;;</code></pre>
 <div>
 <div>
 <h2 id="f4">
-f4<a class="mrdocs-anchor" href="#f4" aria-label="Permalink">#</a>
-</h2>
+f4</h2>
 <div>
 <p>Enabled via return type with std::enable_if</p>
 </div>
@@ -372,8 +358,7 @@ requires std::is_integral_v&lt;T&gt;;</code></pre>
 <div>
 <div>
 <h2 id="f5">
-f5<a class="mrdocs-anchor" href="#f5" aria-label="Permalink">#</a>
-</h2>
+f5</h2>
 <div>
 <p>Enabled via a non-type template parameter with helper</p>
 </div>
@@ -392,8 +377,7 @@ f5(T value);</code></pre>
 <div>
 <div>
 <h2 id="f6">
-f6<a class="mrdocs-anchor" href="#f6" aria-label="Permalink">#</a>
-</h2>
+f6</h2>
 <div>
 <p>Enabled via a non-type template parameter without helper</p>
 </div>
@@ -412,8 +396,7 @@ f6(T value);</code></pre>
 <div>
 <div>
 <h2 id="f7">
-f7<a class="mrdocs-anchor" href="#f7" aria-label="Permalink">#</a>
-</h2>
+f7</h2>
 <div>
 <p>Enabled via a non-type template parameter using int instead of bool</p>
 </div>
@@ -432,8 +415,7 @@ f7(T value);</code></pre>
 <div>
 <div>
 <h2 id="f8">
-f8<a class="mrdocs-anchor" href="#f8" aria-label="Permalink">#</a>
-</h2>
+f8</h2>
 <div>
 <p>Enabled via parameter without helper</p>
 </div>
@@ -452,8 +434,7 @@ requires std::is_integral_v&lt;T&gt;;</code></pre>
 <div>
 <div>
 <h2 id="f9">
-f9<a class="mrdocs-anchor" href="#f9" aria-label="Permalink">#</a>
-</h2>
+f9</h2>
 <div>
 <p>Enabled via parameter with helper</p>
 </div>

--- a/test-files/golden-tests/symbols/function/spec-mem-implicit-instantiation.html
+++ b/test-files/golden-tests/symbols/function/spec-mem-implicit-instantiation.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -34,8 +33,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e">
-A<a class="mrdocs-anchor" href="#A-0e" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -80,8 +78,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0e-B">
-A::B<a class="mrdocs-anchor" href="#A-0e-B" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 </div>
 <div>
 <h3>
@@ -111,8 +108,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0e-B-g">
-A::B::g<a class="mrdocs-anchor" href="#A-0e-B-g" aria-label="Permalink">#</a>
-</h2>
+A::B::g</h2>
 </div>
 <div>
 <h3>
@@ -126,8 +122,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="A-0e-C">
-A::C<a class="mrdocs-anchor" href="#A-0e-C" aria-label="Permalink">#</a>
-</h2>
+A::C</h2>
 </div>
 <div>
 <h3>
@@ -157,8 +152,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0e-C-h">
-A::C::h<a class="mrdocs-anchor" href="#A-0e-C-h" aria-label="Permalink">#</a>
-</h2>
+A::C::h</h2>
 </div>
 <div>
 <h3>
@@ -172,8 +166,7 @@ h();</code></pre>
 <div>
 <div>
 <h2 id="A-0e-f">
-A::f<a class="mrdocs-anchor" href="#A-0e-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -187,8 +180,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-0f">
-A&lt;bool&gt;<a class="mrdocs-anchor" href="#A-0f" aria-label="Permalink">#</a>
-</h2>
+A&lt;bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -235,8 +227,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0f-B">
-A&lt;bool&gt;::B<a class="mrdocs-anchor" href="#A-0f-B" aria-label="Permalink">#</a>
-</h2>
+A&lt;bool&gt;::B</h2>
 </div>
 <div>
 <h3>
@@ -252,8 +243,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="A-0f-C-00">
-A&lt;bool&gt;::C<a class="mrdocs-anchor" href="#A-0f-C-00" aria-label="Permalink">#</a>
-</h2>
+A&lt;bool&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -269,8 +259,7 @@ struct C;</code></pre>
 <div>
 <div>
 <h2 id="A-0f-C-01">
-A&lt;bool&gt;::C&lt;double*&gt;<a class="mrdocs-anchor" href="#A-0f-C-01" aria-label="Permalink">#</a>
-</h2>
+A&lt;bool&gt;::C&lt;double*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -300,8 +289,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0f-C-01-j">
-A&lt;bool&gt;::C&lt;double*&gt;::j<a class="mrdocs-anchor" href="#A-0f-C-01-j" aria-label="Permalink">#</a>
-</h2>
+A&lt;bool&gt;::C&lt;double*&gt;::j</h2>
 </div>
 <div>
 <h3>
@@ -315,8 +303,7 @@ j();</code></pre>
 <div>
 <div>
 <h2 id="A-0f-C-0c">
-A&lt;bool&gt;::C&lt;U*&gt;<a class="mrdocs-anchor" href="#A-0f-C-0c" aria-label="Permalink">#</a>
-</h2>
+A&lt;bool&gt;::C&lt;U*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -346,8 +333,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0f-C-0c-j">
-A&lt;bool&gt;::C&lt;U*&gt;::j<a class="mrdocs-anchor" href="#A-0f-C-0c-j" aria-label="Permalink">#</a>
-</h2>
+A&lt;bool&gt;::C&lt;U*&gt;::j</h2>
 </div>
 <div>
 <h3>
@@ -361,8 +347,7 @@ j();</code></pre>
 <div>
 <div>
 <h2 id="A-0f-f">
-A&lt;bool&gt;::f<a class="mrdocs-anchor" href="#A-0f-f" aria-label="Permalink">#</a>
-</h2>
+A&lt;bool&gt;::f</h2>
 </div>
 <div>
 <h3>
@@ -376,8 +361,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-00b">
-A&lt;short&gt;<a class="mrdocs-anchor" href="#A-00b" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;</h2>
 </div>
 <div>
 <h3>
@@ -422,8 +406,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-00b-B">
-A&lt;short&gt;::B<a class="mrdocs-anchor" href="#A-00b-B" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::B</h2>
 </div>
 <div>
 <h3>
@@ -439,8 +422,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="A-00b-C">
-A&lt;short&gt;::C<a class="mrdocs-anchor" href="#A-00b-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -470,8 +452,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-00b-C-i">
-A&lt;short&gt;::C::i<a class="mrdocs-anchor" href="#A-00b-C-i" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::C::i</h2>
 </div>
 <div>
 <h3>
@@ -485,8 +466,7 @@ i();</code></pre>
 <div>
 <div>
 <h2 id="A-00b-f">
-A&lt;short&gt;::f<a class="mrdocs-anchor" href="#A-00b-f" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::f</h2>
 </div>
 <div>
 <h3>
@@ -500,8 +480,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-000">
-A&lt;int&gt;<a class="mrdocs-anchor" href="#A-000" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -547,8 +526,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-000-B-03">
-A&lt;int&gt;::B<a class="mrdocs-anchor" href="#A-000-B-03" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::B</h2>
 </div>
 <div>
 <h3>
@@ -564,8 +542,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="A-000-B-09">
-A&lt;int&gt;::B&lt;long&gt;<a class="mrdocs-anchor" href="#A-000-B-09" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::B&lt;long&gt;</h2>
 </div>
 <div>
 <h3>
@@ -595,8 +572,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-000-B-09-g">
-A&lt;int&gt;::B&lt;long&gt;::g<a class="mrdocs-anchor" href="#A-000-B-09-g" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::B&lt;long&gt;::g</h2>
 </div>
 <div>
 <h3>
@@ -610,8 +586,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="A-000-C">
-A&lt;int&gt;::C<a class="mrdocs-anchor" href="#A-000-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -627,8 +602,7 @@ struct C;</code></pre>
 <div>
 <div>
 <h2 id="A-000-f">
-A&lt;int&gt;::f<a class="mrdocs-anchor" href="#A-000-f" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::f</h2>
 </div>
 <div>
 <h3>
@@ -642,8 +616,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="D">
-D<a class="mrdocs-anchor" href="#D" aria-label="Permalink">#</a>
-</h2>
+D</h2>
 </div>
 <div>
 <h3>
@@ -673,8 +646,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="D-E-0e">
-D::E<a class="mrdocs-anchor" href="#D-E-0e" aria-label="Permalink">#</a>
-</h2>
+D::E</h2>
 </div>
 <div>
 <h3>
@@ -704,8 +676,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="D-E-0e-k">
-D::E::k<a class="mrdocs-anchor" href="#D-E-0e-k" aria-label="Permalink">#</a>
-</h2>
+D::E::k</h2>
 </div>
 <div>
 <h3>
@@ -719,8 +690,7 @@ k();</code></pre>
 <div>
 <div>
 <h2 id="D-E-0d">
-D::E&lt;int&gt;<a class="mrdocs-anchor" href="#D-E-0d" aria-label="Permalink">#</a>
-</h2>
+D::E&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -750,8 +720,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="D-E-0d-k">
-D::E&lt;int&gt;::k<a class="mrdocs-anchor" href="#D-E-0d-k" aria-label="Permalink">#</a>
-</h2>
+D::E&lt;int&gt;::k</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/type-resolution.html
+++ b/test-files/golden-tests/symbols/function/type-resolution.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -92,8 +91,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="C">
-C<a class="mrdocs-anchor" href="#C" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>
@@ -106,8 +104,7 @@ Declared in <code>&lt;type-resolution.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="D">
-D<a class="mrdocs-anchor" href="#D" aria-label="Permalink">#</a>
-</h2>
+D</h2>
 </div>
 <div>
 <h3>
@@ -120,8 +117,7 @@ Declared in <code>&lt;type-resolution.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E">
-E<a class="mrdocs-anchor" href="#E" aria-label="Permalink">#</a>
-</h2>
+E</h2>
 </div>
 <div>
 <h3>
@@ -135,8 +131,7 @@ using E = <a href="#B">B&lt;T, long&gt;</a>;</code></pre>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -151,8 +146,7 @@ Declared in <code>&lt;type-resolution.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -170,8 +164,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="f0">
-f0<a class="mrdocs-anchor" href="#f0" aria-label="Permalink">#</a>
-</h2>
+f0</h2>
 </div>
 <div>
 <h3>
@@ -185,8 +178,7 @@ f0(<a href="#A">A</a>);</code></pre>
 <div>
 <div>
 <h2 id="f1">
-f1<a class="mrdocs-anchor" href="#f1" aria-label="Permalink">#</a>
-</h2>
+f1</h2>
 </div>
 <div>
 <h3>
@@ -200,8 +192,7 @@ f1(<a href="#A">A</a> const);</code></pre>
 <div>
 <div>
 <h2 id="f2">
-f2<a class="mrdocs-anchor" href="#f2" aria-label="Permalink">#</a>
-</h2>
+f2</h2>
 </div>
 <div>
 <h3>
@@ -215,8 +206,7 @@ f2(<a href="#A">A</a>&);</code></pre>
 <div>
 <div>
 <h2 id="f3">
-f3<a class="mrdocs-anchor" href="#f3" aria-label="Permalink">#</a>
-</h2>
+f3</h2>
 </div>
 <div>
 <h3>
@@ -230,8 +220,7 @@ f3(<a href="#A">A</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="f4">
-f4<a class="mrdocs-anchor" href="#f4" aria-label="Permalink">#</a>
-</h2>
+f4</h2>
 </div>
 <div>
 <h3>
@@ -245,8 +234,7 @@ f4(<a href="#A">A</a>*);</code></pre>
 <div>
 <div>
 <h2 id="f5">
-f5<a class="mrdocs-anchor" href="#f5" aria-label="Permalink">#</a>
-</h2>
+f5</h2>
 </div>
 <div>
 <h3>
@@ -260,8 +248,7 @@ f5(<a href="#A">A</a> const*);</code></pre>
 <div>
 <div>
 <h2 id="f6">
-f6<a class="mrdocs-anchor" href="#f6" aria-label="Permalink">#</a>
-</h2>
+f6</h2>
 </div>
 <div>
 <h3>
@@ -275,8 +262,7 @@ f6(<a href="#A">A</a>**);</code></pre>
 <div>
 <div>
 <h2 id="f7">
-f7<a class="mrdocs-anchor" href="#f7" aria-label="Permalink">#</a>
-</h2>
+f7</h2>
 </div>
 <div>
 <h3>
@@ -290,8 +276,7 @@ f7(<a href="#A">A</a> const**);</code></pre>
 <div>
 <div>
 <h2 id="f8">
-f8<a class="mrdocs-anchor" href="#f8" aria-label="Permalink">#</a>
-</h2>
+f8</h2>
 </div>
 <div>
 <h3>
@@ -305,8 +290,7 @@ f8(<a href="#A">A</a> const const**);</code></pre>
 <div>
 <div>
 <h2 id="g0">
-g0<a class="mrdocs-anchor" href="#g0" aria-label="Permalink">#</a>
-</h2>
+g0</h2>
 </div>
 <div>
 <h3>
@@ -320,8 +304,7 @@ g0(<a href="#C">C</a>);</code></pre>
 <div>
 <div>
 <h2 id="g1">
-g1<a class="mrdocs-anchor" href="#g1" aria-label="Permalink">#</a>
-</h2>
+g1</h2>
 </div>
 <div>
 <h3>
@@ -335,8 +318,7 @@ g1(<a href="#C">C</a> const);</code></pre>
 <div>
 <div>
 <h2 id="g2">
-g2<a class="mrdocs-anchor" href="#g2" aria-label="Permalink">#</a>
-</h2>
+g2</h2>
 </div>
 <div>
 <h3>
@@ -350,8 +332,7 @@ g2(<a href="#C">C</a>&);</code></pre>
 <div>
 <div>
 <h2 id="g3">
-g3<a class="mrdocs-anchor" href="#g3" aria-label="Permalink">#</a>
-</h2>
+g3</h2>
 </div>
 <div>
 <h3>
@@ -365,8 +346,7 @@ g3(<a href="#C">C</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="g4">
-g4<a class="mrdocs-anchor" href="#g4" aria-label="Permalink">#</a>
-</h2>
+g4</h2>
 </div>
 <div>
 <h3>
@@ -380,8 +360,7 @@ g4(<a href="#C">C</a>*);</code></pre>
 <div>
 <div>
 <h2 id="g5">
-g5<a class="mrdocs-anchor" href="#g5" aria-label="Permalink">#</a>
-</h2>
+g5</h2>
 </div>
 <div>
 <h3>
@@ -395,8 +374,7 @@ g5(<a href="#C">C</a> const*);</code></pre>
 <div>
 <div>
 <h2 id="g6">
-g6<a class="mrdocs-anchor" href="#g6" aria-label="Permalink">#</a>
-</h2>
+g6</h2>
 </div>
 <div>
 <h3>
@@ -410,8 +388,7 @@ g6(<a href="#C">C</a>**);</code></pre>
 <div>
 <div>
 <h2 id="g7">
-g7<a class="mrdocs-anchor" href="#g7" aria-label="Permalink">#</a>
-</h2>
+g7</h2>
 </div>
 <div>
 <h3>
@@ -425,8 +402,7 @@ g7(<a href="#C">C</a> const**);</code></pre>
 <div>
 <div>
 <h2 id="g8">
-g8<a class="mrdocs-anchor" href="#g8" aria-label="Permalink">#</a>
-</h2>
+g8</h2>
 </div>
 <div>
 <h3>
@@ -440,8 +416,7 @@ g8(<a href="#C">C</a> const const**);</code></pre>
 <div>
 <div>
 <h2 id="h0">
-h0<a class="mrdocs-anchor" href="#h0" aria-label="Permalink">#</a>
-</h2>
+h0</h2>
 </div>
 <div>
 <h3>
@@ -455,8 +430,7 @@ h0(<a href="#B">B&lt;short, long&gt;</a>);</code></pre>
 <div>
 <div>
 <h2 id="h1">
-h1<a class="mrdocs-anchor" href="#h1" aria-label="Permalink">#</a>
-</h2>
+h1</h2>
 </div>
 <div>
 <h3>
@@ -470,8 +444,7 @@ h1(<a href="#B">B&lt;short, long&gt;</a> const);</code></pre>
 <div>
 <div>
 <h2 id="h2">
-h2<a class="mrdocs-anchor" href="#h2" aria-label="Permalink">#</a>
-</h2>
+h2</h2>
 </div>
 <div>
 <h3>
@@ -485,8 +458,7 @@ h2(<a href="#B">B&lt;short, long&gt;</a>&);</code></pre>
 <div>
 <div>
 <h2 id="h3">
-h3<a class="mrdocs-anchor" href="#h3" aria-label="Permalink">#</a>
-</h2>
+h3</h2>
 </div>
 <div>
 <h3>
@@ -500,8 +472,7 @@ h3(<a href="#B">B&lt;short, long&gt;</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="h4">
-h4<a class="mrdocs-anchor" href="#h4" aria-label="Permalink">#</a>
-</h2>
+h4</h2>
 </div>
 <div>
 <h3>
@@ -515,8 +486,7 @@ h4(<a href="#B">B&lt;short, long&gt;</a>*);</code></pre>
 <div>
 <div>
 <h2 id="h5">
-h5<a class="mrdocs-anchor" href="#h5" aria-label="Permalink">#</a>
-</h2>
+h5</h2>
 </div>
 <div>
 <h3>
@@ -530,8 +500,7 @@ h5(<a href="#B">B&lt;short, long&gt;</a> const*);</code></pre>
 <div>
 <div>
 <h2 id="h6">
-h6<a class="mrdocs-anchor" href="#h6" aria-label="Permalink">#</a>
-</h2>
+h6</h2>
 </div>
 <div>
 <h3>
@@ -545,8 +514,7 @@ h6(<a href="#B">B&lt;short, long&gt;</a>**);</code></pre>
 <div>
 <div>
 <h2 id="h7">
-h7<a class="mrdocs-anchor" href="#h7" aria-label="Permalink">#</a>
-</h2>
+h7</h2>
 </div>
 <div>
 <h3>
@@ -560,8 +528,7 @@ h7(<a href="#B">B&lt;short, long&gt;</a> const**);</code></pre>
 <div>
 <div>
 <h2 id="h8">
-h8<a class="mrdocs-anchor" href="#h8" aria-label="Permalink">#</a>
-</h2>
+h8</h2>
 </div>
 <div>
 <h3>
@@ -575,8 +542,7 @@ h8(<a href="#B">B&lt;short, long&gt;</a> const const**);</code></pre>
 <div>
 <div>
 <h2 id="i0">
-i0<a class="mrdocs-anchor" href="#i0" aria-label="Permalink">#</a>
-</h2>
+i0</h2>
 </div>
 <div>
 <h3>
@@ -590,8 +556,7 @@ i0(<a href="#D">D</a>);</code></pre>
 <div>
 <div>
 <h2 id="i1">
-i1<a class="mrdocs-anchor" href="#i1" aria-label="Permalink">#</a>
-</h2>
+i1</h2>
 </div>
 <div>
 <h3>
@@ -605,8 +570,7 @@ i1(<a href="#D">D</a> const);</code></pre>
 <div>
 <div>
 <h2 id="i2">
-i2<a class="mrdocs-anchor" href="#i2" aria-label="Permalink">#</a>
-</h2>
+i2</h2>
 </div>
 <div>
 <h3>
@@ -620,8 +584,7 @@ i2(<a href="#D">D</a>&);</code></pre>
 <div>
 <div>
 <h2 id="i3">
-i3<a class="mrdocs-anchor" href="#i3" aria-label="Permalink">#</a>
-</h2>
+i3</h2>
 </div>
 <div>
 <h3>
@@ -635,8 +598,7 @@ i3(<a href="#D">D</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="i4">
-i4<a class="mrdocs-anchor" href="#i4" aria-label="Permalink">#</a>
-</h2>
+i4</h2>
 </div>
 <div>
 <h3>
@@ -650,8 +612,7 @@ i4(<a href="#D">D</a>*);</code></pre>
 <div>
 <div>
 <h2 id="i5">
-i5<a class="mrdocs-anchor" href="#i5" aria-label="Permalink">#</a>
-</h2>
+i5</h2>
 </div>
 <div>
 <h3>
@@ -665,8 +626,7 @@ i5(<a href="#D">D</a> const*);</code></pre>
 <div>
 <div>
 <h2 id="i6">
-i6<a class="mrdocs-anchor" href="#i6" aria-label="Permalink">#</a>
-</h2>
+i6</h2>
 </div>
 <div>
 <h3>
@@ -680,8 +640,7 @@ i6(<a href="#D">D</a>**);</code></pre>
 <div>
 <div>
 <h2 id="i7">
-i7<a class="mrdocs-anchor" href="#i7" aria-label="Permalink">#</a>
-</h2>
+i7</h2>
 </div>
 <div>
 <h3>
@@ -695,8 +654,7 @@ i7(<a href="#D">D</a> const**);</code></pre>
 <div>
 <div>
 <h2 id="i8">
-i8<a class="mrdocs-anchor" href="#i8" aria-label="Permalink">#</a>
-</h2>
+i8</h2>
 </div>
 <div>
 <h3>
@@ -710,8 +668,7 @@ i8(<a href="#D">D</a> const const**);</code></pre>
 <div>
 <div>
 <h2 id="j0">
-j0<a class="mrdocs-anchor" href="#j0" aria-label="Permalink">#</a>
-</h2>
+j0</h2>
 </div>
 <div>
 <h3>
@@ -725,8 +682,7 @@ j0(<a href="#E">E&lt;short&gt;</a>);</code></pre>
 <div>
 <div>
 <h2 id="j1">
-j1<a class="mrdocs-anchor" href="#j1" aria-label="Permalink">#</a>
-</h2>
+j1</h2>
 </div>
 <div>
 <h3>
@@ -740,8 +696,7 @@ j1(<a href="#E">E&lt;short&gt;</a> const);</code></pre>
 <div>
 <div>
 <h2 id="j2">
-j2<a class="mrdocs-anchor" href="#j2" aria-label="Permalink">#</a>
-</h2>
+j2</h2>
 </div>
 <div>
 <h3>
@@ -755,8 +710,7 @@ j2(<a href="#E">E&lt;short&gt;</a>&);</code></pre>
 <div>
 <div>
 <h2 id="j3">
-j3<a class="mrdocs-anchor" href="#j3" aria-label="Permalink">#</a>
-</h2>
+j3</h2>
 </div>
 <div>
 <h3>
@@ -770,8 +724,7 @@ j3(<a href="#E">E&lt;short&gt;</a> const&);</code></pre>
 <div>
 <div>
 <h2 id="j4">
-j4<a class="mrdocs-anchor" href="#j4" aria-label="Permalink">#</a>
-</h2>
+j4</h2>
 </div>
 <div>
 <h3>
@@ -785,8 +738,7 @@ j4(<a href="#E">E&lt;short&gt;</a>*);</code></pre>
 <div>
 <div>
 <h2 id="j5">
-j5<a class="mrdocs-anchor" href="#j5" aria-label="Permalink">#</a>
-</h2>
+j5</h2>
 </div>
 <div>
 <h3>
@@ -800,8 +752,7 @@ j5(<a href="#E">E&lt;short&gt;</a> const*);</code></pre>
 <div>
 <div>
 <h2 id="j6">
-j6<a class="mrdocs-anchor" href="#j6" aria-label="Permalink">#</a>
-</h2>
+j6</h2>
 </div>
 <div>
 <h3>
@@ -815,8 +766,7 @@ j6(<a href="#E">E&lt;short&gt;</a>**);</code></pre>
 <div>
 <div>
 <h2 id="j7">
-j7<a class="mrdocs-anchor" href="#j7" aria-label="Permalink">#</a>
-</h2>
+j7</h2>
 </div>
 <div>
 <h3>
@@ -830,8 +780,7 @@ j7(<a href="#E">E&lt;short&gt;</a> const**);</code></pre>
 <div>
 <div>
 <h2 id="j8">
-j8<a class="mrdocs-anchor" href="#j8" aria-label="Permalink">#</a>
-</h2>
+j8</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/function/variadic-function.html
+++ b/test-files/golden-tests/symbols/function/variadic-function.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -47,8 +46,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Declared in <code>&lt;variadic-function.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U">
-U<a class="mrdocs-anchor" href="#U" aria-label="Permalink">#</a>
-</h2>
+U</h2>
 </div>
 <div>
 <h3>
@@ -75,8 +72,7 @@ Declared in <code>&lt;variadic-function.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C">
-C<a class="mrdocs-anchor" href="#C" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>
@@ -94,8 +90,7 @@ struct C;</code></pre>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -109,8 +104,7 @@ f(...);</code></pre>
 <div>
 <div>
 <h2 id="g">
-g<a class="mrdocs-anchor" href="#g" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/guide/explicit-deduct-guide.html
+++ b/test-files/golden-tests/symbols/guide/explicit-deduct-guide.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -47,8 +46,7 @@ Deduction Guides</h2>
 <div>
 <div>
 <h2 id="X-0e">
-X<a class="mrdocs-anchor" href="#X-0e" aria-label="Permalink">#</a>
-</h2>
+X</h2>
 </div>
 <div>
 <h3>
@@ -64,8 +62,7 @@ struct X;</code></pre>
 <div>
 <div>
 <h2 id="X-0d">
-X&lt;0&gt;<a class="mrdocs-anchor" href="#X-0d" aria-label="Permalink">#</a>
-</h2>
+X&lt;0&gt;</h2>
 </div>
 <div>
 <h3>
@@ -78,8 +75,7 @@ Declared in <code>&lt;explicit-deduct-guide.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-00">
-X&lt;0&gt;<a class="mrdocs-anchor" href="#X-00" aria-label="Permalink">#</a>
-</h2>
+X&lt;0&gt;</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +88,7 @@ Declared in <code>&lt;explicit-deduct-guide.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-0b">
-X&lt;0&gt;<a class="mrdocs-anchor" href="#X-0b" aria-label="Permalink">#</a>
-</h2>
+X&lt;0&gt;</h2>
 </div>
 <div>
 <h3>
@@ -106,8 +101,7 @@ Declared in <code>&lt;explicit-deduct-guide.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-06">
-X&lt;0&gt;<a class="mrdocs-anchor" href="#X-06" aria-label="Permalink">#</a>
-</h2>
+X&lt;0&gt;</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/namespace-alias/namespace-alias-1.html
+++ b/test-files/golden-tests/symbols/namespace-alias/namespace-alias-1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Namespace Aliases</h2>
 <div>
 <div>
 <h2 id="LongName">
-LongName<a class="mrdocs-anchor" href="#LongName" aria-label="Permalink">#</a>
-</h2>
+LongName</h2>
 </div>
 <h2>
 Types</h2>
@@ -65,8 +63,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="LongName-A">
-LongName::A<a class="mrdocs-anchor" href="#LongName-A" aria-label="Permalink">#</a>
-</h2>
+LongName::A</h2>
 </div>
 <div>
 <h3>
@@ -81,8 +78,7 @@ Declared in <code>&lt;namespace-alias-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/namespace-alias/namespace-alias-2.html
+++ b/test-files/golden-tests/symbols/namespace-alias/namespace-alias-2.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -45,8 +44,7 @@ Namespace Aliases</h2>
 <div>
 <div>
 <h2 id="LongName">
-LongName<a class="mrdocs-anchor" href="#LongName" aria-label="Permalink">#</a>
-</h2>
+LongName</h2>
 </div>
 <h2>
 Types</h2>
@@ -66,8 +64,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="LongName-A">
-LongName::A<a class="mrdocs-anchor" href="#LongName-A" aria-label="Permalink">#</a>
-</h2>
+LongName::A</h2>
 </div>
 <div>
 <h3>
@@ -82,8 +79,7 @@ Declared in <code>&lt;namespace-alias-2.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -96,8 +92,7 @@ Declared in <code>&lt;namespace-alias-2.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/namespace-alias/namespace-alias-3.html
+++ b/test-files/golden-tests/symbols/namespace-alias/namespace-alias-3.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -45,8 +44,7 @@ Namespace Aliases</h2>
 <div>
 <div>
 <h2 id="LongName">
-LongName<a class="mrdocs-anchor" href="#LongName" aria-label="Permalink">#</a>
-</h2>
+LongName</h2>
 </div>
 <h2>
 Types</h2>
@@ -66,8 +64,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="LongName-A">
-LongName::A<a class="mrdocs-anchor" href="#LongName-A" aria-label="Permalink">#</a>
-</h2>
+LongName::A</h2>
 </div>
 <div>
 <h3>
@@ -82,8 +79,7 @@ Declared in <code>&lt;namespace-alias-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -96,8 +92,7 @@ Declared in <code>&lt;namespace-alias-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/namespace/namespace.html
+++ b/test-files/golden-tests/symbols/namespace/namespace.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -51,8 +50,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -88,8 +86,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A-B">
-A::B<a class="mrdocs-anchor" href="#A-B" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 </div>
 <h2>
 Functions</h2>
@@ -109,8 +106,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A-B-f1">
-A::B::f1<a class="mrdocs-anchor" href="#A-B-f1" aria-label="Permalink">#</a>
-</h2>
+A::B::f1</h2>
 </div>
 <div>
 <h3>
@@ -124,8 +120,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="A-f0">
-A::f0<a class="mrdocs-anchor" href="#A-f0" aria-label="Permalink">#</a>
-</h2>
+A::f0</h2>
 </div>
 <div>
 <h3>
@@ -139,8 +134,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="A-f2">
-A::f2<a class="mrdocs-anchor" href="#A-f2" aria-label="Permalink">#</a>
-</h2>
+A::f2</h2>
 </div>
 <div>
 <h3>
@@ -154,8 +148,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="A-f3">
-A::f3<a class="mrdocs-anchor" href="#A-f3" aria-label="Permalink">#</a>
-</h2>
+A::f3</h2>
 </div>
 <div>
 <h3>
@@ -169,8 +162,7 @@ f3();</code></pre>
 <div>
 <div>
 <h2 id="E">
-E<a class="mrdocs-anchor" href="#E" aria-label="Permalink">#</a>
-</h2>
+E</h2>
 </div>
 <h2>
 Functions</h2>
@@ -190,8 +182,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="E-f6">
-E::f6<a class="mrdocs-anchor" href="#E-f6" aria-label="Permalink">#</a>
-</h2>
+E::f6</h2>
 </div>
 <div>
 <h3>
@@ -205,8 +196,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="G">
-G<a class="mrdocs-anchor" href="#G" aria-label="Permalink">#</a>
-</h2>
+G</h2>
 </div>
 <h2>
 Functions</h2>
@@ -226,8 +216,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="G-f11">
-G::f11<a class="mrdocs-anchor" href="#G-f11" aria-label="Permalink">#</a>
-</h2>
+G::f11</h2>
 </div>
 <div>
 <h3>
@@ -241,8 +230,7 @@ f11();</code></pre>
 <div>
 <div>
 <h2 id="I">
-I<a class="mrdocs-anchor" href="#I" aria-label="Permalink">#</a>
-</h2>
+I</h2>
 </div>
 <h2>
 Functions</h2>
@@ -262,8 +250,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="I-f14">
-I::f14<a class="mrdocs-anchor" href="#I-f14" aria-label="Permalink">#</a>
-</h2>
+I::f14</h2>
 </div>
 <div>
 <h3>
@@ -277,8 +264,7 @@ f14();</code></pre>
 <div>
 <div>
 <h2 id="f10">
-f10<a class="mrdocs-anchor" href="#f10" aria-label="Permalink">#</a>
-</h2>
+f10</h2>
 </div>
 <div>
 <h3>
@@ -292,8 +278,7 @@ f10();</code></pre>
 <div>
 <div>
 <h2 id="f12">
-f12<a class="mrdocs-anchor" href="#f12" aria-label="Permalink">#</a>
-</h2>
+f12</h2>
 </div>
 <div>
 <h3>
@@ -307,8 +292,7 @@ f12();</code></pre>
 <div>
 <div>
 <h2 id="f5">
-f5<a class="mrdocs-anchor" href="#f5" aria-label="Permalink">#</a>
-</h2>
+f5</h2>
 </div>
 <div>
 <h3>
@@ -322,8 +306,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="f7">
-f7<a class="mrdocs-anchor" href="#f7" aria-label="Permalink">#</a>
-</h2>
+f7</h2>
 </div>
 <div>
 <h3>
@@ -337,8 +320,7 @@ f7();</code></pre>
 <div>
 <div>
 <h2 id="f8">
-f8<a class="mrdocs-anchor" href="#f8" aria-label="Permalink">#</a>
-</h2>
+f8</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/overloads/overloads-brief.html
+++ b/test-files/golden-tests/symbols/overloads/overloads-brief.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -47,8 +46,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>Overload briefs from function or operator classes</p>
 </div>
@@ -98,8 +96,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="A-2constructor-0f">
-A::A<a class="mrdocs-anchor" href="#A-2constructor-0f" aria-label="Permalink">#</a>
-</h2>
+A::A</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -140,8 +137,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-2constructor-03">
-A::A<a class="mrdocs-anchor" href="#A-2constructor-03" aria-label="Permalink">#</a>
-</h2>
+A::A</h2>
 <div>
 <p>First constructor</p>
 </div>
@@ -157,8 +153,7 @@ Declared in <code>&lt;overloads-brief.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-2constructor-01">
-A::A<a class="mrdocs-anchor" href="#A-2constructor-01" aria-label="Permalink">#</a>
-</h2>
+A::A</h2>
 <div>
 <p>Second constructor</p>
 </div>
@@ -192,8 +187,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-operator_assign-04c">
-A::operator&#x3D;<a class="mrdocs-anchor" href="#A-operator_assign-04c" aria-label="Permalink">#</a>
-</h2>
+A::operator&#x3D;</h2>
 <div>
 <p>Assignment operators</p>
 </div>
@@ -241,8 +235,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-operator_assign-045">
-A::operator&#x3D;<a class="mrdocs-anchor" href="#A-operator_assign-045" aria-label="Permalink">#</a>
-</h2>
+A::operator&#x3D;</h2>
 <div>
 <p>Assign from A</p>
 </div>
@@ -282,8 +275,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-operator_assign-06">
-A::operator&#x3D;<a class="mrdocs-anchor" href="#A-operator_assign-06" aria-label="Permalink">#</a>
-</h2>
+A::operator&#x3D;</h2>
 <div>
 <p>Assign from int</p>
 </div>
@@ -323,8 +315,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-operator_plus-00">
-A::operator+<a class="mrdocs-anchor" href="#A-operator_plus-00" aria-label="Permalink">#</a>
-</h2>
+A::operator+</h2>
 <div>
 <p>Addition operators</p>
 </div>
@@ -372,8 +363,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-operator_plus-0c">
-A::operator+<a class="mrdocs-anchor" href="#A-operator_plus-0c" aria-label="Permalink">#</a>
-</h2>
+A::operator+</h2>
 <div>
 <p>Addition operator for ints</p>
 </div>
@@ -413,8 +403,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-operator_plus-0e">
-A::operator+<a class="mrdocs-anchor" href="#A-operator_plus-0e" aria-label="Permalink">#</a>
-</h2>
+A::operator+</h2>
 <div>
 <p>Addition operator for As</p>
 </div>
@@ -454,8 +443,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-operator_minus-09">
-A::operator-<a class="mrdocs-anchor" href="#A-operator_minus-09" aria-label="Permalink">#</a>
-</h2>
+A::operator-</h2>
 <div>
 <p>Unary minus operators</p>
 </div>
@@ -485,8 +473,7 @@ Result
 <div>
 <div>
 <h2 id="A-operator_minus-02">
-A::operator-<a class="mrdocs-anchor" href="#A-operator_minus-02" aria-label="Permalink">#</a>
-</h2>
+A::operator-</h2>
 <div>
 <p>Unary operator- for A</p>
 </div>
@@ -513,8 +500,7 @@ Result
 <div>
 <div>
 <h2 id="A-operator_minus-0c">
-A::operator-<a class="mrdocs-anchor" href="#A-operator_minus-0c" aria-label="Permalink">#</a>
-</h2>
+A::operator-</h2>
 <div>
 <p>Binary operator- for A</p>
 </div>
@@ -559,8 +545,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 <div>
 <p>Auxiliary class</p>
 </div>
@@ -593,8 +578,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="no_way_to_infer_this_brief-04">
-no_way_to_infer_this_brief<a class="mrdocs-anchor" href="#no_way_to_infer_this_brief-04" aria-label="Permalink">#</a>
-</h2>
+no_way_to_infer_this_brief</h2>
 <div>
 <p><code>no_way_to_infer_this_brief</code> overloads</p>
 </div>
@@ -637,8 +621,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="no_way_to_infer_this_brief-02">
-no_way_to_infer_this_brief<a class="mrdocs-anchor" href="#no_way_to_infer_this_brief-02" aria-label="Permalink">#</a>
-</h2>
+no_way_to_infer_this_brief</h2>
 <div>
 <p>Function with no params</p>
 </div>
@@ -655,8 +638,7 @@ no_way_to_infer_this_brief();</code></pre>
 <div>
 <div>
 <h2 id="no_way_to_infer_this_brief-01">
-no_way_to_infer_this_brief<a class="mrdocs-anchor" href="#no_way_to_infer_this_brief-01" aria-label="Permalink">#</a>
-</h2>
+no_way_to_infer_this_brief</h2>
 <div>
 <p>Function with single param</p>
 </div>
@@ -691,8 +673,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_plus-09">
-operator+<a class="mrdocs-anchor" href="#operator_plus-09" aria-label="Permalink">#</a>
-</h2>
+operator+</h2>
 <div>
 <p>Unary plus operators</p>
 </div>
@@ -722,8 +703,7 @@ Result
 <div>
 <div>
 <h2 id="operator_plus-0d">
-operator+<a class="mrdocs-anchor" href="#operator_plus-0d" aria-label="Permalink">#</a>
-</h2>
+operator+</h2>
 <div>
 <p>Unary operator for A</p>
 </div>
@@ -763,8 +743,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_plus-06">
-operator+<a class="mrdocs-anchor" href="#operator_plus-06" aria-label="Permalink">#</a>
-</h2>
+operator+</h2>
 <div>
 <p>Unary operator for B</p>
 </div>
@@ -804,8 +783,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="sameBrief-07">
-sameBrief<a class="mrdocs-anchor" href="#sameBrief-07" aria-label="Permalink">#</a>
-</h2>
+sameBrief</h2>
 <div>
 <p>Function with same brief</p>
 </div>
@@ -854,8 +832,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="sameBrief-0a">
-sameBrief<a class="mrdocs-anchor" href="#sameBrief-0a" aria-label="Permalink">#</a>
-</h2>
+sameBrief</h2>
 <div>
 <p>Function with same brief</p>
 </div>
@@ -890,8 +867,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="sameBrief-0e">
-sameBrief<a class="mrdocs-anchor" href="#sameBrief-0e" aria-label="Permalink">#</a>
-</h2>
+sameBrief</h2>
 <div>
 <p>Function with same brief</p>
 </div>

--- a/test-files/golden-tests/symbols/overloads/overloads-metadata.html
+++ b/test-files/golden-tests/symbols/overloads/overloads-metadata.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f-0c">
-f<a class="mrdocs-anchor" href="#f-0c" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Test function</p>
 </div>
@@ -167,8 +165,7 @@ See Also</h3>
 <div>
 <div>
 <h2 id="f-08">
-f<a class="mrdocs-anchor" href="#f-08" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Test function</p>
 </div>
@@ -265,8 +262,7 @@ See Also</h3>
 <div>
 <div>
 <h2 id="f-04">
-f<a class="mrdocs-anchor" href="#f-04" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Test function</p>
 </div>
@@ -314,8 +310,7 @@ See Also</h3>
 <div>
 <div>
 <h2 id="f-02">
-f<a class="mrdocs-anchor" href="#f-02" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Test function</p>
 </div>

--- a/test-files/golden-tests/symbols/overloads/overloads-ostream.html
+++ b/test-files/golden-tests/symbols/overloads/overloads-ostream.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -31,8 +30,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="left_shift">
-left_shift<a class="mrdocs-anchor" href="#left_shift" aria-label="Permalink">#</a>
-</h2>
+left_shift</h2>
 </div>
 <h2>
 Types</h2>
@@ -66,8 +64,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="left_shift-A">
-left_shift::A<a class="mrdocs-anchor" href="#left_shift-A" aria-label="Permalink">#</a>
-</h2>
+left_shift::A</h2>
 </div>
 <div>
 <h3>
@@ -96,8 +93,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="left_shift-A-operator_lshift-00">
-left_shift::A::operator&lt;&lt;<a class="mrdocs-anchor" href="#left_shift-A-operator_lshift-00" aria-label="Permalink">#</a>
-</h2>
+left_shift::A::operator&lt;&lt;</h2>
 <div>
 <p>Left shift operators</p>
 </div>
@@ -122,8 +118,7 @@ Declared in <code>&lt;overloads-ostream.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="left_shift-A-operator_lshift-0f">
-left_shift::A::operator&lt;&lt;<a class="mrdocs-anchor" href="#left_shift-A-operator_lshift-0f" aria-label="Permalink">#</a>
-</h2>
+left_shift::A::operator&lt;&lt;</h2>
 <div>
 <p>Left shift operator</p>
 </div>
@@ -163,8 +158,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="left_shift-A-operator_lshift-0b">
-left_shift::A::operator&lt;&lt;<a class="mrdocs-anchor" href="#left_shift-A-operator_lshift-0b" aria-label="Permalink">#</a>
-</h2>
+left_shift::A::operator&lt;&lt;</h2>
 <div>
 <p>Left shift operator</p>
 </div>
@@ -204,8 +198,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="left_shift-operator_lshift">
-left_shift::operator&lt;&lt;<a class="mrdocs-anchor" href="#left_shift-operator_lshift" aria-label="Permalink">#</a>
-</h2>
+left_shift::operator&lt;&lt;</h2>
 </div>
 <div>
 <h3>
@@ -221,8 +214,7 @@ operator&lt;&lt;(
 <div>
 <div>
 <h2 id="ostream">
-ostream<a class="mrdocs-anchor" href="#ostream" aria-label="Permalink">#</a>
-</h2>
+ostream</h2>
 </div>
 <h2>
 Types</h2>
@@ -258,8 +250,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="ostream-B">
-ostream::B<a class="mrdocs-anchor" href="#ostream-B" aria-label="Permalink">#</a>
-</h2>
+ostream::B</h2>
 </div>
 <div>
 <h3>
@@ -293,8 +284,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="ostream-C">
-ostream::C<a class="mrdocs-anchor" href="#ostream-C" aria-label="Permalink">#</a>
-</h2>
+ostream::C</h2>
 </div>
 <div>
 <h3>
@@ -309,8 +299,7 @@ Declared in <code>&lt;overloads-ostream.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="ostream-OStream">
-ostream::OStream<a class="mrdocs-anchor" href="#ostream-OStream" aria-label="Permalink">#</a>
-</h2>
+ostream::OStream</h2>
 </div>
 <div>
 <h3>
@@ -341,8 +330,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="ostream-operator_lshift-0f">
-ostream::operator&lt;&lt;<a class="mrdocs-anchor" href="#ostream-operator_lshift-0f" aria-label="Permalink">#</a>
-</h2>
+ostream::operator&lt;&lt;</h2>
 <div>
 <p>Stream insertion operators</p>
 </div>
@@ -371,8 +359,7 @@ Declared in <code>&lt;overloads-ostream.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="ostream-operator_lshift-0d">
-ostream::operator&lt;&lt;<a class="mrdocs-anchor" href="#ostream-operator_lshift-0d" aria-label="Permalink">#</a>
-</h2>
+ostream::operator&lt;&lt;</h2>
 <div>
 <p>Stream insertion operator</p>
 </div>
@@ -418,8 +405,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="ostream-operator_lshift-0a">
-ostream::operator&lt;&lt;<a class="mrdocs-anchor" href="#ostream-operator_lshift-0a" aria-label="Permalink">#</a>
-</h2>
+ostream::operator&lt;&lt;</h2>
 <div>
 <p>Stream insertion operator</p>
 </div>

--- a/test-files/golden-tests/symbols/overloads/overloads.html
+++ b/test-files/golden-tests/symbols/overloads/overloads.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -46,8 +45,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -113,8 +111,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="A-f-07">
-A::f<a class="mrdocs-anchor" href="#A-f-07" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -136,8 +133,7 @@ Declared in <code>&lt;overloads.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-f-08">
-A::f<a class="mrdocs-anchor" href="#A-f-08" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -151,8 +147,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-f-0e">
-A::f<a class="mrdocs-anchor" href="#A-f-0e" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -166,8 +161,7 @@ f(int);</code></pre>
 <div>
 <div>
 <h2 id="A-g-0d">
-A::g<a class="mrdocs-anchor" href="#A-g-0d" aria-label="Permalink">#</a>
-</h2>
+A::g</h2>
 </div>
 <div>
 <h3>
@@ -191,8 +185,7 @@ int
 <div>
 <div>
 <h2 id="A-g-0a">
-A::g<a class="mrdocs-anchor" href="#A-g-0a" aria-label="Permalink">#</a>
-</h2>
+A::g</h2>
 </div>
 <div>
 <h3>
@@ -207,8 +200,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="A-g-01">
-A::g<a class="mrdocs-anchor" href="#A-g-01" aria-label="Permalink">#</a>
-</h2>
+A::g</h2>
 </div>
 <div>
 <h3>
@@ -223,8 +215,7 @@ g(int);</code></pre>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -255,8 +246,7 @@ Non-Member Functions</h2>
 <div>
 <div>
 <h2 id="f-0c">
-f<a class="mrdocs-anchor" href="#f-0c" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -278,8 +268,7 @@ Declared in <code>&lt;overloads.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="f-0b">
-f<a class="mrdocs-anchor" href="#f-0b" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -293,8 +282,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="f-06">
-f<a class="mrdocs-anchor" href="#f-06" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -308,8 +296,7 @@ f(int);</code></pre>
 <div>
 <div>
 <h2 id="operator_eq-073">
-operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#operator_eq-073" aria-label="Permalink">#</a>
-</h2>
+operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operators</p>
 </div>
@@ -352,8 +339,7 @@ Declared in <code>&lt;overloads.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="operator_eq-0e">
-operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#operator_eq-0e" aria-label="Permalink">#</a>
-</h2>
+operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -399,8 +385,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_eq-0a">
-operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#operator_eq-0a" aria-label="Permalink">#</a>
-</h2>
+operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -446,8 +431,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_eq-08">
-operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#operator_eq-08" aria-label="Permalink">#</a>
-</h2>
+operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>
@@ -493,8 +477,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="operator_eq-071">
-operator&#x3D;&#x3D;<a class="mrdocs-anchor" href="#operator_eq-071" aria-label="Permalink">#</a>
-</h2>
+operator&#x3D;&#x3D;</h2>
 <div>
 <p>Equality operator</p>
 </div>

--- a/test-files/golden-tests/symbols/record/class-private-alias.html
+++ b/test-files/golden-tests/symbols/record/class-private-alias.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="S">
-S<a class="mrdocs-anchor" href="#S" aria-label="Permalink">#</a>
-</h2>
+S</h2>
 </div>
 <div>
 <h3>
@@ -60,8 +58,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S-f">
-S::f<a class="mrdocs-anchor" href="#S-f" aria-label="Permalink">#</a>
-</h2>
+S::f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/class-template-partial-spec.html
+++ b/test-files/golden-tests/symbols/record/class-template-partial-spec.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -63,8 +61,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-B-0a">
-A::B<a class="mrdocs-anchor" href="#A-B-0a" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 </div>
 <div>
 <h3>
@@ -82,8 +79,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="A-B-04">
-A::B&lt;T, long&gt;<a class="mrdocs-anchor" href="#A-B-04" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;T, long&gt;</h2>
 </div>
 <div>
 <h3>
@@ -99,8 +95,7 @@ struct <a href="#A-B-0a">B</a>&lt;T, long&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-B-06">
-A::B&lt;U*, T&gt;<a class="mrdocs-anchor" href="#A-B-06" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;U*, T&gt;</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/class-template-spec.html
+++ b/test-files/golden-tests/symbols/record/class-template-spec.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -38,8 +37,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e">
-A<a class="mrdocs-anchor" href="#A-0e" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -69,8 +67,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0e-f">
-A::f<a class="mrdocs-anchor" href="#A-0e-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -84,8 +81,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-00">
-A&lt;int&gt;<a class="mrdocs-anchor" href="#A-00" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -115,8 +111,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-00-g">
-A&lt;int&gt;::g<a class="mrdocs-anchor" href="#A-00-g" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::g</h2>
 </div>
 <div>
 <h3>
@@ -130,8 +125,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="A-0c">
-A&lt;long&gt;<a class="mrdocs-anchor" href="#A-0c" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;</h2>
 </div>
 <div>
 <h3>
@@ -161,8 +155,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0c-h">
-A&lt;long&gt;::h<a class="mrdocs-anchor" href="#A-0c-h" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::h</h2>
 </div>
 <div>
 <h3>
@@ -176,8 +169,7 @@ h();</code></pre>
 <div>
 <div>
 <h2 id="B-00">
-B<a class="mrdocs-anchor" href="#B-00" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -207,8 +199,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="B-00-f">
-B::f<a class="mrdocs-anchor" href="#B-00-f" aria-label="Permalink">#</a>
-</h2>
+B::f</h2>
 </div>
 <div>
 <h3>
@@ -222,8 +213,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="B-06">
-B&lt;T&&gt;<a class="mrdocs-anchor" href="#B-06" aria-label="Permalink">#</a>
-</h2>
+B&lt;T&&gt;</h2>
 </div>
 <div>
 <h3>
@@ -253,8 +243,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="B-06-h">
-B&lt;T&&gt;::h<a class="mrdocs-anchor" href="#B-06-h" aria-label="Permalink">#</a>
-</h2>
+B&lt;T&&gt;::h</h2>
 </div>
 <div>
 <h3>
@@ -268,8 +257,7 @@ h();</code></pre>
 <div>
 <div>
 <h2 id="B-07">
-B&lt;T*&gt;<a class="mrdocs-anchor" href="#B-07" aria-label="Permalink">#</a>
-</h2>
+B&lt;T*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -299,8 +287,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="B-07-g">
-B&lt;T*&gt;::g<a class="mrdocs-anchor" href="#B-07-g" aria-label="Permalink">#</a>
-</h2>
+B&lt;T*&gt;::g</h2>
 </div>
 <div>
 <h3>
@@ -314,8 +301,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="C-0f">
-C<a class="mrdocs-anchor" href="#C-0f" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>
@@ -347,8 +333,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="C-0f-f">
-C::f<a class="mrdocs-anchor" href="#C-0f-f" aria-label="Permalink">#</a>
-</h2>
+C::f</h2>
 </div>
 <div>
 <h3>
@@ -362,8 +347,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="C-0a">
-C&lt;int, int&gt;<a class="mrdocs-anchor" href="#C-0a" aria-label="Permalink">#</a>
-</h2>
+C&lt;int, int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -393,8 +377,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="C-0a-g">
-C&lt;int, int&gt;::g<a class="mrdocs-anchor" href="#C-0a-g" aria-label="Permalink">#</a>
-</h2>
+C&lt;int, int&gt;::g</h2>
 </div>
 <div>
 <h3>
@@ -408,8 +391,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="C-0e">
-C&lt;T*, int&gt;<a class="mrdocs-anchor" href="#C-0e" aria-label="Permalink">#</a>
-</h2>
+C&lt;T*, int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -439,8 +421,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="C-0e-h">
-C&lt;T*, int&gt;::h<a class="mrdocs-anchor" href="#C-0e-h" aria-label="Permalink">#</a>
-</h2>
+C&lt;T*, int&gt;::h</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/class-template-specializations-1.html
+++ b/test-files/golden-tests/symbols/record/class-template-specializations-1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -120,8 +119,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="R0">
-R0<a class="mrdocs-anchor" href="#R0" aria-label="Permalink">#</a>
-</h2>
+R0</h2>
 </div>
 <div>
 <h3>
@@ -181,8 +179,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="R1">
-R1<a class="mrdocs-anchor" href="#R1" aria-label="Permalink">#</a>
-</h2>
+R1</h2>
 </div>
 <div>
 <h3>
@@ -213,8 +210,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R10">
-R10<a class="mrdocs-anchor" href="#R10" aria-label="Permalink">#</a>
-</h2>
+R10</h2>
 </div>
 <div>
 <h3>
@@ -245,8 +241,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R11">
-R11<a class="mrdocs-anchor" href="#R11" aria-label="Permalink">#</a>
-</h2>
+R11</h2>
 </div>
 <div>
 <h3>
@@ -277,8 +272,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R12">
-R12<a class="mrdocs-anchor" href="#R12" aria-label="Permalink">#</a>
-</h2>
+R12</h2>
 </div>
 <div>
 <h3>
@@ -309,8 +303,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R13">
-R13<a class="mrdocs-anchor" href="#R13" aria-label="Permalink">#</a>
-</h2>
+R13</h2>
 </div>
 <div>
 <h3>
@@ -341,8 +334,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R14">
-R14<a class="mrdocs-anchor" href="#R14" aria-label="Permalink">#</a>
-</h2>
+R14</h2>
 </div>
 <div>
 <h3>
@@ -373,8 +365,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R15">
-R15<a class="mrdocs-anchor" href="#R15" aria-label="Permalink">#</a>
-</h2>
+R15</h2>
 </div>
 <div>
 <h3>
@@ -405,8 +396,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R16">
-R16<a class="mrdocs-anchor" href="#R16" aria-label="Permalink">#</a>
-</h2>
+R16</h2>
 </div>
 <div>
 <h3>
@@ -437,8 +427,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R17">
-R17<a class="mrdocs-anchor" href="#R17" aria-label="Permalink">#</a>
-</h2>
+R17</h2>
 </div>
 <div>
 <h3>
@@ -469,8 +458,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R18">
-R18<a class="mrdocs-anchor" href="#R18" aria-label="Permalink">#</a>
-</h2>
+R18</h2>
 </div>
 <div>
 <h3>
@@ -501,8 +489,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R19">
-R19<a class="mrdocs-anchor" href="#R19" aria-label="Permalink">#</a>
-</h2>
+R19</h2>
 </div>
 <div>
 <h3>
@@ -533,8 +520,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R2">
-R2<a class="mrdocs-anchor" href="#R2" aria-label="Permalink">#</a>
-</h2>
+R2</h2>
 </div>
 <div>
 <h3>
@@ -594,8 +580,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="R20">
-R20<a class="mrdocs-anchor" href="#R20" aria-label="Permalink">#</a>
-</h2>
+R20</h2>
 </div>
 <div>
 <h3>
@@ -626,8 +611,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R21">
-R21<a class="mrdocs-anchor" href="#R21" aria-label="Permalink">#</a>
-</h2>
+R21</h2>
 </div>
 <div>
 <h3>
@@ -658,8 +642,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R22">
-R22<a class="mrdocs-anchor" href="#R22" aria-label="Permalink">#</a>
-</h2>
+R22</h2>
 </div>
 <div>
 <h3>
@@ -690,8 +673,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R23">
-R23<a class="mrdocs-anchor" href="#R23" aria-label="Permalink">#</a>
-</h2>
+R23</h2>
 </div>
 <div>
 <h3>
@@ -722,8 +704,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R24">
-R24<a class="mrdocs-anchor" href="#R24" aria-label="Permalink">#</a>
-</h2>
+R24</h2>
 </div>
 <div>
 <h3>
@@ -754,8 +735,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R25">
-R25<a class="mrdocs-anchor" href="#R25" aria-label="Permalink">#</a>
-</h2>
+R25</h2>
 </div>
 <div>
 <h3>
@@ -786,8 +766,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R26">
-R26<a class="mrdocs-anchor" href="#R26" aria-label="Permalink">#</a>
-</h2>
+R26</h2>
 </div>
 <div>
 <h3>
@@ -818,8 +797,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R27">
-R27<a class="mrdocs-anchor" href="#R27" aria-label="Permalink">#</a>
-</h2>
+R27</h2>
 </div>
 <div>
 <h3>
@@ -850,8 +828,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R28">
-R28<a class="mrdocs-anchor" href="#R28" aria-label="Permalink">#</a>
-</h2>
+R28</h2>
 </div>
 <div>
 <h3>
@@ -911,8 +888,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="R29">
-R29<a class="mrdocs-anchor" href="#R29" aria-label="Permalink">#</a>
-</h2>
+R29</h2>
 </div>
 <div>
 <h3>
@@ -972,8 +948,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="R3">
-R3<a class="mrdocs-anchor" href="#R3" aria-label="Permalink">#</a>
-</h2>
+R3</h2>
 </div>
 <div>
 <h3>
@@ -1004,8 +979,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R30">
-R30<a class="mrdocs-anchor" href="#R30" aria-label="Permalink">#</a>
-</h2>
+R30</h2>
 </div>
 <div>
 <h3>
@@ -1064,8 +1038,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="R31">
-R31<a class="mrdocs-anchor" href="#R31" aria-label="Permalink">#</a>
-</h2>
+R31</h2>
 </div>
 <div>
 <h3>
@@ -1099,8 +1072,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R32">
-R32<a class="mrdocs-anchor" href="#R32" aria-label="Permalink">#</a>
-</h2>
+R32</h2>
 </div>
 <div>
 <h3>
@@ -1131,8 +1103,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R33">
-R33<a class="mrdocs-anchor" href="#R33" aria-label="Permalink">#</a>
-</h2>
+R33</h2>
 </div>
 <div>
 <h3>
@@ -1163,8 +1134,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R34">
-R34<a class="mrdocs-anchor" href="#R34" aria-label="Permalink">#</a>
-</h2>
+R34</h2>
 </div>
 <div>
 <h3>
@@ -1209,8 +1179,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="R35">
-R35<a class="mrdocs-anchor" href="#R35" aria-label="Permalink">#</a>
-</h2>
+R35</h2>
 </div>
 <div>
 <h3>
@@ -1244,8 +1213,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R36">
-R36<a class="mrdocs-anchor" href="#R36" aria-label="Permalink">#</a>
-</h2>
+R36</h2>
 </div>
 <div>
 <h3>
@@ -1276,8 +1244,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R37">
-R37<a class="mrdocs-anchor" href="#R37" aria-label="Permalink">#</a>
-</h2>
+R37</h2>
 </div>
 <div>
 <h3>
@@ -1308,8 +1275,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R38">
-R38<a class="mrdocs-anchor" href="#R38" aria-label="Permalink">#</a>
-</h2>
+R38</h2>
 </div>
 <div>
 <h3>
@@ -1343,8 +1309,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R39">
-R39<a class="mrdocs-anchor" href="#R39" aria-label="Permalink">#</a>
-</h2>
+R39</h2>
 </div>
 <div>
 <h3>
@@ -1375,8 +1340,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R4">
-R4<a class="mrdocs-anchor" href="#R4" aria-label="Permalink">#</a>
-</h2>
+R4</h2>
 </div>
 <div>
 <h3>
@@ -1407,8 +1371,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R40">
-R40<a class="mrdocs-anchor" href="#R40" aria-label="Permalink">#</a>
-</h2>
+R40</h2>
 </div>
 <div>
 <h3>
@@ -1439,8 +1402,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R41">
-R41<a class="mrdocs-anchor" href="#R41" aria-label="Permalink">#</a>
-</h2>
+R41</h2>
 </div>
 <div>
 <h3>
@@ -1499,8 +1461,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="R42">
-R42<a class="mrdocs-anchor" href="#R42" aria-label="Permalink">#</a>
-</h2>
+R42</h2>
 </div>
 <div>
 <h3>
@@ -1534,8 +1495,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R43">
-R43<a class="mrdocs-anchor" href="#R43" aria-label="Permalink">#</a>
-</h2>
+R43</h2>
 </div>
 <div>
 <h3>
@@ -1566,8 +1526,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R44">
-R44<a class="mrdocs-anchor" href="#R44" aria-label="Permalink">#</a>
-</h2>
+R44</h2>
 </div>
 <div>
 <h3>
@@ -1598,8 +1557,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R45">
-R45<a class="mrdocs-anchor" href="#R45" aria-label="Permalink">#</a>
-</h2>
+R45</h2>
 </div>
 <div>
 <h3>
@@ -1644,8 +1602,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="R46">
-R46<a class="mrdocs-anchor" href="#R46" aria-label="Permalink">#</a>
-</h2>
+R46</h2>
 </div>
 <div>
 <h3>
@@ -1679,8 +1636,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R47">
-R47<a class="mrdocs-anchor" href="#R47" aria-label="Permalink">#</a>
-</h2>
+R47</h2>
 </div>
 <div>
 <h3>
@@ -1711,8 +1667,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R48">
-R48<a class="mrdocs-anchor" href="#R48" aria-label="Permalink">#</a>
-</h2>
+R48</h2>
 </div>
 <div>
 <h3>
@@ -1743,8 +1698,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R5">
-R5<a class="mrdocs-anchor" href="#R5" aria-label="Permalink">#</a>
-</h2>
+R5</h2>
 </div>
 <div>
 <h3>
@@ -1775,8 +1729,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R6">
-R6<a class="mrdocs-anchor" href="#R6" aria-label="Permalink">#</a>
-</h2>
+R6</h2>
 </div>
 <div>
 <h3>
@@ -1807,8 +1760,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R7">
-R7<a class="mrdocs-anchor" href="#R7" aria-label="Permalink">#</a>
-</h2>
+R7</h2>
 </div>
 <div>
 <h3>
@@ -1839,8 +1791,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R8">
-R8<a class="mrdocs-anchor" href="#R8" aria-label="Permalink">#</a>
-</h2>
+R8</h2>
 </div>
 <div>
 <h3>
@@ -1871,8 +1822,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R9">
-R9<a class="mrdocs-anchor" href="#R9" aria-label="Permalink">#</a>
-</h2>
+R9</h2>
 </div>
 <div>
 <h3>
@@ -1903,8 +1853,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="S0-0cf">
-S0<a class="mrdocs-anchor" href="#S0-0cf" aria-label="Permalink">#</a>
-</h2>
+S0</h2>
 </div>
 <div>
 <h3>
@@ -1973,8 +1922,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0cf-S1">
-S0::S1<a class="mrdocs-anchor" href="#S0-0cf-S1" aria-label="Permalink">#</a>
-</h2>
+S0::S1</h2>
 </div>
 <div>
 <h3>
@@ -2017,8 +1965,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cf-S1-S2">
-S0::S1::S2<a class="mrdocs-anchor" href="#S0-0cf-S1-S2" aria-label="Permalink">#</a>
-</h2>
+S0::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -2065,8 +2012,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cf-S1-S2-S3">
-S0::S1::S2::S3<a class="mrdocs-anchor" href="#S0-0cf-S1-S2-S3" aria-label="Permalink">#</a>
-</h2>
+S0::S1::S2::S3</h2>
 </div>
 <div>
 <h3>
@@ -2095,8 +2041,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cf-S1-S2-S3-f3">
-S0::S1::S2::S3::f3<a class="mrdocs-anchor" href="#S0-0cf-S1-S2-S3-f3" aria-label="Permalink">#</a>
-</h2>
+S0::S1::S2::S3::f3</h2>
 </div>
 <div>
 <h3>
@@ -2110,8 +2055,7 @@ f3();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cf-S1-S2-S4">
-S0::S1::S2::S4<a class="mrdocs-anchor" href="#S0-0cf-S1-S2-S4" aria-label="Permalink">#</a>
-</h2>
+S0::S1::S2::S4</h2>
 </div>
 <div>
 <h3>
@@ -2143,8 +2087,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cf-S1-S2-S4-f4">
-S0::S1::S2::S4::f4<a class="mrdocs-anchor" href="#S0-0cf-S1-S2-S4-f4" aria-label="Permalink">#</a>
-</h2>
+S0::S1::S2::S4::f4</h2>
 </div>
 <div>
 <h3>
@@ -2158,8 +2101,7 @@ f4();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cf-S1-S2-f2">
-S0::S1::S2::f2<a class="mrdocs-anchor" href="#S0-0cf-S1-S2-f2" aria-label="Permalink">#</a>
-</h2>
+S0::S1::S2::f2</h2>
 </div>
 <div>
 <h3>
@@ -2173,8 +2115,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cf-S1-f1">
-S0::S1::f1<a class="mrdocs-anchor" href="#S0-0cf-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -2188,8 +2129,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cf-S5">
-S0::S5<a class="mrdocs-anchor" href="#S0-0cf-S5" aria-label="Permalink">#</a>
-</h2>
+S0::S5</h2>
 </div>
 <div>
 <h3>
@@ -2235,8 +2175,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cf-S5-S6">
-S0::S5::S6<a class="mrdocs-anchor" href="#S0-0cf-S5-S6" aria-label="Permalink">#</a>
-</h2>
+S0::S5::S6</h2>
 </div>
 <div>
 <h3>
@@ -2279,8 +2218,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cf-S5-S6-S7">
-S0::S5::S6::S7<a class="mrdocs-anchor" href="#S0-0cf-S5-S6-S7" aria-label="Permalink">#</a>
-</h2>
+S0::S5::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -2327,8 +2265,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cf-S5-S6-S7-S8">
-S0::S5::S6::S7::S8<a class="mrdocs-anchor" href="#S0-0cf-S5-S6-S7-S8" aria-label="Permalink">#</a>
-</h2>
+S0::S5::S6::S7::S8</h2>
 </div>
 <div>
 <h3>
@@ -2357,8 +2294,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cf-S5-S6-S7-S8-f8">
-S0::S5::S6::S7::S8::f8<a class="mrdocs-anchor" href="#S0-0cf-S5-S6-S7-S8-f8" aria-label="Permalink">#</a>
-</h2>
+S0::S5::S6::S7::S8::f8</h2>
 </div>
 <div>
 <h3>
@@ -2372,8 +2308,7 @@ f8();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cf-S5-S6-S7-S9">
-S0::S5::S6::S7::S9<a class="mrdocs-anchor" href="#S0-0cf-S5-S6-S7-S9" aria-label="Permalink">#</a>
-</h2>
+S0::S5::S6::S7::S9</h2>
 </div>
 <div>
 <h3>
@@ -2405,8 +2340,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cf-S5-S6-S7-S9-f9">
-S0::S5::S6::S7::S9::f9<a class="mrdocs-anchor" href="#S0-0cf-S5-S6-S7-S9-f9" aria-label="Permalink">#</a>
-</h2>
+S0::S5::S6::S7::S9::f9</h2>
 </div>
 <div>
 <h3>
@@ -2420,8 +2354,7 @@ f9();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cf-S5-S6-S7-f7">
-S0::S5::S6::S7::f7<a class="mrdocs-anchor" href="#S0-0cf-S5-S6-S7-f7" aria-label="Permalink">#</a>
-</h2>
+S0::S5::S6::S7::f7</h2>
 </div>
 <div>
 <h3>
@@ -2435,8 +2368,7 @@ f7();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cf-S5-S6-f6">
-S0::S5::S6::f6<a class="mrdocs-anchor" href="#S0-0cf-S5-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0::S5::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -2450,8 +2382,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cf-S5-f5">
-S0::S5::f5<a class="mrdocs-anchor" href="#S0-0cf-S5-f5" aria-label="Permalink">#</a>
-</h2>
+S0::S5::f5</h2>
 </div>
 <div>
 <h3>
@@ -2465,8 +2396,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cf-f0">
-S0::f0<a class="mrdocs-anchor" href="#S0-0cf-f0" aria-label="Permalink">#</a>
-</h2>
+S0::f0</h2>
 </div>
 <div>
 <h3>
@@ -2480,8 +2410,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0be">
-S0&lt;0&gt;<a class="mrdocs-anchor" href="#S0-0be" aria-label="Permalink">#</a>
-</h2>
+S0&lt;0&gt;</h2>
 </div>
 <div>
 <h3>
@@ -2513,8 +2442,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-087">
-S0&lt;10&gt;<a class="mrdocs-anchor" href="#S0-087" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10&gt;</h2>
 </div>
 <div>
 <h3>
@@ -2559,8 +2487,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-087-S1">
-S0&lt;10&gt;::S1<a class="mrdocs-anchor" href="#S0-087-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -2604,8 +2531,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-087-S1-S2-0b">
-S0&lt;10&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-087-S1-S2-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -2623,8 +2549,7 @@ struct S2;</code></pre>
 <div>
 <div>
 <h2 id="S0-087-S1-S2-08">
-S0&lt;10&gt;::S1::S2&lt;11&gt;<a class="mrdocs-anchor" href="#S0-087-S1-S2-08" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10&gt;::S1::S2&lt;11&gt;</h2>
 </div>
 <div>
 <h3>
@@ -2669,8 +2594,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-087-S1-S2-08-S3">
-S0&lt;10&gt;::S1::S2&lt;11&gt;::S3<a class="mrdocs-anchor" href="#S0-087-S1-S2-08-S3" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10&gt;::S1::S2&lt;11&gt;::S3</h2>
 </div>
 <div>
 <h3>
@@ -2685,8 +2609,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-087-S1-S2-08-S4-08">
-S0&lt;10&gt;::S1::S2&lt;11&gt;::S4<a class="mrdocs-anchor" href="#S0-087-S1-S2-08-S4-08" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10&gt;::S1::S2&lt;11&gt;::S4</h2>
 </div>
 <div>
 <h3>
@@ -2720,8 +2643,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-087-S1-S2-08-f2">
-S0&lt;10&gt;::S1::S2&lt;11&gt;::f2<a class="mrdocs-anchor" href="#S0-087-S1-S2-08-f2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10&gt;::S1::S2&lt;11&gt;::f2</h2>
 </div>
 <div>
 <h3>
@@ -2735,8 +2657,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="S0-087-S1-f1">
-S0&lt;10&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-087-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -2750,8 +2671,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-087-S5">
-S0&lt;10&gt;::S5<a class="mrdocs-anchor" href="#S0-087-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -2769,8 +2689,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-087-f0">
-S0&lt;10&gt;::f0<a class="mrdocs-anchor" href="#S0-087-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -2784,8 +2703,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0e">
-S0&lt;12&gt;<a class="mrdocs-anchor" href="#S0-0e" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12&gt;</h2>
 </div>
 <div>
 <h3>
@@ -2830,8 +2748,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0e-S1">
-S0&lt;12&gt;::S1<a class="mrdocs-anchor" href="#S0-0e-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -2875,8 +2792,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0e-S1-S2-09">
-S0&lt;12&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-0e-S1-S2-09" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -2894,8 +2810,7 @@ struct S2;</code></pre>
 <div>
 <div>
 <h2 id="S0-0e-S1-S2-02">
-S0&lt;12&gt;::S1::S2&lt;13&gt;<a class="mrdocs-anchor" href="#S0-0e-S1-S2-02" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12&gt;::S1::S2&lt;13&gt;</h2>
 </div>
 <div>
 <h3>
@@ -2941,8 +2856,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0e-S1-S2-02-S3">
-S0&lt;12&gt;::S1::S2&lt;13&gt;::S3<a class="mrdocs-anchor" href="#S0-0e-S1-S2-02-S3" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12&gt;::S1::S2&lt;13&gt;::S3</h2>
 </div>
 <div>
 <h3>
@@ -2957,8 +2871,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0e-S1-S2-02-S4-00">
-S0&lt;12&gt;::S1::S2&lt;13&gt;::S4<a class="mrdocs-anchor" href="#S0-0e-S1-S2-02-S4-00" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12&gt;::S1::S2&lt;13&gt;::S4</h2>
 </div>
 <div>
 <h3>
@@ -2976,8 +2889,7 @@ struct S4;</code></pre>
 <div>
 <div>
 <h2 id="S0-0e-S1-S2-02-S4-0c">
-S0&lt;12&gt;::S1::S2&lt;13&gt;::S4&lt;14&gt;<a class="mrdocs-anchor" href="#S0-0e-S1-S2-02-S4-0c" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12&gt;::S1::S2&lt;13&gt;::S4&lt;14&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3009,8 +2921,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0e-S1-S2-02-f2">
-S0&lt;12&gt;::S1::S2&lt;13&gt;::f2<a class="mrdocs-anchor" href="#S0-0e-S1-S2-02-f2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12&gt;::S1::S2&lt;13&gt;::f2</h2>
 </div>
 <div>
 <h3>
@@ -3024,8 +2935,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="S0-0e-S1-f1">
-S0&lt;12&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-0e-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -3039,8 +2949,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-0e-S5">
-S0&lt;12&gt;::S5<a class="mrdocs-anchor" href="#S0-0e-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -3058,8 +2967,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0e-f0">
-S0&lt;12&gt;::f0<a class="mrdocs-anchor" href="#S0-0e-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -3073,8 +2981,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-09e4">
-S0&lt;15&gt;<a class="mrdocs-anchor" href="#S0-09e4" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3119,8 +3026,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-09e4-S1">
-S0&lt;15&gt;::S1<a class="mrdocs-anchor" href="#S0-09e4-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -3164,8 +3070,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-09e4-S1-S2-07">
-S0&lt;15&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-09e4-S1-S2-07" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -3183,8 +3088,7 @@ struct S2;</code></pre>
 <div>
 <div>
 <h2 id="S0-09e4-S1-S2-02">
-S0&lt;15&gt;::S1::S2&lt;16&gt;<a class="mrdocs-anchor" href="#S0-09e4-S1-S2-02" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;::S1::S2&lt;16&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3231,8 +3135,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-09e4-S1-S2-02-S3">
-S0&lt;15&gt;::S1::S2&lt;16&gt;::S3<a class="mrdocs-anchor" href="#S0-09e4-S1-S2-02-S3" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;::S1::S2&lt;16&gt;::S3</h2>
 </div>
 <div>
 <h3>
@@ -3247,8 +3150,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-09e4-S1-S2-02-S4-00">
-S0&lt;15&gt;::S1::S2&lt;16&gt;::S4<a class="mrdocs-anchor" href="#S0-09e4-S1-S2-02-S4-00" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;::S1::S2&lt;16&gt;::S4</h2>
 </div>
 <div>
 <h3>
@@ -3282,8 +3184,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-09e4-S1-S2-02-S4-02">
-S0&lt;15&gt;::S1::S2&lt;16&gt;::S4&lt;17, int*&gt;<a class="mrdocs-anchor" href="#S0-09e4-S1-S2-02-S4-02" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;::S1::S2&lt;16&gt;::S4&lt;17, int*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3315,8 +3216,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-09e4-S1-S2-02-S4-07">
-S0&lt;15&gt;::S1::S2&lt;16&gt;::S4&lt;17, T*&gt;<a class="mrdocs-anchor" href="#S0-09e4-S1-S2-02-S4-07" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;::S1::S2&lt;16&gt;::S4&lt;17, T*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3332,8 +3232,7 @@ struct <a href="#S0-0cf-S1-S2-S4">S4</a>&lt;17, T*&gt;;</code></pre>
 <div>
 <div>
 <h2 id="S0-09e4-S1-S2-02-f2">
-S0&lt;15&gt;::S1::S2&lt;16&gt;::f2<a class="mrdocs-anchor" href="#S0-09e4-S1-S2-02-f2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;::S1::S2&lt;16&gt;::f2</h2>
 </div>
 <div>
 <h3>
@@ -3347,8 +3246,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="S0-09e4-S1-f1">
-S0&lt;15&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-09e4-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -3362,8 +3260,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-09e4-S5">
-S0&lt;15&gt;::S5<a class="mrdocs-anchor" href="#S0-09e4-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -3381,8 +3278,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-09e4-f0">
-S0&lt;15&gt;::f0<a class="mrdocs-anchor" href="#S0-09e4-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -3396,8 +3292,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-07a">
-S0&lt;18&gt;<a class="mrdocs-anchor" href="#S0-07a" aria-label="Permalink">#</a>
-</h2>
+S0&lt;18&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3442,8 +3337,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-07a-S1">
-S0&lt;18&gt;::S1<a class="mrdocs-anchor" href="#S0-07a-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;18&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -3458,8 +3352,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-07a-S5-07">
-S0&lt;18&gt;::S5<a class="mrdocs-anchor" href="#S0-07a-S5-07" aria-label="Permalink">#</a>
-</h2>
+S0&lt;18&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -3493,8 +3386,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-07a-f0">
-S0&lt;18&gt;::f0<a class="mrdocs-anchor" href="#S0-07a-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;18&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -3508,8 +3400,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0a7">
-S0&lt;19&gt;<a class="mrdocs-anchor" href="#S0-0a7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;19&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3555,8 +3446,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0a7-S1">
-S0&lt;19&gt;::S1<a class="mrdocs-anchor" href="#S0-0a7-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;19&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -3571,8 +3461,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0a7-S5-03">
-S0&lt;19&gt;::S5<a class="mrdocs-anchor" href="#S0-0a7-S5-03" aria-label="Permalink">#</a>
-</h2>
+S0&lt;19&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -3590,8 +3479,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0a7-S5-07">
-S0&lt;19&gt;::S5&lt;20&gt;<a class="mrdocs-anchor" href="#S0-0a7-S5-07" aria-label="Permalink">#</a>
-</h2>
+S0&lt;19&gt;::S5&lt;20&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3623,8 +3511,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0a7-f0">
-S0&lt;19&gt;::f0<a class="mrdocs-anchor" href="#S0-0a7-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;19&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -3638,8 +3525,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-09c">
-S0&lt;2&gt;<a class="mrdocs-anchor" href="#S0-09c" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3684,8 +3570,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-09c-S1">
-S0&lt;2&gt;::S1<a class="mrdocs-anchor" href="#S0-09c-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -3716,8 +3601,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-09c-S5">
-S0&lt;2&gt;::S5<a class="mrdocs-anchor" href="#S0-09c-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -3735,8 +3619,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-09c-f0">
-S0&lt;2&gt;::f0<a class="mrdocs-anchor" href="#S0-09c-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -3750,8 +3633,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0314">
-S0&lt;21&gt;<a class="mrdocs-anchor" href="#S0-0314" aria-label="Permalink">#</a>
-</h2>
+S0&lt;21&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3798,8 +3680,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0314-S1">
-S0&lt;21&gt;::S1<a class="mrdocs-anchor" href="#S0-0314-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;21&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -3814,8 +3695,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0314-S5-07">
-S0&lt;21&gt;::S5<a class="mrdocs-anchor" href="#S0-0314-S5-07" aria-label="Permalink">#</a>
-</h2>
+S0&lt;21&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -3849,8 +3729,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0314-S5-03">
-S0&lt;21&gt;::S5&lt;22, int*&gt;<a class="mrdocs-anchor" href="#S0-0314-S5-03" aria-label="Permalink">#</a>
-</h2>
+S0&lt;21&gt;::S5&lt;22, int*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3882,8 +3761,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0314-S5-0b">
-S0&lt;21&gt;::S5&lt;22, T*&gt;<a class="mrdocs-anchor" href="#S0-0314-S5-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;21&gt;::S5&lt;22, T*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3899,8 +3777,7 @@ struct <a href="#S0-0cf-S5">S5</a>&lt;22, T*&gt;;</code></pre>
 <div>
 <div>
 <h2 id="S0-0314-f0">
-S0&lt;21&gt;::f0<a class="mrdocs-anchor" href="#S0-0314-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;21&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -3914,8 +3791,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-058">
-S0&lt;23&gt;<a class="mrdocs-anchor" href="#S0-058" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23&gt;</h2>
 </div>
 <div>
 <h3>
@@ -3961,8 +3837,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-058-S1">
-S0&lt;23&gt;::S1<a class="mrdocs-anchor" href="#S0-058-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -3977,8 +3852,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-058-S5-0b">
-S0&lt;23&gt;::S5<a class="mrdocs-anchor" href="#S0-058-S5-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -3996,8 +3870,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-058-S5-09">
-S0&lt;23&gt;::S5&lt;24&gt;<a class="mrdocs-anchor" href="#S0-058-S5-09" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23&gt;::S5&lt;24&gt;</h2>
 </div>
 <div>
 <h3>
@@ -4041,8 +3914,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-058-S5-09-S6">
-S0&lt;23&gt;::S5&lt;24&gt;::S6<a class="mrdocs-anchor" href="#S0-058-S5-09-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23&gt;::S5&lt;24&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -4073,8 +3945,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-058-S5-09-f5">
-S0&lt;23&gt;::S5&lt;24&gt;::f5<a class="mrdocs-anchor" href="#S0-058-S5-09-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23&gt;::S5&lt;24&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -4088,8 +3959,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-058-f0">
-S0&lt;23&gt;::f0<a class="mrdocs-anchor" href="#S0-058-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -4103,8 +3973,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0a2">
-S0&lt;25&gt;<a class="mrdocs-anchor" href="#S0-0a2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25&gt;</h2>
 </div>
 <div>
 <h3>
@@ -4150,8 +4019,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0a2-S1">
-S0&lt;25&gt;::S1<a class="mrdocs-anchor" href="#S0-0a2-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -4166,8 +4034,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0a2-S5-04">
-S0&lt;25&gt;::S5<a class="mrdocs-anchor" href="#S0-0a2-S5-04" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -4185,8 +4052,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0a2-S5-02">
-S0&lt;25&gt;::S5&lt;26&gt;<a class="mrdocs-anchor" href="#S0-0a2-S5-02" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25&gt;::S5&lt;26&gt;</h2>
 </div>
 <div>
 <h3>
@@ -4230,8 +4096,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0a2-S5-02-S6">
-S0&lt;25&gt;::S5&lt;26&gt;::S6<a class="mrdocs-anchor" href="#S0-0a2-S5-02-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25&gt;::S5&lt;26&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -4274,8 +4139,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0a2-S5-02-S6-S7-01">
-S0&lt;25&gt;::S5&lt;26&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-0a2-S5-02-S6-S7-01" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25&gt;::S5&lt;26&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -4309,8 +4173,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0a2-S5-02-S6-f6">
-S0&lt;25&gt;::S5&lt;26&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-0a2-S5-02-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25&gt;::S5&lt;26&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -4324,8 +4187,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-0a2-S5-02-f5">
-S0&lt;25&gt;::S5&lt;26&gt;::f5<a class="mrdocs-anchor" href="#S0-0a2-S5-02-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25&gt;::S5&lt;26&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -4339,8 +4201,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-0a2-f0">
-S0&lt;25&gt;::f0<a class="mrdocs-anchor" href="#S0-0a2-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -4354,8 +4215,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-09e2">
-S0&lt;27&gt;<a class="mrdocs-anchor" href="#S0-09e2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27&gt;</h2>
 </div>
 <div>
 <h3>
@@ -4401,8 +4261,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-09e2-S1">
-S0&lt;27&gt;::S1<a class="mrdocs-anchor" href="#S0-09e2-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -4417,8 +4276,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-09e2-S5-0b">
-S0&lt;27&gt;::S5<a class="mrdocs-anchor" href="#S0-09e2-S5-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -4436,8 +4294,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-09e2-S5-0c">
-S0&lt;27&gt;::S5&lt;28&gt;<a class="mrdocs-anchor" href="#S0-09e2-S5-0c" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27&gt;::S5&lt;28&gt;</h2>
 </div>
 <div>
 <h3>
@@ -4481,8 +4338,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-09e2-S5-0c-S6">
-S0&lt;27&gt;::S5&lt;28&gt;::S6<a class="mrdocs-anchor" href="#S0-09e2-S5-0c-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27&gt;::S5&lt;28&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -4527,8 +4383,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-09e2-S5-0c-S6-S7-0b">
-S0&lt;27&gt;::S5&lt;28&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-09e2-S5-0c-S6-S7-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27&gt;::S5&lt;28&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -4562,8 +4417,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-09e2-S5-0c-S6-S7-0d">
-S0&lt;27&gt;::S5&lt;28&gt;::S6::S7&lt;29, int*&gt;<a class="mrdocs-anchor" href="#S0-09e2-S5-0c-S6-S7-0d" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27&gt;::S5&lt;28&gt;::S6::S7&lt;29, int*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -4595,8 +4449,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-09e2-S5-0c-S6-S7-0a">
-S0&lt;27&gt;::S5&lt;28&gt;::S6::S7&lt;29, T*&gt;<a class="mrdocs-anchor" href="#S0-09e2-S5-0c-S6-S7-0a" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27&gt;::S5&lt;28&gt;::S6::S7&lt;29, T*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -4612,8 +4465,7 @@ struct <a href="#S0-0cf-S5-S6-S7">S7</a>&lt;29, T*&gt;;</code></pre>
 <div>
 <div>
 <h2 id="S0-09e2-S5-0c-S6-f6">
-S0&lt;27&gt;::S5&lt;28&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-09e2-S5-0c-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27&gt;::S5&lt;28&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -4627,8 +4479,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-09e2-S5-0c-f5">
-S0&lt;27&gt;::S5&lt;28&gt;::f5<a class="mrdocs-anchor" href="#S0-09e2-S5-0c-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27&gt;::S5&lt;28&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -4642,8 +4493,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-09e2-f0">
-S0&lt;27&gt;::f0<a class="mrdocs-anchor" href="#S0-09e2-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -4657,8 +4507,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-073">
-S0&lt;3&gt;<a class="mrdocs-anchor" href="#S0-073" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3&gt;</h2>
 </div>
 <div>
 <h3>
@@ -4703,8 +4552,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-073-S1">
-S0&lt;3&gt;::S1<a class="mrdocs-anchor" href="#S0-073-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -4747,8 +4595,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-073-S1-S2-0f">
-S0&lt;3&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-073-S1-S2-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -4782,8 +4629,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-073-S1-f1">
-S0&lt;3&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-073-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -4797,8 +4643,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-073-S5">
-S0&lt;3&gt;::S5<a class="mrdocs-anchor" href="#S0-073-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -4816,8 +4661,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-073-f0">
-S0&lt;3&gt;::f0<a class="mrdocs-anchor" href="#S0-073-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -4831,8 +4675,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-01">
-S0&lt;30&gt;<a class="mrdocs-anchor" href="#S0-01" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30&gt;</h2>
 </div>
 <div>
 <h3>
@@ -4878,8 +4721,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-01-S1">
-S0&lt;30&gt;::S1<a class="mrdocs-anchor" href="#S0-01-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -4894,8 +4736,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-01-S5-07">
-S0&lt;30&gt;::S5<a class="mrdocs-anchor" href="#S0-01-S5-07" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -4913,8 +4754,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-01-S5-04">
-S0&lt;30&gt;::S5&lt;31&gt;<a class="mrdocs-anchor" href="#S0-01-S5-04" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30&gt;::S5&lt;31&gt;</h2>
 </div>
 <div>
 <h3>
@@ -4958,8 +4798,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-01-S5-04-S6">
-S0&lt;30&gt;::S5&lt;31&gt;::S6<a class="mrdocs-anchor" href="#S0-01-S5-04-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30&gt;::S5&lt;31&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -5003,8 +4842,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-01-S5-04-S6-S7-0c">
-S0&lt;30&gt;::S5&lt;31&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-01-S5-04-S6-S7-0c" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30&gt;::S5&lt;31&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -5022,8 +4860,7 @@ struct S7;</code></pre>
 <div>
 <div>
 <h2 id="S0-01-S5-04-S6-S7-05">
-S0&lt;30&gt;::S5&lt;31&gt;::S6::S7&lt;32&gt;<a class="mrdocs-anchor" href="#S0-01-S5-04-S6-S7-05" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30&gt;::S5&lt;31&gt;::S6::S7&lt;32&gt;</h2>
 </div>
 <div>
 <h3>
@@ -5055,8 +4892,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-01-S5-04-S6-f6">
-S0&lt;30&gt;::S5&lt;31&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-01-S5-04-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30&gt;::S5&lt;31&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -5070,8 +4906,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-01-S5-04-f5">
-S0&lt;30&gt;::S5&lt;31&gt;::f5<a class="mrdocs-anchor" href="#S0-01-S5-04-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30&gt;::S5&lt;31&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -5085,8 +4920,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-01-f0">
-S0&lt;30&gt;::f0<a class="mrdocs-anchor" href="#S0-01-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -5100,8 +4934,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-09ee">
-S0&lt;33&gt;<a class="mrdocs-anchor" href="#S0-09ee" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;</h2>
 </div>
 <div>
 <h3>
@@ -5147,8 +4980,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-09ee-S1">
-S0&lt;33&gt;::S1<a class="mrdocs-anchor" href="#S0-09ee-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -5163,8 +4995,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-09ee-S5-0b">
-S0&lt;33&gt;::S5<a class="mrdocs-anchor" href="#S0-09ee-S5-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -5182,8 +5013,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-09ee-S5-02">
-S0&lt;33&gt;::S5&lt;34&gt;<a class="mrdocs-anchor" href="#S0-09ee-S5-02" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::S5&lt;34&gt;</h2>
 </div>
 <div>
 <h3>
@@ -5227,8 +5057,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-09ee-S5-02-S6">
-S0&lt;33&gt;::S5&lt;34&gt;::S6<a class="mrdocs-anchor" href="#S0-09ee-S5-02-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::S5&lt;34&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -5272,8 +5101,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-09ee-S5-02-S6-S7-09">
-S0&lt;33&gt;::S5&lt;34&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-09ee-S5-02-S6-S7-09" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::S5&lt;34&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -5291,8 +5119,7 @@ struct S7;</code></pre>
 <div>
 <div>
 <h2 id="S0-09ee-S5-02-S6-S7-03">
-S0&lt;33&gt;::S5&lt;34&gt;::S6::S7&lt;35&gt;<a class="mrdocs-anchor" href="#S0-09ee-S5-02-S6-S7-03" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::S5&lt;34&gt;::S6::S7&lt;35&gt;</h2>
 </div>
 <div>
 <h3>
@@ -5337,8 +5164,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-09ee-S5-02-S6-S7-03-S8">
-S0&lt;33&gt;::S5&lt;34&gt;::S6::S7&lt;35&gt;::S8<a class="mrdocs-anchor" href="#S0-09ee-S5-02-S6-S7-03-S8" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::S5&lt;34&gt;::S6::S7&lt;35&gt;::S8</h2>
 </div>
 <div>
 <h3>
@@ -5369,8 +5195,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-09ee-S5-02-S6-S7-03-S9">
-S0&lt;33&gt;::S5&lt;34&gt;::S6::S7&lt;35&gt;::S9<a class="mrdocs-anchor" href="#S0-09ee-S5-02-S6-S7-03-S9" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::S5&lt;34&gt;::S6::S7&lt;35&gt;::S9</h2>
 </div>
 <div>
 <h3>
@@ -5388,8 +5213,7 @@ struct S9;</code></pre>
 <div>
 <div>
 <h2 id="S0-09ee-S5-02-S6-S7-03-f7">
-S0&lt;33&gt;::S5&lt;34&gt;::S6::S7&lt;35&gt;::f7<a class="mrdocs-anchor" href="#S0-09ee-S5-02-S6-S7-03-f7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::S5&lt;34&gt;::S6::S7&lt;35&gt;::f7</h2>
 </div>
 <div>
 <h3>
@@ -5403,8 +5227,7 @@ f7();</code></pre>
 <div>
 <div>
 <h2 id="S0-09ee-S5-02-S6-f6">
-S0&lt;33&gt;::S5&lt;34&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-09ee-S5-02-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::S5&lt;34&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -5418,8 +5241,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-09ee-S5-02-f5">
-S0&lt;33&gt;::S5&lt;34&gt;::f5<a class="mrdocs-anchor" href="#S0-09ee-S5-02-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::S5&lt;34&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -5433,8 +5255,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-09ee-f0">
-S0&lt;33&gt;::f0<a class="mrdocs-anchor" href="#S0-09ee-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -5448,8 +5269,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-033">
-S0&lt;36&gt;<a class="mrdocs-anchor" href="#S0-033" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;</h2>
 </div>
 <div>
 <h3>
@@ -5495,8 +5315,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-033-S1">
-S0&lt;36&gt;::S1<a class="mrdocs-anchor" href="#S0-033-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -5511,8 +5330,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-033-S5-03">
-S0&lt;36&gt;::S5<a class="mrdocs-anchor" href="#S0-033-S5-03" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -5530,8 +5348,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-033-S5-0f">
-S0&lt;36&gt;::S5&lt;37&gt;<a class="mrdocs-anchor" href="#S0-033-S5-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::S5&lt;37&gt;</h2>
 </div>
 <div>
 <h3>
@@ -5575,8 +5392,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-033-S5-0f-S6">
-S0&lt;36&gt;::S5&lt;37&gt;::S6<a class="mrdocs-anchor" href="#S0-033-S5-0f-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::S5&lt;37&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -5620,8 +5436,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-033-S5-0f-S6-S7-05">
-S0&lt;36&gt;::S5&lt;37&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-033-S5-0f-S6-S7-05" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::S5&lt;37&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -5639,8 +5454,7 @@ struct S7;</code></pre>
 <div>
 <div>
 <h2 id="S0-033-S5-0f-S6-S7-0d">
-S0&lt;36&gt;::S5&lt;37&gt;::S6::S7&lt;38&gt;<a class="mrdocs-anchor" href="#S0-033-S5-0f-S6-S7-0d" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::S5&lt;37&gt;::S6::S7&lt;38&gt;</h2>
 </div>
 <div>
 <h3>
@@ -5685,8 +5499,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-033-S5-0f-S6-S7-0d-S8">
-S0&lt;36&gt;::S5&lt;37&gt;::S6::S7&lt;38&gt;::S8<a class="mrdocs-anchor" href="#S0-033-S5-0f-S6-S7-0d-S8" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::S5&lt;37&gt;::S6::S7&lt;38&gt;::S8</h2>
 </div>
 <div>
 <h3>
@@ -5701,8 +5514,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-033-S5-0f-S6-S7-0d-S9-02">
-S0&lt;36&gt;::S5&lt;37&gt;::S6::S7&lt;38&gt;::S9<a class="mrdocs-anchor" href="#S0-033-S5-0f-S6-S7-0d-S9-02" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::S5&lt;37&gt;::S6::S7&lt;38&gt;::S9</h2>
 </div>
 <div>
 <h3>
@@ -5736,8 +5548,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-033-S5-0f-S6-S7-0d-f7">
-S0&lt;36&gt;::S5&lt;37&gt;::S6::S7&lt;38&gt;::f7<a class="mrdocs-anchor" href="#S0-033-S5-0f-S6-S7-0d-f7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::S5&lt;37&gt;::S6::S7&lt;38&gt;::f7</h2>
 </div>
 <div>
 <h3>
@@ -5751,8 +5562,7 @@ f7();</code></pre>
 <div>
 <div>
 <h2 id="S0-033-S5-0f-S6-f6">
-S0&lt;36&gt;::S5&lt;37&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-033-S5-0f-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::S5&lt;37&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -5766,8 +5576,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-033-S5-0f-f5">
-S0&lt;36&gt;::S5&lt;37&gt;::f5<a class="mrdocs-anchor" href="#S0-033-S5-0f-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::S5&lt;37&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -5781,8 +5590,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-033-f0">
-S0&lt;36&gt;::f0<a class="mrdocs-anchor" href="#S0-033-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -5796,8 +5604,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-06">
-S0&lt;39&gt;<a class="mrdocs-anchor" href="#S0-06" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;</h2>
 </div>
 <div>
 <h3>
@@ -5843,8 +5650,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-06-S1">
-S0&lt;39&gt;::S1<a class="mrdocs-anchor" href="#S0-06-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -5859,8 +5665,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-06-S5-03">
-S0&lt;39&gt;::S5<a class="mrdocs-anchor" href="#S0-06-S5-03" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -5878,8 +5683,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-06-S5-07">
-S0&lt;39&gt;::S5&lt;40&gt;<a class="mrdocs-anchor" href="#S0-06-S5-07" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5&lt;40&gt;</h2>
 </div>
 <div>
 <h3>
@@ -5923,8 +5727,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-06-S5-07-S6">
-S0&lt;39&gt;::S5&lt;40&gt;::S6<a class="mrdocs-anchor" href="#S0-06-S5-07-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5&lt;40&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -5968,8 +5771,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-06-S5-07-S6-S7-08">
-S0&lt;39&gt;::S5&lt;40&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-06-S5-07-S6-S7-08" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5&lt;40&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -5987,8 +5789,7 @@ struct S7;</code></pre>
 <div>
 <div>
 <h2 id="S0-06-S5-07-S6-S7-0a">
-S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;<a class="mrdocs-anchor" href="#S0-06-S5-07-S6-S7-0a" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6035,8 +5836,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-06-S5-07-S6-S7-0a-S8">
-S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;::S8<a class="mrdocs-anchor" href="#S0-06-S5-07-S6-S7-0a-S8" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;::S8</h2>
 </div>
 <div>
 <h3>
@@ -6051,8 +5851,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-06-S5-07-S6-S7-0a-S9-05">
-S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;::S9<a class="mrdocs-anchor" href="#S0-06-S5-07-S6-S7-0a-S9-05" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;::S9</h2>
 </div>
 <div>
 <h3>
@@ -6086,8 +5885,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-06-S5-07-S6-S7-0a-S9-08">
-S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;::S9&lt;42, int*&gt;<a class="mrdocs-anchor" href="#S0-06-S5-07-S6-S7-0a-S9-08" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;::S9&lt;42, int*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6119,8 +5917,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-06-S5-07-S6-S7-0a-S9-00">
-S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;::S9&lt;42, T*&gt;<a class="mrdocs-anchor" href="#S0-06-S5-07-S6-S7-0a-S9-00" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;::S9&lt;42, T*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6136,8 +5933,7 @@ struct <a href="#S0-0cf-S5-S6-S7-S9">S9</a>&lt;42, T*&gt;;</code></pre>
 <div>
 <div>
 <h2 id="S0-06-S5-07-S6-S7-0a-f7">
-S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;::f7<a class="mrdocs-anchor" href="#S0-06-S5-07-S6-S7-0a-f7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5&lt;40&gt;::S6::S7&lt;41&gt;::f7</h2>
 </div>
 <div>
 <h3>
@@ -6151,8 +5947,7 @@ f7();</code></pre>
 <div>
 <div>
 <h2 id="S0-06-S5-07-S6-f6">
-S0&lt;39&gt;::S5&lt;40&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-06-S5-07-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5&lt;40&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -6166,8 +5961,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-06-S5-07-f5">
-S0&lt;39&gt;::S5&lt;40&gt;::f5<a class="mrdocs-anchor" href="#S0-06-S5-07-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::S5&lt;40&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -6181,8 +5975,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-06-f0">
-S0&lt;39&gt;::f0<a class="mrdocs-anchor" href="#S0-06-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -6196,8 +5989,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0a1">
-S0&lt;4&gt;<a class="mrdocs-anchor" href="#S0-0a1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6242,8 +6034,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0a1-S1">
-S0&lt;4&gt;::S1<a class="mrdocs-anchor" href="#S0-0a1-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -6287,8 +6078,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0a1-S1-S2-00">
-S0&lt;4&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-0a1-S1-S2-00" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -6306,8 +6096,7 @@ struct S2;</code></pre>
 <div>
 <div>
 <h2 id="S0-0a1-S1-S2-0f">
-S0&lt;4&gt;::S1::S2&lt;5&gt;<a class="mrdocs-anchor" href="#S0-0a1-S1-S2-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4&gt;::S1::S2&lt;5&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6339,8 +6128,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0a1-S1-f1">
-S0&lt;4&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-0a1-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -6354,8 +6142,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-0a1-S5">
-S0&lt;4&gt;::S5<a class="mrdocs-anchor" href="#S0-0a1-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -6373,8 +6160,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0a1-f0">
-S0&lt;4&gt;::f0<a class="mrdocs-anchor" href="#S0-0a1-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -6388,8 +6174,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0ba">
-S0&lt;43&gt;<a class="mrdocs-anchor" href="#S0-0ba" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6435,8 +6220,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0ba-S1">
-S0&lt;43&gt;::S1<a class="mrdocs-anchor" href="#S0-0ba-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -6451,8 +6235,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0ba-S5-0f">
-S0&lt;43&gt;::S5<a class="mrdocs-anchor" href="#S0-0ba-S5-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -6470,8 +6253,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0ba-S5-08">
-S0&lt;43&gt;::S5&lt;44&gt;<a class="mrdocs-anchor" href="#S0-0ba-S5-08" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S5&lt;44&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6515,8 +6297,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0ba-S5-08-S6">
-S0&lt;43&gt;::S5&lt;44&gt;::S6<a class="mrdocs-anchor" href="#S0-0ba-S5-08-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S5&lt;44&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -6560,8 +6341,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0ba-S5-08-S6-S7-04">
-S0&lt;43&gt;::S5&lt;44&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-0ba-S5-08-S6-S7-04" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S5&lt;44&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -6579,8 +6359,7 @@ struct S7;</code></pre>
 <div>
 <div>
 <h2 id="S0-0ba-S5-08-S6-S7-02">
-S0&lt;43&gt;::S5&lt;44&gt;::S6::S7&lt;45&gt;<a class="mrdocs-anchor" href="#S0-0ba-S5-08-S6-S7-02" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S5&lt;44&gt;::S6::S7&lt;45&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6626,8 +6405,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0ba-S5-08-S6-S7-02-S8">
-S0&lt;43&gt;::S5&lt;44&gt;::S6::S7&lt;45&gt;::S8<a class="mrdocs-anchor" href="#S0-0ba-S5-08-S6-S7-02-S8" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S5&lt;44&gt;::S6::S7&lt;45&gt;::S8</h2>
 </div>
 <div>
 <h3>
@@ -6642,8 +6420,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0ba-S5-08-S6-S7-02-S9-0b">
-S0&lt;43&gt;::S5&lt;44&gt;::S6::S7&lt;45&gt;::S9<a class="mrdocs-anchor" href="#S0-0ba-S5-08-S6-S7-02-S9-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S5&lt;44&gt;::S6::S7&lt;45&gt;::S9</h2>
 </div>
 <div>
 <h3>
@@ -6661,8 +6438,7 @@ struct S9;</code></pre>
 <div>
 <div>
 <h2 id="S0-0ba-S5-08-S6-S7-02-S9-0f">
-S0&lt;43&gt;::S5&lt;44&gt;::S6::S7&lt;45&gt;::S9&lt;46&gt;<a class="mrdocs-anchor" href="#S0-0ba-S5-08-S6-S7-02-S9-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S5&lt;44&gt;::S6::S7&lt;45&gt;::S9&lt;46&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6694,8 +6470,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0ba-S5-08-S6-S7-02-f7">
-S0&lt;43&gt;::S5&lt;44&gt;::S6::S7&lt;45&gt;::f7<a class="mrdocs-anchor" href="#S0-0ba-S5-08-S6-S7-02-f7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S5&lt;44&gt;::S6::S7&lt;45&gt;::f7</h2>
 </div>
 <div>
 <h3>
@@ -6709,8 +6484,7 @@ f7();</code></pre>
 <div>
 <div>
 <h2 id="S0-0ba-S5-08-S6-f6">
-S0&lt;43&gt;::S5&lt;44&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-0ba-S5-08-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S5&lt;44&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -6724,8 +6498,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-0ba-S5-08-f5">
-S0&lt;43&gt;::S5&lt;44&gt;::f5<a class="mrdocs-anchor" href="#S0-0ba-S5-08-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::S5&lt;44&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -6739,8 +6512,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-0ba-f0">
-S0&lt;43&gt;::f0<a class="mrdocs-anchor" href="#S0-0ba-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -6754,8 +6526,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-07e">
-S0&lt;6&gt;<a class="mrdocs-anchor" href="#S0-07e" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6800,8 +6571,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-07e-S1">
-S0&lt;6&gt;::S1<a class="mrdocs-anchor" href="#S0-07e-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -6846,8 +6616,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-07e-S1-S2-04">
-S0&lt;6&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-07e-S1-S2-04" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -6881,8 +6650,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-07e-S1-S2-07">
-S0&lt;6&gt;::S1::S2&lt;7, int*&gt;<a class="mrdocs-anchor" href="#S0-07e-S1-S2-07" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6&gt;::S1::S2&lt;7, int*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6914,8 +6682,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-07e-S1-S2-06">
-S0&lt;6&gt;::S1::S2&lt;7, T*&gt;<a class="mrdocs-anchor" href="#S0-07e-S1-S2-06" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6&gt;::S1::S2&lt;7, T*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -6931,8 +6698,7 @@ struct <a href="#S0-0cf-S1-S2">S2</a>&lt;7, T*&gt;;</code></pre>
 <div>
 <div>
 <h2 id="S0-07e-S1-f1">
-S0&lt;6&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-07e-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -6946,8 +6712,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-07e-S5">
-S0&lt;6&gt;::S5<a class="mrdocs-anchor" href="#S0-07e-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -6965,8 +6730,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-07e-f0">
-S0&lt;6&gt;::f0<a class="mrdocs-anchor" href="#S0-07e-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -6980,8 +6744,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0a3">
-S0&lt;8&gt;<a class="mrdocs-anchor" href="#S0-0a3" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8&gt;</h2>
 </div>
 <div>
 <h3>
@@ -7026,8 +6789,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0a3-S1">
-S0&lt;8&gt;::S1<a class="mrdocs-anchor" href="#S0-0a3-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -7071,8 +6833,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0a3-S1-S2-0b">
-S0&lt;8&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-0a3-S1-S2-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -7090,8 +6851,7 @@ struct S2;</code></pre>
 <div>
 <div>
 <h2 id="S0-0a3-S1-S2-0c">
-S0&lt;8&gt;::S1::S2&lt;9&gt;<a class="mrdocs-anchor" href="#S0-0a3-S1-S2-0c" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8&gt;::S1::S2&lt;9&gt;</h2>
 </div>
 <div>
 <h3>
@@ -7136,8 +6896,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0a3-S1-S2-0c-S3">
-S0&lt;8&gt;::S1::S2&lt;9&gt;::S3<a class="mrdocs-anchor" href="#S0-0a3-S1-S2-0c-S3" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8&gt;::S1::S2&lt;9&gt;::S3</h2>
 </div>
 <div>
 <h3>
@@ -7168,8 +6927,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0a3-S1-S2-0c-S4">
-S0&lt;8&gt;::S1::S2&lt;9&gt;::S4<a class="mrdocs-anchor" href="#S0-0a3-S1-S2-0c-S4" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8&gt;::S1::S2&lt;9&gt;::S4</h2>
 </div>
 <div>
 <h3>
@@ -7187,8 +6945,7 @@ struct S4;</code></pre>
 <div>
 <div>
 <h2 id="S0-0a3-S1-S2-0c-f2">
-S0&lt;8&gt;::S1::S2&lt;9&gt;::f2<a class="mrdocs-anchor" href="#S0-0a3-S1-S2-0c-f2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8&gt;::S1::S2&lt;9&gt;::f2</h2>
 </div>
 <div>
 <h3>
@@ -7202,8 +6959,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="S0-0a3-S1-f1">
-S0&lt;8&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-0a3-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -7217,8 +6973,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-0a3-S5">
-S0&lt;8&gt;::S5<a class="mrdocs-anchor" href="#S0-0a3-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -7236,8 +6991,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0a3-f0">
-S0&lt;8&gt;::f0<a class="mrdocs-anchor" href="#S0-0a3-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -7251,8 +7005,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-020a">
-S0&lt;1, int*&gt;<a class="mrdocs-anchor" href="#S0-020a" aria-label="Permalink">#</a>
-</h2>
+S0&lt;1, int*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -7284,8 +7037,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-05a">
-S0&lt;10, bool&gt;<a class="mrdocs-anchor" href="#S0-05a" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -7330,8 +7082,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-05a-S1">
-S0&lt;10, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-05a-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -7375,8 +7126,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-05a-S1-S2-07">
-S0&lt;10, bool&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-05a-S1-S2-07" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10, bool&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -7394,8 +7144,7 @@ struct S2;</code></pre>
 <div>
 <div>
 <h2 id="S0-05a-S1-S2-0b">
-S0&lt;10, bool&gt;::S1::S2&lt;11, bool&gt;<a class="mrdocs-anchor" href="#S0-05a-S1-S2-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10, bool&gt;::S1::S2&lt;11, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -7440,8 +7189,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-05a-S1-S2-0b-S3">
-S0&lt;10, bool&gt;::S1::S2&lt;11, bool&gt;::S3<a class="mrdocs-anchor" href="#S0-05a-S1-S2-0b-S3" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10, bool&gt;::S1::S2&lt;11, bool&gt;::S3</h2>
 </div>
 <div>
 <h3>
@@ -7456,8 +7204,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-05a-S1-S2-0b-S4">
-S0&lt;10, bool&gt;::S1::S2&lt;11, bool&gt;::S4<a class="mrdocs-anchor" href="#S0-05a-S1-S2-0b-S4" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10, bool&gt;::S1::S2&lt;11, bool&gt;::S4</h2>
 </div>
 <div>
 <h3>
@@ -7491,8 +7238,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-05a-S1-S2-0b-f2">
-S0&lt;10, bool&gt;::S1::S2&lt;11, bool&gt;::f2<a class="mrdocs-anchor" href="#S0-05a-S1-S2-0b-f2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10, bool&gt;::S1::S2&lt;11, bool&gt;::f2</h2>
 </div>
 <div>
 <h3>
@@ -7506,8 +7252,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="S0-05a-S1-f1">
-S0&lt;10, bool&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-05a-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10, bool&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -7521,8 +7266,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-05a-S5">
-S0&lt;10, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-05a-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -7540,8 +7284,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-05a-f0">
-S0&lt;10, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-05a-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;10, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -7555,8 +7298,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cd">
-S0&lt;12, bool&gt;<a class="mrdocs-anchor" href="#S0-0cd" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -7601,8 +7343,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cd-S1">
-S0&lt;12, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-0cd-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -7646,8 +7387,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cd-S1-S2-0e">
-S0&lt;12, bool&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-0cd-S1-S2-0e" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12, bool&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -7665,8 +7405,7 @@ struct S2;</code></pre>
 <div>
 <div>
 <h2 id="S0-0cd-S1-S2-05">
-S0&lt;12, bool&gt;::S1::S2&lt;13, bool&gt;<a class="mrdocs-anchor" href="#S0-0cd-S1-S2-05" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12, bool&gt;::S1::S2&lt;13, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -7711,8 +7450,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0cd-S1-S2-05-S3">
-S0&lt;12, bool&gt;::S1::S2&lt;13, bool&gt;::S3<a class="mrdocs-anchor" href="#S0-0cd-S1-S2-05-S3" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12, bool&gt;::S1::S2&lt;13, bool&gt;::S3</h2>
 </div>
 <div>
 <h3>
@@ -7727,8 +7465,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0cd-S1-S2-05-S4-00">
-S0&lt;12, bool&gt;::S1::S2&lt;13, bool&gt;::S4<a class="mrdocs-anchor" href="#S0-0cd-S1-S2-05-S4-00" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12, bool&gt;::S1::S2&lt;13, bool&gt;::S4</h2>
 </div>
 <div>
 <h3>
@@ -7762,8 +7499,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0cd-S1-S2-05-f2">
-S0&lt;12, bool&gt;::S1::S2&lt;13, bool&gt;::f2<a class="mrdocs-anchor" href="#S0-0cd-S1-S2-05-f2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12, bool&gt;::S1::S2&lt;13, bool&gt;::f2</h2>
 </div>
 <div>
 <h3>
@@ -7777,8 +7513,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cd-S1-f1">
-S0&lt;12, bool&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-0cd-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12, bool&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -7792,8 +7527,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-0cd-S5">
-S0&lt;12, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-0cd-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -7811,8 +7545,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0cd-f0">
-S0&lt;12, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-0cd-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;12, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -7826,8 +7559,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-000">
-S0&lt;15, bool&gt;<a class="mrdocs-anchor" href="#S0-000" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -7872,8 +7604,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-000-S1">
-S0&lt;15, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-000-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -7917,8 +7648,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-000-S1-S2-08">
-S0&lt;15, bool&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-000-S1-S2-08" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15, bool&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -7936,8 +7666,7 @@ struct S2;</code></pre>
 <div>
 <div>
 <h2 id="S0-000-S1-S2-03">
-S0&lt;15, bool&gt;::S1::S2&lt;16, bool&gt;<a class="mrdocs-anchor" href="#S0-000-S1-S2-03" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15, bool&gt;::S1::S2&lt;16, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -7982,8 +7711,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-000-S1-S2-03-S3">
-S0&lt;15, bool&gt;::S1::S2&lt;16, bool&gt;::S3<a class="mrdocs-anchor" href="#S0-000-S1-S2-03-S3" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15, bool&gt;::S1::S2&lt;16, bool&gt;::S3</h2>
 </div>
 <div>
 <h3>
@@ -7998,8 +7726,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-000-S1-S2-03-S4-0b">
-S0&lt;15, bool&gt;::S1::S2&lt;16, bool&gt;::S4<a class="mrdocs-anchor" href="#S0-000-S1-S2-03-S4-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15, bool&gt;::S1::S2&lt;16, bool&gt;::S4</h2>
 </div>
 <div>
 <h3>
@@ -8033,8 +7760,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-000-S1-S2-03-f2">
-S0&lt;15, bool&gt;::S1::S2&lt;16, bool&gt;::f2<a class="mrdocs-anchor" href="#S0-000-S1-S2-03-f2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15, bool&gt;::S1::S2&lt;16, bool&gt;::f2</h2>
 </div>
 <div>
 <h3>
@@ -8048,8 +7774,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="S0-000-S1-f1">
-S0&lt;15, bool&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-000-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15, bool&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -8063,8 +7788,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-000-S5">
-S0&lt;15, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-000-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -8082,8 +7806,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-000-f0">
-S0&lt;15, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-000-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;15, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -8097,8 +7820,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-051">
-S0&lt;18, bool&gt;<a class="mrdocs-anchor" href="#S0-051" aria-label="Permalink">#</a>
-</h2>
+S0&lt;18, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -8143,8 +7865,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-051-S1">
-S0&lt;18, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-051-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;18, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -8159,8 +7880,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-051-S5">
-S0&lt;18, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-051-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;18, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -8194,8 +7914,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-051-f0">
-S0&lt;18, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-051-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;18, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -8209,8 +7928,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-002">
-S0&lt;19, bool&gt;<a class="mrdocs-anchor" href="#S0-002" aria-label="Permalink">#</a>
-</h2>
+S0&lt;19, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -8255,8 +7973,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-002-S1">
-S0&lt;19, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-002-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;19, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -8271,8 +7988,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-002-S5-08">
-S0&lt;19, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-002-S5-08" aria-label="Permalink">#</a>
-</h2>
+S0&lt;19, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -8306,8 +8022,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-002-f0">
-S0&lt;19, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-002-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;19, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -8321,8 +8036,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-03c">
-S0&lt;2, bool&gt;<a class="mrdocs-anchor" href="#S0-03c" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -8367,8 +8081,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-03c-S1">
-S0&lt;2, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-03c-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -8427,8 +8140,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-03c-S1-S2">
-S0&lt;2, bool&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-03c-S1-S2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2, bool&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -8446,8 +8158,7 @@ struct S2;</code></pre>
 <div>
 <div>
 <h2 id="S0-03c-S1-f1">
-S0&lt;2, bool&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-03c-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2, bool&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -8461,8 +8172,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-03c-S5">
-S0&lt;2, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-03c-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -8480,8 +8190,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-03c-f0">
-S0&lt;2, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-03c-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -8495,8 +8204,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-003">
-S0&lt;21, bool&gt;<a class="mrdocs-anchor" href="#S0-003" aria-label="Permalink">#</a>
-</h2>
+S0&lt;21, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -8541,8 +8249,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-003-S1">
-S0&lt;21, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-003-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;21, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -8557,8 +8264,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-003-S5-0c">
-S0&lt;21, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-003-S5-0c" aria-label="Permalink">#</a>
-</h2>
+S0&lt;21, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -8592,8 +8298,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-003-f0">
-S0&lt;21, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-003-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;21, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -8607,8 +8312,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0c7">
-S0&lt;23, bool&gt;<a class="mrdocs-anchor" href="#S0-0c7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -8654,8 +8358,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0c7-S1">
-S0&lt;23, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-0c7-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -8670,8 +8373,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0c7-S5-03">
-S0&lt;23, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-0c7-S5-03" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -8689,8 +8391,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0c7-S5-0f">
-S0&lt;23, bool&gt;::S5&lt;24, bool&gt;<a class="mrdocs-anchor" href="#S0-0c7-S5-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23, bool&gt;::S5&lt;24, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -8734,8 +8435,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0c7-S5-0f-S6">
-S0&lt;23, bool&gt;::S5&lt;24, bool&gt;::S6<a class="mrdocs-anchor" href="#S0-0c7-S5-0f-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23, bool&gt;::S5&lt;24, bool&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -8794,8 +8494,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0c7-S5-0f-S6-S7">
-S0&lt;23, bool&gt;::S5&lt;24, bool&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-0c7-S5-0f-S6-S7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23, bool&gt;::S5&lt;24, bool&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -8813,8 +8512,7 @@ struct S7;</code></pre>
 <div>
 <div>
 <h2 id="S0-0c7-S5-0f-S6-f6">
-S0&lt;23, bool&gt;::S5&lt;24, bool&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-0c7-S5-0f-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23, bool&gt;::S5&lt;24, bool&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -8828,8 +8526,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-0c7-S5-0f-f5">
-S0&lt;23, bool&gt;::S5&lt;24, bool&gt;::f5<a class="mrdocs-anchor" href="#S0-0c7-S5-0f-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23, bool&gt;::S5&lt;24, bool&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -8843,8 +8540,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-0c7-f0">
-S0&lt;23, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-0c7-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;23, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -8858,8 +8554,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0529f">
-S0&lt;25, bool&gt;<a class="mrdocs-anchor" href="#S0-0529f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -8905,8 +8600,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0529f-S1">
-S0&lt;25, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-0529f-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -8921,8 +8615,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0529f-S5-051">
-S0&lt;25, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-0529f-S5-051" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -8940,8 +8633,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0529f-S5-05c">
-S0&lt;25, bool&gt;::S5&lt;26, bool&gt;<a class="mrdocs-anchor" href="#S0-0529f-S5-05c" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25, bool&gt;::S5&lt;26, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -8985,8 +8677,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0529f-S5-05c-S6">
-S0&lt;25, bool&gt;::S5&lt;26, bool&gt;::S6<a class="mrdocs-anchor" href="#S0-0529f-S5-05c-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25, bool&gt;::S5&lt;26, bool&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -9029,8 +8720,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0529f-S5-05c-S6-S7">
-S0&lt;25, bool&gt;::S5&lt;26, bool&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-0529f-S5-05c-S6-S7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25, bool&gt;::S5&lt;26, bool&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -9064,8 +8754,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0529f-S5-05c-S6-f6">
-S0&lt;25, bool&gt;::S5&lt;26, bool&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-0529f-S5-05c-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25, bool&gt;::S5&lt;26, bool&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -9079,8 +8768,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-0529f-S5-05c-f5">
-S0&lt;25, bool&gt;::S5&lt;26, bool&gt;::f5<a class="mrdocs-anchor" href="#S0-0529f-S5-05c-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25, bool&gt;::S5&lt;26, bool&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -9094,8 +8782,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-0529f-f0">
-S0&lt;25, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-0529f-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;25, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -9109,8 +8796,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-007">
-S0&lt;27, bool&gt;<a class="mrdocs-anchor" href="#S0-007" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -9156,8 +8842,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-007-S1">
-S0&lt;27, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-007-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -9172,8 +8857,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-007-S5-0f">
-S0&lt;27, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-007-S5-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -9191,8 +8875,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-007-S5-0d">
-S0&lt;27, bool&gt;::S5&lt;28, bool&gt;<a class="mrdocs-anchor" href="#S0-007-S5-0d" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27, bool&gt;::S5&lt;28, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -9236,8 +8919,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-007-S5-0d-S6">
-S0&lt;27, bool&gt;::S5&lt;28, bool&gt;::S6<a class="mrdocs-anchor" href="#S0-007-S5-0d-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27, bool&gt;::S5&lt;28, bool&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -9280,8 +8962,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-007-S5-0d-S6-S7-0d">
-S0&lt;27, bool&gt;::S5&lt;28, bool&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-007-S5-0d-S6-S7-0d" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27, bool&gt;::S5&lt;28, bool&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -9315,8 +8996,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-007-S5-0d-S6-f6">
-S0&lt;27, bool&gt;::S5&lt;28, bool&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-007-S5-0d-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27, bool&gt;::S5&lt;28, bool&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -9330,8 +9010,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-007-S5-0d-f5">
-S0&lt;27, bool&gt;::S5&lt;28, bool&gt;::f5<a class="mrdocs-anchor" href="#S0-007-S5-0d-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27, bool&gt;::S5&lt;28, bool&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -9345,8 +9024,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-007-f0">
-S0&lt;27, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-007-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;27, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -9360,8 +9038,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-092">
-S0&lt;3, bool&gt;<a class="mrdocs-anchor" href="#S0-092" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -9406,8 +9083,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-092-S1">
-S0&lt;3, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-092-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -9450,8 +9126,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-092-S1-S2">
-S0&lt;3, bool&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-092-S1-S2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3, bool&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -9485,8 +9160,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-092-S1-f1">
-S0&lt;3, bool&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-092-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3, bool&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -9500,8 +9174,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-092-S5">
-S0&lt;3, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-092-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -9519,8 +9192,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-092-f0">
-S0&lt;3, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-092-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -9534,8 +9206,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-021">
-S0&lt;30, bool&gt;<a class="mrdocs-anchor" href="#S0-021" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -9581,8 +9252,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-021-S1">
-S0&lt;30, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-021-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -9597,8 +9267,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-021-S5-06">
-S0&lt;30, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-021-S5-06" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -9616,8 +9285,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-021-S5-0b">
-S0&lt;30, bool&gt;::S5&lt;31, bool&gt;<a class="mrdocs-anchor" href="#S0-021-S5-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30, bool&gt;::S5&lt;31, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -9661,8 +9329,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-021-S5-0b-S6">
-S0&lt;30, bool&gt;::S5&lt;31, bool&gt;::S6<a class="mrdocs-anchor" href="#S0-021-S5-0b-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30, bool&gt;::S5&lt;31, bool&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -9705,8 +9372,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-021-S5-0b-S6-S7-0f">
-S0&lt;30, bool&gt;::S5&lt;31, bool&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-021-S5-0b-S6-S7-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30, bool&gt;::S5&lt;31, bool&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -9740,8 +9406,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-021-S5-0b-S6-f6">
-S0&lt;30, bool&gt;::S5&lt;31, bool&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-021-S5-0b-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30, bool&gt;::S5&lt;31, bool&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -9755,8 +9420,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-021-S5-0b-f5">
-S0&lt;30, bool&gt;::S5&lt;31, bool&gt;::f5<a class="mrdocs-anchor" href="#S0-021-S5-0b-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30, bool&gt;::S5&lt;31, bool&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -9770,8 +9434,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-021-f0">
-S0&lt;30, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-021-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;30, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -9785,8 +9448,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0318">
-S0&lt;33, bool&gt;<a class="mrdocs-anchor" href="#S0-0318" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -9832,8 +9494,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0318-S1">
-S0&lt;33, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-0318-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -9848,8 +9509,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0318-S5-0f">
-S0&lt;33, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-0318-S5-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -9867,8 +9527,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0318-S5-0b">
-S0&lt;33, bool&gt;::S5&lt;34, bool&gt;<a class="mrdocs-anchor" href="#S0-0318-S5-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S5&lt;34, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -9912,8 +9571,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0318-S5-0b-S6">
-S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6<a class="mrdocs-anchor" href="#S0-0318-S5-0b-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -9957,8 +9615,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0318-S5-0b-S6-S7-04">
-S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-0318-S5-0b-S6-S7-04" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -9976,8 +9633,7 @@ struct S7;</code></pre>
 <div>
 <div>
 <h2 id="S0-0318-S5-0b-S6-S7-05">
-S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7&lt;35, bool&gt;<a class="mrdocs-anchor" href="#S0-0318-S5-0b-S6-S7-05" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7&lt;35, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -10022,8 +9678,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0318-S5-0b-S6-S7-05-S8">
-S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7&lt;35, bool&gt;::S8<a class="mrdocs-anchor" href="#S0-0318-S5-0b-S6-S7-05-S8" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7&lt;35, bool&gt;::S8</h2>
 </div>
 <div>
 <h3>
@@ -10068,8 +9723,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0318-S5-0b-S6-S7-05-S8-f8">
-S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7&lt;35, bool&gt;::S8::f8<a class="mrdocs-anchor" href="#S0-0318-S5-0b-S6-S7-05-S8-f8" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7&lt;35, bool&gt;::S8::f8</h2>
 </div>
 <div>
 <h3>
@@ -10083,8 +9737,7 @@ f8();</code></pre>
 <div>
 <div>
 <h2 id="S0-0318-S5-0b-S6-S7-05-S9">
-S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7&lt;35, bool&gt;::S9<a class="mrdocs-anchor" href="#S0-0318-S5-0b-S6-S7-05-S9" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7&lt;35, bool&gt;::S9</h2>
 </div>
 <div>
 <h3>
@@ -10102,8 +9755,7 @@ struct S9;</code></pre>
 <div>
 <div>
 <h2 id="S0-0318-S5-0b-S6-S7-05-f7">
-S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7&lt;35, bool&gt;::f7<a class="mrdocs-anchor" href="#S0-0318-S5-0b-S6-S7-05-f7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::S7&lt;35, bool&gt;::f7</h2>
 </div>
 <div>
 <h3>
@@ -10117,8 +9769,7 @@ f7();</code></pre>
 <div>
 <div>
 <h2 id="S0-0318-S5-0b-S6-f6">
-S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-0318-S5-0b-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -10132,8 +9783,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-0318-S5-0b-f5">
-S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::f5<a class="mrdocs-anchor" href="#S0-0318-S5-0b-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::S5&lt;34, bool&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -10147,8 +9797,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-0318-f0">
-S0&lt;33, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-0318-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;33, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -10162,8 +9811,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0d">
-S0&lt;36, bool&gt;<a class="mrdocs-anchor" href="#S0-0d" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -10209,8 +9857,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0d-S1">
-S0&lt;36, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-0d-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -10225,8 +9872,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0d-S5-09">
-S0&lt;36, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-0d-S5-09" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -10244,8 +9890,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0d-S5-0b">
-S0&lt;36, bool&gt;::S5&lt;37, bool&gt;<a class="mrdocs-anchor" href="#S0-0d-S5-0b" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::S5&lt;37, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -10289,8 +9934,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0d-S5-0b-S6">
-S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6<a class="mrdocs-anchor" href="#S0-0d-S5-0b-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -10334,8 +9978,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0d-S5-0b-S6-S7-08">
-S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-0d-S5-0b-S6-S7-08" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -10353,8 +9996,7 @@ struct S7;</code></pre>
 <div>
 <div>
 <h2 id="S0-0d-S5-0b-S6-S7-0d">
-S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::S7&lt;38, bool&gt;<a class="mrdocs-anchor" href="#S0-0d-S5-0b-S6-S7-0d" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::S7&lt;38, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -10399,8 +10041,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0d-S5-0b-S6-S7-0d-S8">
-S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::S7&lt;38, bool&gt;::S8<a class="mrdocs-anchor" href="#S0-0d-S5-0b-S6-S7-0d-S8" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::S7&lt;38, bool&gt;::S8</h2>
 </div>
 <div>
 <h3>
@@ -10415,8 +10056,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0d-S5-0b-S6-S7-0d-S9">
-S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::S7&lt;38, bool&gt;::S9<a class="mrdocs-anchor" href="#S0-0d-S5-0b-S6-S7-0d-S9" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::S7&lt;38, bool&gt;::S9</h2>
 </div>
 <div>
 <h3>
@@ -10450,8 +10090,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0d-S5-0b-S6-S7-0d-f7">
-S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::S7&lt;38, bool&gt;::f7<a class="mrdocs-anchor" href="#S0-0d-S5-0b-S6-S7-0d-f7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::S7&lt;38, bool&gt;::f7</h2>
 </div>
 <div>
 <h3>
@@ -10465,8 +10104,7 @@ f7();</code></pre>
 <div>
 <div>
 <h2 id="S0-0d-S5-0b-S6-f6">
-S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-0d-S5-0b-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -10480,8 +10118,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-0d-S5-0b-f5">
-S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::f5<a class="mrdocs-anchor" href="#S0-0d-S5-0b-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::S5&lt;37, bool&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -10495,8 +10132,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-0d-f0">
-S0&lt;36, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-0d-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;36, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -10510,8 +10146,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0206">
-S0&lt;39, bool&gt;<a class="mrdocs-anchor" href="#S0-0206" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -10557,8 +10192,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0206-S1">
-S0&lt;39, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-0206-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -10573,8 +10207,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0206-S5-06">
-S0&lt;39, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-0206-S5-06" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -10592,8 +10225,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0206-S5-08">
-S0&lt;39, bool&gt;::S5&lt;40, bool&gt;<a class="mrdocs-anchor" href="#S0-0206-S5-08" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::S5&lt;40, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -10637,8 +10269,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0206-S5-08-S6">
-S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6<a class="mrdocs-anchor" href="#S0-0206-S5-08-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -10682,8 +10313,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0206-S5-08-S6-S7-06">
-S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-0206-S5-08-S6-S7-06" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -10701,8 +10331,7 @@ struct S7;</code></pre>
 <div>
 <div>
 <h2 id="S0-0206-S5-08-S6-S7-01">
-S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::S7&lt;41, bool&gt;<a class="mrdocs-anchor" href="#S0-0206-S5-08-S6-S7-01" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::S7&lt;41, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -10747,8 +10376,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0206-S5-08-S6-S7-01-S8">
-S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::S7&lt;41, bool&gt;::S8<a class="mrdocs-anchor" href="#S0-0206-S5-08-S6-S7-01-S8" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::S7&lt;41, bool&gt;::S8</h2>
 </div>
 <div>
 <h3>
@@ -10763,8 +10391,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-0206-S5-08-S6-S7-01-S9-0f">
-S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::S7&lt;41, bool&gt;::S9<a class="mrdocs-anchor" href="#S0-0206-S5-08-S6-S7-01-S9-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::S7&lt;41, bool&gt;::S9</h2>
 </div>
 <div>
 <h3>
@@ -10798,8 +10425,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0206-S5-08-S6-S7-01-f7">
-S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::S7&lt;41, bool&gt;::f7<a class="mrdocs-anchor" href="#S0-0206-S5-08-S6-S7-01-f7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::S7&lt;41, bool&gt;::f7</h2>
 </div>
 <div>
 <h3>
@@ -10813,8 +10439,7 @@ f7();</code></pre>
 <div>
 <div>
 <h2 id="S0-0206-S5-08-S6-f6">
-S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-0206-S5-08-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -10828,8 +10453,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-0206-S5-08-f5">
-S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::f5<a class="mrdocs-anchor" href="#S0-0206-S5-08-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::S5&lt;40, bool&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -10843,8 +10467,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-0206-f0">
-S0&lt;39, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-0206-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;39, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -10858,8 +10481,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0b6">
-S0&lt;4, bool&gt;<a class="mrdocs-anchor" href="#S0-0b6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -10904,8 +10526,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0b6-S1">
-S0&lt;4, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-0b6-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -10948,8 +10569,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-0b6-S1-S2-06">
-S0&lt;4, bool&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-0b6-S1-S2-06" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4, bool&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -10983,8 +10603,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0b6-S1-f1">
-S0&lt;4, bool&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-0b6-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4, bool&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -10998,8 +10617,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-0b6-S5">
-S0&lt;4, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-0b6-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -11017,8 +10635,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-0b6-f0">
-S0&lt;4, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-0b6-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;4, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -11032,8 +10649,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-05291">
-S0&lt;43, bool&gt;<a class="mrdocs-anchor" href="#S0-05291" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -11079,8 +10695,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-05291-S1">
-S0&lt;43, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-05291-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -11095,8 +10710,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-05291-S5-02">
-S0&lt;43, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-05291-S5-02" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -11114,8 +10728,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-05291-S5-0e">
-S0&lt;43, bool&gt;::S5&lt;44, bool&gt;<a class="mrdocs-anchor" href="#S0-05291-S5-0e" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::S5&lt;44, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -11159,8 +10772,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-05291-S5-0e-S6">
-S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6<a class="mrdocs-anchor" href="#S0-05291-S5-0e-S6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6</h2>
 </div>
 <div>
 <h3>
@@ -11204,8 +10816,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-05291-S5-0e-S6-S7-04">
-S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::S7<a class="mrdocs-anchor" href="#S0-05291-S5-0e-S6-S7-04" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::S7</h2>
 </div>
 <div>
 <h3>
@@ -11223,8 +10834,7 @@ struct S7;</code></pre>
 <div>
 <div>
 <h2 id="S0-05291-S5-0e-S6-S7-0f">
-S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::S7&lt;45, bool&gt;<a class="mrdocs-anchor" href="#S0-05291-S5-0e-S6-S7-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::S7&lt;45, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -11269,8 +10879,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-05291-S5-0e-S6-S7-0f-S8">
-S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::S7&lt;45, bool&gt;::S8<a class="mrdocs-anchor" href="#S0-05291-S5-0e-S6-S7-0f-S8" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::S7&lt;45, bool&gt;::S8</h2>
 </div>
 <div>
 <h3>
@@ -11285,8 +10894,7 @@ Declared in <code>&lt;class-template-specializations-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-05291-S5-0e-S6-S7-0f-S9-06">
-S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::S7&lt;45, bool&gt;::S9<a class="mrdocs-anchor" href="#S0-05291-S5-0e-S6-S7-0f-S9-06" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::S7&lt;45, bool&gt;::S9</h2>
 </div>
 <div>
 <h3>
@@ -11320,8 +10928,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-05291-S5-0e-S6-S7-0f-f7">
-S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::S7&lt;45, bool&gt;::f7<a class="mrdocs-anchor" href="#S0-05291-S5-0e-S6-S7-0f-f7" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::S7&lt;45, bool&gt;::f7</h2>
 </div>
 <div>
 <h3>
@@ -11335,8 +10942,7 @@ f7();</code></pre>
 <div>
 <div>
 <h2 id="S0-05291-S5-0e-S6-f6">
-S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::f6<a class="mrdocs-anchor" href="#S0-05291-S5-0e-S6-f6" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::S6::f6</h2>
 </div>
 <div>
 <h3>
@@ -11350,8 +10956,7 @@ f6();</code></pre>
 <div>
 <div>
 <h2 id="S0-05291-S5-0e-f5">
-S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::f5<a class="mrdocs-anchor" href="#S0-05291-S5-0e-f5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::S5&lt;44, bool&gt;::f5</h2>
 </div>
 <div>
 <h3>
@@ -11365,8 +10970,7 @@ f5();</code></pre>
 <div>
 <div>
 <h2 id="S0-05291-f0">
-S0&lt;43, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-05291-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;43, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -11380,8 +10984,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-023">
-S0&lt;6, bool&gt;<a class="mrdocs-anchor" href="#S0-023" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -11426,8 +11029,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-023-S1">
-S0&lt;6, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-023-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -11470,8 +11072,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-023-S1-S2-0f">
-S0&lt;6, bool&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-023-S1-S2-0f" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6, bool&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -11505,8 +11106,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-023-S1-f1">
-S0&lt;6, bool&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-023-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6, bool&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -11520,8 +11120,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-023-S5">
-S0&lt;6, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-023-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -11539,8 +11138,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-023-f0">
-S0&lt;6, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-023-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -11554,8 +11152,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-04">
-S0&lt;8, bool&gt;<a class="mrdocs-anchor" href="#S0-04" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -11600,8 +11197,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-04-S1">
-S0&lt;8, bool&gt;::S1<a class="mrdocs-anchor" href="#S0-04-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8, bool&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -11645,8 +11241,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-04-S1-S2-0e">
-S0&lt;8, bool&gt;::S1::S2<a class="mrdocs-anchor" href="#S0-04-S1-S2-0e" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8, bool&gt;::S1::S2</h2>
 </div>
 <div>
 <h3>
@@ -11664,8 +11259,7 @@ struct S2;</code></pre>
 <div>
 <div>
 <h2 id="S0-04-S1-S2-0a">
-S0&lt;8, bool&gt;::S1::S2&lt;9, bool&gt;<a class="mrdocs-anchor" href="#S0-04-S1-S2-0a" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8, bool&gt;::S1::S2&lt;9, bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -11710,8 +11304,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-04-S1-S2-0a-S3">
-S0&lt;8, bool&gt;::S1::S2&lt;9, bool&gt;::S3<a class="mrdocs-anchor" href="#S0-04-S1-S2-0a-S3" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8, bool&gt;::S1::S2&lt;9, bool&gt;::S3</h2>
 </div>
 <div>
 <h3>
@@ -11756,8 +11349,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-04-S1-S2-0a-S3-f3">
-S0&lt;8, bool&gt;::S1::S2&lt;9, bool&gt;::S3::f3<a class="mrdocs-anchor" href="#S0-04-S1-S2-0a-S3-f3" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8, bool&gt;::S1::S2&lt;9, bool&gt;::S3::f3</h2>
 </div>
 <div>
 <h3>
@@ -11771,8 +11363,7 @@ f3();</code></pre>
 <div>
 <div>
 <h2 id="S0-04-S1-S2-0a-S4">
-S0&lt;8, bool&gt;::S1::S2&lt;9, bool&gt;::S4<a class="mrdocs-anchor" href="#S0-04-S1-S2-0a-S4" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8, bool&gt;::S1::S2&lt;9, bool&gt;::S4</h2>
 </div>
 <div>
 <h3>
@@ -11790,8 +11381,7 @@ struct S4;</code></pre>
 <div>
 <div>
 <h2 id="S0-04-S1-S2-0a-f2">
-S0&lt;8, bool&gt;::S1::S2&lt;9, bool&gt;::f2<a class="mrdocs-anchor" href="#S0-04-S1-S2-0a-f2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8, bool&gt;::S1::S2&lt;9, bool&gt;::f2</h2>
 </div>
 <div>
 <h3>
@@ -11805,8 +11395,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="S0-04-S1-f1">
-S0&lt;8, bool&gt;::S1::f1<a class="mrdocs-anchor" href="#S0-04-S1-f1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8, bool&gt;::S1::f1</h2>
 </div>
 <div>
 <h3>
@@ -11820,8 +11409,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-04-S5">
-S0&lt;8, bool&gt;::S5<a class="mrdocs-anchor" href="#S0-04-S5" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8, bool&gt;::S5</h2>
 </div>
 <div>
 <h3>
@@ -11839,8 +11427,7 @@ struct S5;</code></pre>
 <div>
 <div>
 <h2 id="S0-04-f0">
-S0&lt;8, bool&gt;::f0<a class="mrdocs-anchor" href="#S0-04-f0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;8, bool&gt;::f0</h2>
 </div>
 <div>
 <h3>
@@ -11854,8 +11441,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-0c4">
-S0&lt;1, T*&gt;<a class="mrdocs-anchor" href="#S0-0c4" aria-label="Permalink">#</a>
-</h2>
+S0&lt;1, T*&gt;</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/class-template-specializations-2.html
+++ b/test-files/golden-tests/symbols/record/class-template-specializations-2.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -33,8 +32,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e">
-A<a class="mrdocs-anchor" href="#A-0e" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -50,8 +48,7 @@ struct A;</code></pre>
 <div>
 <div>
 <h2 id="A-06">
-A&lt;double&gt;<a class="mrdocs-anchor" href="#A-06" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;</h2>
 </div>
 <div>
 <h3>
@@ -83,8 +80,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-06-D-0b">
-A&lt;double&gt;::D<a class="mrdocs-anchor" href="#A-06-D-0b" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;::D</h2>
 </div>
 <div>
 <h3>
@@ -115,8 +111,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-06-D-0b-E-01">
-A&lt;double&gt;::D::E<a class="mrdocs-anchor" href="#A-06-D-0b-E-01" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;::D::E</h2>
 </div>
 <div>
 <h3>
@@ -132,8 +127,7 @@ struct E;</code></pre>
 <div>
 <div>
 <h2 id="A-06-D-0b-E-04">
-A&lt;double&gt;::D::E&lt;T*&gt;<a class="mrdocs-anchor" href="#A-06-D-0b-E-04" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;::D::E&lt;T*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -163,8 +157,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-06-D-0b-E-04-F">
-A&lt;double&gt;::D::E&lt;T*&gt;::F<a class="mrdocs-anchor" href="#A-06-D-0b-E-04-F" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;::D::E&lt;T*&gt;::F</h2>
 </div>
 <div>
 <h3>
@@ -179,8 +172,7 @@ Declared in <code>&lt;class-template-specializations-2.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-06-D-07">
-A&lt;double&gt;::D&lt;short&gt;<a class="mrdocs-anchor" href="#A-06-D-07" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;::D&lt;short&gt;</h2>
 </div>
 <div>
 <h3>
@@ -211,8 +203,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-06-D-07-E-07">
-A&lt;double&gt;::D&lt;short&gt;::E<a class="mrdocs-anchor" href="#A-06-D-07-E-07" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;::D&lt;short&gt;::E</h2>
 </div>
 <div>
 <h3>
@@ -228,8 +219,7 @@ struct E;</code></pre>
 <div>
 <div>
 <h2 id="A-06-D-07-E-01">
-A&lt;double&gt;::D&lt;short&gt;::E&lt;int*&gt;<a class="mrdocs-anchor" href="#A-06-D-07-E-01" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;::D&lt;short&gt;::E&lt;int*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -259,8 +249,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-06-D-07-E-01-F">
-A&lt;double&gt;::D&lt;short&gt;::E&lt;int*&gt;::F<a class="mrdocs-anchor" href="#A-06-D-07-E-01-F" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;::D&lt;short&gt;::E&lt;int*&gt;::F</h2>
 </div>
 <div>
 <h3>
@@ -275,8 +264,7 @@ Declared in <code>&lt;class-template-specializations-2.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-06-D-04">
-A&lt;double&gt;::D&lt;float&gt;<a class="mrdocs-anchor" href="#A-06-D-04" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;::D&lt;float&gt;</h2>
 </div>
 <div>
 <h3>
@@ -307,8 +295,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-06-D-04-G-06">
-A&lt;double&gt;::D&lt;float&gt;::G<a class="mrdocs-anchor" href="#A-06-D-04-G-06" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;::D&lt;float&gt;::G</h2>
 </div>
 <div>
 <h3>
@@ -324,8 +311,7 @@ struct G;</code></pre>
 <div>
 <div>
 <h2 id="A-06-D-04-G-0c">
-A&lt;double&gt;::D&lt;float&gt;::G&lt;T*&gt;<a class="mrdocs-anchor" href="#A-06-D-04-G-0c" aria-label="Permalink">#</a>
-</h2>
+A&lt;double&gt;::D&lt;float&gt;::G&lt;T*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -341,8 +327,7 @@ struct <a href="#A-06-D-04-G-06">G</a>&lt;T*&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-02">
-A&lt;long*&gt;<a class="mrdocs-anchor" href="#A-02" aria-label="Permalink">#</a>
-</h2>
+A&lt;long*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -374,8 +359,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-02-B-06">
-A&lt;long*&gt;::B<a class="mrdocs-anchor" href="#A-02-B-06" aria-label="Permalink">#</a>
-</h2>
+A&lt;long*&gt;::B</h2>
 </div>
 <div>
 <h3>
@@ -391,8 +375,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="A-02-B-0d">
-A&lt;long*&gt;::B&lt;int&gt;<a class="mrdocs-anchor" href="#A-02-B-0d" aria-label="Permalink">#</a>
-</h2>
+A&lt;long*&gt;::B&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -408,8 +391,7 @@ struct <a href="#A-03-B-05">B</a>&lt;int&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-02-B-05">
-A&lt;long*&gt;::B&lt;int*&gt;<a class="mrdocs-anchor" href="#A-02-B-05" aria-label="Permalink">#</a>
-</h2>
+A&lt;long*&gt;::B&lt;int*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -439,8 +421,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-02-B-05-C">
-A&lt;long*&gt;::B&lt;int*&gt;::C<a class="mrdocs-anchor" href="#A-02-B-05-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;long*&gt;::B&lt;int*&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -455,8 +436,7 @@ Declared in <code>&lt;class-template-specializations-2.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-03">
-A&lt;T*&gt;<a class="mrdocs-anchor" href="#A-03" aria-label="Permalink">#</a>
-</h2>
+A&lt;T*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -488,8 +468,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-03-B-05">
-A&lt;T*&gt;::B<a class="mrdocs-anchor" href="#A-03-B-05" aria-label="Permalink">#</a>
-</h2>
+A&lt;T*&gt;::B</h2>
 </div>
 <div>
 <h3>
@@ -505,8 +484,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="A-03-B-0b">
-A&lt;T*&gt;::B&lt;int&gt;<a class="mrdocs-anchor" href="#A-03-B-0b" aria-label="Permalink">#</a>
-</h2>
+A&lt;T*&gt;::B&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -522,8 +500,7 @@ struct <a href="#A-03-B-05">B</a>&lt;int&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-03-B-01">
-A&lt;T*&gt;::B&lt;U*&gt;<a class="mrdocs-anchor" href="#A-03-B-01" aria-label="Permalink">#</a>
-</h2>
+A&lt;T*&gt;::B&lt;U*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -553,8 +530,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-03-B-01-C">
-A&lt;T*&gt;::B&lt;U*&gt;::C<a class="mrdocs-anchor" href="#A-03-B-01-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;T*&gt;::B&lt;U*&gt;::C</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/class-template-specializations-3.html
+++ b/test-files/golden-tests/symbols/record/class-template-specializations-3.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -35,8 +34,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e">
-A<a class="mrdocs-anchor" href="#A-0e" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -67,8 +65,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e-B-07">
-A::B<a class="mrdocs-anchor" href="#A-0e-B-07" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 </div>
 <div>
 <h3>
@@ -100,8 +97,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e-B-07-C">
-A::B::C<a class="mrdocs-anchor" href="#A-0e-B-07-C" aria-label="Permalink">#</a>
-</h2>
+A::B::C</h2>
 </div>
 <div>
 <h3>
@@ -116,8 +112,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-0e-B-07-D-09">
-A::B::D<a class="mrdocs-anchor" href="#A-0e-B-07-D-09" aria-label="Permalink">#</a>
-</h2>
+A::B::D</h2>
 </div>
 <div>
 <h3>
@@ -133,8 +128,7 @@ struct D;</code></pre>
 <div>
 <div>
 <h2 id="A-0e-B-07-D-0f">
-A::B::D&lt;bool&gt;<a class="mrdocs-anchor" href="#A-0e-B-07-D-0f" aria-label="Permalink">#</a>
-</h2>
+A::B::D&lt;bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -150,8 +144,7 @@ struct <a href="#A-0e-B-07-D-09">D</a>&lt;bool&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-0e-B-00">
-A::B&lt;double&gt;<a class="mrdocs-anchor" href="#A-0e-B-00" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;double&gt;</h2>
 </div>
 <div>
 <h3>
@@ -183,8 +176,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e-B-00-C">
-A::B&lt;double&gt;::C<a class="mrdocs-anchor" href="#A-0e-B-00-C" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;double&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -199,8 +191,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-0e-B-00-D-09">
-A::B&lt;double&gt;::D<a class="mrdocs-anchor" href="#A-0e-B-00-D-09" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;double&gt;::D</h2>
 </div>
 <div>
 <h3>
@@ -216,8 +207,7 @@ struct D;</code></pre>
 <div>
 <div>
 <h2 id="A-0e-B-00-D-0d">
-A::B&lt;double&gt;::D&lt;bool&gt;<a class="mrdocs-anchor" href="#A-0e-B-00-D-0d" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;double&gt;::D&lt;bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -233,8 +223,7 @@ struct <a href="#A-0e-B-00-D-09">D</a>&lt;bool&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-00">
-A&lt;short&gt;<a class="mrdocs-anchor" href="#A-00" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;</h2>
 </div>
 <div>
 <h3>
@@ -266,8 +255,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-00-B-0e">
-A&lt;short&gt;::B<a class="mrdocs-anchor" href="#A-00-B-0e" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::B</h2>
 </div>
 <div>
 <h3>
@@ -283,8 +271,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="A-00-B-00">
-A&lt;short&gt;::B&lt;void&gt;<a class="mrdocs-anchor" href="#A-00-B-00" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::B&lt;void&gt;</h2>
 </div>
 <div>
 <h3>
@@ -316,8 +303,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-00-B-00-C">
-A&lt;short&gt;::B&lt;void&gt;::C<a class="mrdocs-anchor" href="#A-00-B-00-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::B&lt;void&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -332,8 +318,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-00-B-00-D-03">
-A&lt;short&gt;::B&lt;void&gt;::D<a class="mrdocs-anchor" href="#A-00-B-00-D-03" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::B&lt;void&gt;::D</h2>
 </div>
 <div>
 <h3>
@@ -349,8 +334,7 @@ struct D;</code></pre>
 <div>
 <div>
 <h2 id="A-00-B-00-D-07">
-A&lt;short&gt;::B&lt;void&gt;::D&lt;bool&gt;<a class="mrdocs-anchor" href="#A-00-B-00-D-07" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::B&lt;void&gt;::D&lt;bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -366,8 +350,7 @@ struct <a href="#A-00-B-00-D-03">D</a>&lt;bool&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-00-B-07">
-A&lt;short&gt;::B&lt;double&gt;<a class="mrdocs-anchor" href="#A-00-B-07" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::B&lt;double&gt;</h2>
 </div>
 <div>
 <h3>
@@ -399,8 +382,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-00-B-07-C">
-A&lt;short&gt;::B&lt;double&gt;::C<a class="mrdocs-anchor" href="#A-00-B-07-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::B&lt;double&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -415,8 +397,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-00-B-07-D-015b">
-A&lt;short&gt;::B&lt;double&gt;::D<a class="mrdocs-anchor" href="#A-00-B-07-D-015b" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::B&lt;double&gt;::D</h2>
 </div>
 <div>
 <h3>
@@ -432,8 +413,7 @@ struct D;</code></pre>
 <div>
 <div>
 <h2 id="A-00-B-07-D-0150">
-A&lt;short&gt;::B&lt;double&gt;::D&lt;bool&gt;<a class="mrdocs-anchor" href="#A-00-B-07-D-0150" aria-label="Permalink">#</a>
-</h2>
+A&lt;short&gt;::B&lt;double&gt;::D&lt;bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -449,8 +429,7 @@ struct <a href="#A-0e-B-00-D-09">D</a>&lt;bool&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-07">
-A&lt;unsigned int&gt;<a class="mrdocs-anchor" href="#A-07" aria-label="Permalink">#</a>
-</h2>
+A&lt;unsigned int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -482,8 +461,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-07-B-03a">
-A&lt;unsigned int&gt;::B<a class="mrdocs-anchor" href="#A-07-B-03a" aria-label="Permalink">#</a>
-</h2>
+A&lt;unsigned int&gt;::B</h2>
 </div>
 <div>
 <h3>
@@ -499,8 +477,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="A-07-B-05">
-A&lt;unsigned int&gt;::B&lt;float&gt;<a class="mrdocs-anchor" href="#A-07-B-05" aria-label="Permalink">#</a>
-</h2>
+A&lt;unsigned int&gt;::B&lt;float&gt;</h2>
 </div>
 <div>
 <h3>
@@ -532,8 +509,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-07-B-05-C">
-A&lt;unsigned int&gt;::B&lt;float&gt;::C<a class="mrdocs-anchor" href="#A-07-B-05-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;unsigned int&gt;::B&lt;float&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -548,8 +524,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-07-B-05-D-0e">
-A&lt;unsigned int&gt;::B&lt;float&gt;::D<a class="mrdocs-anchor" href="#A-07-B-05-D-0e" aria-label="Permalink">#</a>
-</h2>
+A&lt;unsigned int&gt;::B&lt;float&gt;::D</h2>
 </div>
 <div>
 <h3>
@@ -565,8 +540,7 @@ struct D;</code></pre>
 <div>
 <div>
 <h2 id="A-07-B-05-D-01">
-A&lt;unsigned int&gt;::B&lt;float&gt;::D&lt;bool&gt;<a class="mrdocs-anchor" href="#A-07-B-05-D-01" aria-label="Permalink">#</a>
-</h2>
+A&lt;unsigned int&gt;::B&lt;float&gt;::D&lt;bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -582,8 +556,7 @@ struct <a href="#A-0e-B-07-D-09">D</a>&lt;bool&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-07-B-03e">
-A&lt;unsigned int&gt;::B&lt;double&gt;<a class="mrdocs-anchor" href="#A-07-B-03e" aria-label="Permalink">#</a>
-</h2>
+A&lt;unsigned int&gt;::B&lt;double&gt;</h2>
 </div>
 <div>
 <h3>
@@ -615,8 +588,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-07-B-03e-C">
-A&lt;unsigned int&gt;::B&lt;double&gt;::C<a class="mrdocs-anchor" href="#A-07-B-03e-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;unsigned int&gt;::B&lt;double&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -631,8 +603,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-07-B-03e-D-01">
-A&lt;unsigned int&gt;::B&lt;double&gt;::D<a class="mrdocs-anchor" href="#A-07-B-03e-D-01" aria-label="Permalink">#</a>
-</h2>
+A&lt;unsigned int&gt;::B&lt;double&gt;::D</h2>
 </div>
 <div>
 <h3>
@@ -648,8 +619,7 @@ struct D;</code></pre>
 <div>
 <div>
 <h2 id="A-07-B-03e-D-0f">
-A&lt;unsigned int&gt;::B&lt;double&gt;::D&lt;bool&gt;<a class="mrdocs-anchor" href="#A-07-B-03e-D-0f" aria-label="Permalink">#</a>
-</h2>
+A&lt;unsigned int&gt;::B&lt;double&gt;::D&lt;bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -665,8 +635,7 @@ struct <a href="#A-0e-B-00-D-09">D</a>&lt;bool&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-0c">
-A&lt;long&gt;<a class="mrdocs-anchor" href="#A-0c" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;</h2>
 </div>
 <div>
 <h3>
@@ -698,8 +667,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0c-B-0b">
-A&lt;long&gt;::B<a class="mrdocs-anchor" href="#A-0c-B-0b" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B</h2>
 </div>
 <div>
 <h3>
@@ -731,8 +699,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0c-B-0b-C">
-A&lt;long&gt;::B::C<a class="mrdocs-anchor" href="#A-0c-B-0b-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B::C</h2>
 </div>
 <div>
 <h3>
@@ -747,8 +714,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-0c-B-0b-D-00">
-A&lt;long&gt;::B::D<a class="mrdocs-anchor" href="#A-0c-B-0b-D-00" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B::D</h2>
 </div>
 <div>
 <h3>
@@ -764,8 +730,7 @@ struct D;</code></pre>
 <div>
 <div>
 <h2 id="A-0c-B-0b-D-0b">
-A&lt;long&gt;::B::D&lt;bool&gt;<a class="mrdocs-anchor" href="#A-0c-B-0b-D-0b" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B::D&lt;bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -781,8 +746,7 @@ struct <a href="#A-0c-B-0b-D-00">D</a>&lt;bool&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-0c-B-08">
-A&lt;long&gt;::B&lt;float&gt;<a class="mrdocs-anchor" href="#A-0c-B-08" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B&lt;float&gt;</h2>
 </div>
 <div>
 <h3>
@@ -814,8 +778,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0c-B-08-C">
-A&lt;long&gt;::B&lt;float&gt;::C<a class="mrdocs-anchor" href="#A-0c-B-08-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B&lt;float&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -830,8 +793,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-0c-B-08-D-08">
-A&lt;long&gt;::B&lt;float&gt;::D<a class="mrdocs-anchor" href="#A-0c-B-08-D-08" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B&lt;float&gt;::D</h2>
 </div>
 <div>
 <h3>
@@ -847,8 +809,7 @@ struct D;</code></pre>
 <div>
 <div>
 <h2 id="A-0c-B-08-D-03">
-A&lt;long&gt;::B&lt;float&gt;::D&lt;bool&gt;<a class="mrdocs-anchor" href="#A-0c-B-08-D-03" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B&lt;float&gt;::D&lt;bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -864,8 +825,7 @@ struct <a href="#A-0c-B-0b-D-00">D</a>&lt;bool&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-0c-B-0d">
-A&lt;long&gt;::B&lt;double&gt;<a class="mrdocs-anchor" href="#A-0c-B-0d" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B&lt;double&gt;</h2>
 </div>
 <div>
 <h3>
@@ -897,8 +857,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0c-B-0d-C">
-A&lt;long&gt;::B&lt;double&gt;::C<a class="mrdocs-anchor" href="#A-0c-B-0d-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B&lt;double&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -913,8 +872,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-0c-B-0d-D-0c">
-A&lt;long&gt;::B&lt;double&gt;::D<a class="mrdocs-anchor" href="#A-0c-B-0d-D-0c" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B&lt;double&gt;::D</h2>
 </div>
 <div>
 <h3>
@@ -930,8 +888,7 @@ struct D;</code></pre>
 <div>
 <div>
 <h2 id="A-0c-B-0d-D-03">
-A&lt;long&gt;::B&lt;double&gt;::D&lt;bool&gt;<a class="mrdocs-anchor" href="#A-0c-B-0d-D-03" aria-label="Permalink">#</a>
-</h2>
+A&lt;long&gt;::B&lt;double&gt;::D&lt;bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -947,8 +904,7 @@ struct <a href="#A-0e-B-00-D-09">D</a>&lt;bool&gt;;</code></pre>
 <div>
 <div>
 <h2 id="A-01">
-A&lt;float&gt;<a class="mrdocs-anchor" href="#A-01" aria-label="Permalink">#</a>
-</h2>
+A&lt;float&gt;</h2>
 </div>
 <div>
 <h3>
@@ -979,8 +935,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-01-B-07">
-A&lt;float&gt;::B<a class="mrdocs-anchor" href="#A-01-B-07" aria-label="Permalink">#</a>
-</h2>
+A&lt;float&gt;::B</h2>
 </div>
 <div>
 <h3>
@@ -996,8 +951,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="A-01-B-08">
-A&lt;float&gt;::B&lt;double&gt;<a class="mrdocs-anchor" href="#A-01-B-08" aria-label="Permalink">#</a>
-</h2>
+A&lt;float&gt;::B&lt;double&gt;</h2>
 </div>
 <div>
 <h3>
@@ -1029,8 +983,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-01-B-08-C">
-A&lt;float&gt;::B&lt;double&gt;::C<a class="mrdocs-anchor" href="#A-01-B-08-C" aria-label="Permalink">#</a>
-</h2>
+A&lt;float&gt;::B&lt;double&gt;::C</h2>
 </div>
 <div>
 <h3>
@@ -1045,8 +998,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-01-B-08-D-0ae">
-A&lt;float&gt;::B&lt;double&gt;::D<a class="mrdocs-anchor" href="#A-01-B-08-D-0ae" aria-label="Permalink">#</a>
-</h2>
+A&lt;float&gt;::B&lt;double&gt;::D</h2>
 </div>
 <div>
 <h3>
@@ -1062,8 +1014,7 @@ struct D;</code></pre>
 <div>
 <div>
 <h2 id="A-01-B-08-D-0af">
-A&lt;float&gt;::B&lt;double&gt;::D&lt;bool&gt;<a class="mrdocs-anchor" href="#A-01-B-08-D-0af" aria-label="Permalink">#</a>
-</h2>
+A&lt;float&gt;::B&lt;double&gt;::D&lt;bool&gt;</h2>
 </div>
 <div>
 <h3>
@@ -1079,8 +1030,7 @@ struct <a href="#A-0e-B-00-D-09">D</a>&lt;bool&gt;;</code></pre>
 <div>
 <div>
 <h2 id="E">
-E<a class="mrdocs-anchor" href="#E" aria-label="Permalink">#</a>
-</h2>
+E</h2>
 </div>
 <div>
 <h3>
@@ -1123,8 +1073,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="E-m0">
-E::m0<a class="mrdocs-anchor" href="#E-m0" aria-label="Permalink">#</a>
-</h2>
+E::m0</h2>
 </div>
 <div>
 <h3>
@@ -1137,8 +1086,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m1">
-E::m1<a class="mrdocs-anchor" href="#E-m1" aria-label="Permalink">#</a>
-</h2>
+E::m1</h2>
 </div>
 <div>
 <h3>
@@ -1151,8 +1099,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m10">
-E::m10<a class="mrdocs-anchor" href="#E-m10" aria-label="Permalink">#</a>
-</h2>
+E::m10</h2>
 </div>
 <div>
 <h3>
@@ -1165,8 +1112,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m11">
-E::m11<a class="mrdocs-anchor" href="#E-m11" aria-label="Permalink">#</a>
-</h2>
+E::m11</h2>
 </div>
 <div>
 <h3>
@@ -1179,8 +1125,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m12">
-E::m12<a class="mrdocs-anchor" href="#E-m12" aria-label="Permalink">#</a>
-</h2>
+E::m12</h2>
 </div>
 <div>
 <h3>
@@ -1193,8 +1138,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m13">
-E::m13<a class="mrdocs-anchor" href="#E-m13" aria-label="Permalink">#</a>
-</h2>
+E::m13</h2>
 </div>
 <div>
 <h3>
@@ -1207,8 +1151,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m14">
-E::m14<a class="mrdocs-anchor" href="#E-m14" aria-label="Permalink">#</a>
-</h2>
+E::m14</h2>
 </div>
 <div>
 <h3>
@@ -1221,8 +1164,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m2">
-E::m2<a class="mrdocs-anchor" href="#E-m2" aria-label="Permalink">#</a>
-</h2>
+E::m2</h2>
 </div>
 <div>
 <h3>
@@ -1235,8 +1177,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m3">
-E::m3<a class="mrdocs-anchor" href="#E-m3" aria-label="Permalink">#</a>
-</h2>
+E::m3</h2>
 </div>
 <div>
 <h3>
@@ -1249,8 +1190,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m4">
-E::m4<a class="mrdocs-anchor" href="#E-m4" aria-label="Permalink">#</a>
-</h2>
+E::m4</h2>
 </div>
 <div>
 <h3>
@@ -1263,8 +1203,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m5">
-E::m5<a class="mrdocs-anchor" href="#E-m5" aria-label="Permalink">#</a>
-</h2>
+E::m5</h2>
 </div>
 <div>
 <h3>
@@ -1277,8 +1216,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m6">
-E::m6<a class="mrdocs-anchor" href="#E-m6" aria-label="Permalink">#</a>
-</h2>
+E::m6</h2>
 </div>
 <div>
 <h3>
@@ -1291,8 +1229,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m7">
-E::m7<a class="mrdocs-anchor" href="#E-m7" aria-label="Permalink">#</a>
-</h2>
+E::m7</h2>
 </div>
 <div>
 <h3>
@@ -1305,8 +1242,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m8">
-E::m8<a class="mrdocs-anchor" href="#E-m8" aria-label="Permalink">#</a>
-</h2>
+E::m8</h2>
 </div>
 <div>
 <h3>
@@ -1319,8 +1255,7 @@ Declared in <code>&lt;class-template-specializations-3.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E-m9">
-E::m9<a class="mrdocs-anchor" href="#E-m9" aria-label="Permalink">#</a>
-</h2>
+E::m9</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/class-template.html
+++ b/test-files/golden-tests/symbols/record/class-template.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -34,8 +33,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="C0">
-C0<a class="mrdocs-anchor" href="#C0" aria-label="Permalink">#</a>
-</h2>
+C0</h2>
 </div>
 <div>
 <h3>
@@ -81,8 +79,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="C0-N0">
-C0::N0<a class="mrdocs-anchor" href="#C0-N0" aria-label="Permalink">#</a>
-</h2>
+C0::N0</h2>
 </div>
 <div>
 <h3>
@@ -111,8 +108,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="C0-N0-z">
-C0::N0::z<a class="mrdocs-anchor" href="#C0-N0-z" aria-label="Permalink">#</a>
-</h2>
+C0::N0::z</h2>
 </div>
 <div>
 <h3>
@@ -125,8 +121,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C0-w">
-C0::w<a class="mrdocs-anchor" href="#C0-w" aria-label="Permalink">#</a>
-</h2>
+C0::w</h2>
 </div>
 <div>
 <h3>
@@ -139,8 +134,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C0-x">
-C0::x<a class="mrdocs-anchor" href="#C0-x" aria-label="Permalink">#</a>
-</h2>
+C0::x</h2>
 </div>
 <div>
 <h3>
@@ -153,8 +147,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C0-y">
-C0::y<a class="mrdocs-anchor" href="#C0-y" aria-label="Permalink">#</a>
-</h2>
+C0::y</h2>
 </div>
 <div>
 <h3>
@@ -167,8 +160,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C1">
-C1<a class="mrdocs-anchor" href="#C1" aria-label="Permalink">#</a>
-</h2>
+C1</h2>
 </div>
 <div>
 <h3>
@@ -211,8 +203,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="C1-N1">
-C1::N1<a class="mrdocs-anchor" href="#C1-N1" aria-label="Permalink">#</a>
-</h2>
+C1::N1</h2>
 </div>
 <div>
 <h3>
@@ -244,8 +235,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="C1-N1-x">
-C1::N1::x<a class="mrdocs-anchor" href="#C1-N1-x" aria-label="Permalink">#</a>
-</h2>
+C1::N1::x</h2>
 </div>
 <div>
 <h3>
@@ -258,8 +248,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C1-N1-y">
-C1::N1::y<a class="mrdocs-anchor" href="#C1-N1-y" aria-label="Permalink">#</a>
-</h2>
+C1::N1::y</h2>
 </div>
 <div>
 <h3>
@@ -272,8 +261,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C1-N1-z">
-C1::N1::z<a class="mrdocs-anchor" href="#C1-N1-z" aria-label="Permalink">#</a>
-</h2>
+C1::N1::z</h2>
 </div>
 <div>
 <h3>
@@ -286,8 +274,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C1-w">
-C1::w<a class="mrdocs-anchor" href="#C1-w" aria-label="Permalink">#</a>
-</h2>
+C1::w</h2>
 </div>
 <div>
 <h3>
@@ -300,8 +287,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C2">
-C2<a class="mrdocs-anchor" href="#C2" aria-label="Permalink">#</a>
-</h2>
+C2</h2>
 </div>
 <div>
 <h3>
@@ -345,8 +331,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="C2-N2">
-C2::N2<a class="mrdocs-anchor" href="#C2-N2" aria-label="Permalink">#</a>
-</h2>
+C2::N2</h2>
 </div>
 <div>
 <h3>
@@ -379,8 +364,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="C2-N2-w">
-C2::N2::w<a class="mrdocs-anchor" href="#C2-N2-w" aria-label="Permalink">#</a>
-</h2>
+C2::N2::w</h2>
 </div>
 <div>
 <h3>
@@ -393,8 +377,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C2-N2-x">
-C2::N2::x<a class="mrdocs-anchor" href="#C2-N2-x" aria-label="Permalink">#</a>
-</h2>
+C2::N2::x</h2>
 </div>
 <div>
 <h3>
@@ -407,8 +390,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C2-N2-y">
-C2::N2::y<a class="mrdocs-anchor" href="#C2-N2-y" aria-label="Permalink">#</a>
-</h2>
+C2::N2::y</h2>
 </div>
 <div>
 <h3>
@@ -421,8 +403,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C2-N2-z">
-C2::N2::z<a class="mrdocs-anchor" href="#C2-N2-z" aria-label="Permalink">#</a>
-</h2>
+C2::N2::z</h2>
 </div>
 <div>
 <h3>
@@ -435,8 +416,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C2-v">
-C2::v<a class="mrdocs-anchor" href="#C2-v" aria-label="Permalink">#</a>
-</h2>
+C2::v</h2>
 </div>
 <div>
 <h3>
@@ -449,8 +429,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C3">
-C3<a class="mrdocs-anchor" href="#C3" aria-label="Permalink">#</a>
-</h2>
+C3</h2>
 </div>
 <div>
 <h3>
@@ -480,8 +459,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="C3-v">
-C3::v<a class="mrdocs-anchor" href="#C3-v" aria-label="Permalink">#</a>
-</h2>
+C3::v</h2>
 </div>
 <div>
 <h3>
@@ -494,8 +472,7 @@ Declared in <code>&lt;class-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S">
-S<a class="mrdocs-anchor" href="#S" aria-label="Permalink">#</a>
-</h2>
+S</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/conditional-explicit.html
+++ b/test-files/golden-tests/symbols/record/conditional-explicit.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -65,8 +63,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-2constructor-0f">
-A::A<a class="mrdocs-anchor" href="#A-2constructor-0f" aria-label="Permalink">#</a>
-</h2>
+A::A</h2>
 <div>
 <p>Constructors</p>
 </div>
@@ -101,8 +98,7 @@ explicit(sizeof(U) &gt; 4)
 <div>
 <div>
 <h2 id="A-2constructor-0b">
-A::A<a class="mrdocs-anchor" href="#A-2constructor-0b" aria-label="Permalink">#</a>
-</h2>
+A::A</h2>
 <div>
 <p>Conditionally explicit conversion from char</p>
 </div>
@@ -137,8 +133,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-2constructor-01">
-A::A<a class="mrdocs-anchor" href="#A-2constructor-01" aria-label="Permalink">#</a>
-</h2>
+A::A</h2>
 <div>
 <p>Explicit conversion from int</p>
 </div>
@@ -173,8 +168,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-2constructor-00">
-A::A<a class="mrdocs-anchor" href="#A-2constructor-00" aria-label="Permalink">#</a>
-</h2>
+A::A</h2>
 <div>
 <p>Implicit conversion from double</p>
 </div>
@@ -208,8 +202,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-2constructor-02">
-A::A<a class="mrdocs-anchor" href="#A-2constructor-02" aria-label="Permalink">#</a>
-</h2>
+A::A</h2>
 <div>
 <p>Conditionally explicit conversion from other types</p>
 </div>
@@ -245,8 +238,7 @@ Parameters</h3>
 <div>
 <div>
 <h2 id="A-2conversion-0f">
-A::operator U<a class="mrdocs-anchor" href="#A-2conversion-0f" aria-label="Permalink">#</a>
-</h2>
+A::operator U</h2>
 <div>
 <p>Conditional explicit conversion to other types</p>
 </div>
@@ -269,8 +261,7 @@ The object converted to <code>U</code>
 <div>
 <div>
 <h2 id="A-2conversion-00">
-A::operator bool<a class="mrdocs-anchor" href="#A-2conversion-00" aria-label="Permalink">#</a>
-</h2>
+A::operator bool</h2>
 <div>
 <p>Explicit conversion to bool</p>
 </div>
@@ -292,8 +283,7 @@ The object converted to <code>bool</code>
 <div>
 <div>
 <h2 id="A-2conversion-04">
-A::operator char<a class="mrdocs-anchor" href="#A-2conversion-04" aria-label="Permalink">#</a>
-</h2>
+A::operator char</h2>
 <div>
 <p>Conditionally explicit conversion to char</p>
 </div>
@@ -315,8 +305,7 @@ The object converted to <code>char</code>
 <div>
 <div>
 <h2 id="A-2conversion-01">
-A::operator double<a class="mrdocs-anchor" href="#A-2conversion-01" aria-label="Permalink">#</a>
-</h2>
+A::operator double</h2>
 <div>
 <p>Implicit conversion to double</p>
 </div>

--- a/test-files/golden-tests/symbols/record/dtor-overloads.html
+++ b/test-files/golden-tests/symbols/record/dtor-overloads.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-2destructor-02">
-A::~A<a class="mrdocs-anchor" href="#A-2destructor-02" aria-label="Permalink">#</a>
-</h2>
+A::~A</h2>
 <div>
 <p>Destructors</p>
 </div>
@@ -87,8 +84,7 @@ requires (sizeof(T) &lt;&#x3D; 4);</code></pre>
 <div>
 <div>
 <h2 id="A-2destructor-0c">
-A::~A<a class="mrdocs-anchor" href="#A-2destructor-0c" aria-label="Permalink">#</a>
-</h2>
+A::~A</h2>
 <div>
 <p>Destructor</p>
 </div>
@@ -105,8 +101,7 @@ requires (sizeof(T) &gt; 4);</code></pre>
 <div>
 <div>
 <h2 id="A-2destructor-0b">
-A::~A<a class="mrdocs-anchor" href="#A-2destructor-0b" aria-label="Permalink">#</a>
-</h2>
+A::~A</h2>
 <div>
 <p>Destructor</p>
 </div>

--- a/test-files/golden-tests/symbols/record/final-class.html
+++ b/test-files/golden-tests/symbols/record/final-class.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -34,8 +33,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A1">
-A1<a class="mrdocs-anchor" href="#A1" aria-label="Permalink">#</a>
-</h2>
+A1</h2>
 </div>
 <div>
 <h3>
@@ -50,8 +48,7 @@ Declared in <code>&lt;final-class.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A2">
-A2<a class="mrdocs-anchor" href="#A2" aria-label="Permalink">#</a>
-</h2>
+A2</h2>
 </div>
 <div>
 <h3>
@@ -67,8 +64,7 @@ class A2 final</code></pre>
 <div>
 <div>
 <h2 id="A3">
-A3<a class="mrdocs-anchor" href="#A3" aria-label="Permalink">#</a>
-</h2>
+A3</h2>
 </div>
 <div>
 <h3>
@@ -101,8 +97,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="B1">
-B1<a class="mrdocs-anchor" href="#B1" aria-label="Permalink">#</a>
-</h2>
+B1</h2>
 </div>
 <div>
 <h3>
@@ -133,8 +128,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="B2">
-B2<a class="mrdocs-anchor" href="#B2" aria-label="Permalink">#</a>
-</h2>
+B2</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/forward-declared-member.html
+++ b/test-files/golden-tests/symbols/record/forward-declared-member.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -30,8 +29,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="fmt">
-fmt<a class="mrdocs-anchor" href="#fmt" aria-label="Permalink">#</a>
-</h2>
+fmt</h2>
 </div>
 <h2>
 Types</h2>
@@ -51,8 +49,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="fmt-path">
-fmt::path<a class="mrdocs-anchor" href="#fmt-path" aria-label="Permalink">#</a>
-</h2>
+fmt::path</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/friend-duplicate.html
+++ b/test-files/golden-tests/symbols/record/friend-duplicate.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -84,8 +82,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -100,8 +97,7 @@ Declared in <code>&lt;friend-duplicate.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/friend-excluded.html
+++ b/test-files/golden-tests/symbols/record/friend-excluded.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -84,8 +82,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -100,8 +97,7 @@ Declared in <code>&lt;friend-excluded.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/friend-fn-has-docs.html
+++ b/test-files/golden-tests/symbols/record/friend-fn-has-docs.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -44,8 +43,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -79,8 +77,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>f</p>
 </div>

--- a/test-files/golden-tests/symbols/record/friend-fn-member.html
+++ b/test-files/golden-tests/symbols/record/friend-fn-member.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="U">
-U<a class="mrdocs-anchor" href="#U" aria-label="Permalink">#</a>
-</h2>
+U</h2>
 </div>
 <div>
 <h3>
@@ -74,8 +72,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="X">
-X<a class="mrdocs-anchor" href="#X" aria-label="Permalink">#</a>
-</h2>
+X</h2>
 </div>
 <div>
 <h3>
@@ -106,8 +103,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="X-2constructor">
-X::X<a class="mrdocs-anchor" href="#X-2constructor" aria-label="Permalink">#</a>
-</h2>
+X::X</h2>
 <div>
 <p>Default constructor</p>
 </div>
@@ -123,8 +119,7 @@ Declared in <code>&lt;friend-fn-member.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-2destructor">
-X::~X<a class="mrdocs-anchor" href="#X-2destructor" aria-label="Permalink">#</a>
-</h2>
+X::~X</h2>
 <div>
 <p>Destructor</p>
 </div>
@@ -140,8 +135,7 @@ Declared in <code>&lt;friend-fn-member.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-foo">
-X::foo<a class="mrdocs-anchor" href="#X-foo" aria-label="Permalink">#</a>
-</h2>
+X::foo</h2>
 <div>
 <p>Friend member-function</p>
 </div>

--- a/test-files/golden-tests/symbols/record/friend-fn-multi-2nd.html
+++ b/test-files/golden-tests/symbols/record/friend-fn-multi-2nd.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -80,8 +78,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="U">
-U<a class="mrdocs-anchor" href="#U" aria-label="Permalink">#</a>
-</h2>
+U</h2>
 </div>
 <div>
 <h3>
@@ -115,8 +112,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>U::f</p>
 </div>

--- a/test-files/golden-tests/symbols/record/friend-fn-multi-free.html
+++ b/test-files/golden-tests/symbols/record/friend-fn-multi-free.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -80,8 +78,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="U">
-U<a class="mrdocs-anchor" href="#U" aria-label="Permalink">#</a>
-</h2>
+U</h2>
 </div>
 <div>
 <h3>
@@ -115,8 +112,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>f</p>
 </div>

--- a/test-files/golden-tests/symbols/record/friend-fn-multi.html
+++ b/test-files/golden-tests/symbols/record/friend-fn-multi.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -80,8 +78,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="U">
-U<a class="mrdocs-anchor" href="#U" aria-label="Permalink">#</a>
-</h2>
+U</h2>
 </div>
 <div>
 <h3>
@@ -115,8 +112,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>T::f</p>
 </div>

--- a/test-files/golden-tests/symbols/record/friend-fn.html
+++ b/test-files/golden-tests/symbols/record/friend-fn.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -44,8 +43,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -79,8 +77,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>f</p>
 </div>

--- a/test-files/golden-tests/symbols/record/friend-recursive.html
+++ b/test-files/golden-tests/symbols/record/friend-recursive.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -30,8 +29,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="repro">
-repro<a class="mrdocs-anchor" href="#repro" aria-label="Permalink">#</a>
-</h2>
+repro</h2>
 </div>
 <h2>
 Types</h2>
@@ -51,8 +49,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="repro-FriendLoop">
-repro::FriendLoop<a class="mrdocs-anchor" href="#repro-FriendLoop" aria-label="Permalink">#</a>
-</h2>
+repro::FriendLoop</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/friend-type.html
+++ b/test-files/golden-tests/symbols/record/friend-type.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -33,8 +32,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 <div>
 <p>Struct T brief</p>
 </div>
@@ -71,8 +69,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="U">
-U<a class="mrdocs-anchor" href="#U" aria-label="Permalink">#</a>
-</h2>
+U</h2>
 <div>
 <p>Struct U brief</p>
 </div>
@@ -109,8 +106,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="V">
-V<a class="mrdocs-anchor" href="#V" aria-label="Permalink">#</a>
-</h2>
+V</h2>
 <div>
 <p>Struct V brief</p>
 </div>
@@ -147,8 +143,7 @@ Friends</h2>
 <div>
 <div>
 <h2 id="Z">
-Z<a class="mrdocs-anchor" href="#Z" aria-label="Permalink">#</a>
-</h2>
+Z</h2>
 <div>
 <p>Friend class Z brief</p>
 </div>

--- a/test-files/golden-tests/symbols/record/local-class.html
+++ b/test-files/golden-tests/symbols/record/local-class.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -75,8 +73,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-g">
-A::g<a class="mrdocs-anchor" href="#A-g" aria-label="Permalink">#</a>
-</h2>
+A::g</h2>
 </div>
 <div>
 <h3>
@@ -90,8 +87,7 @@ g();</code></pre>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -122,8 +118,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/out-of-line-record-def.html
+++ b/test-files/golden-tests/symbols/record/out-of-line-record-def.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -30,8 +29,7 @@ Namespaces</h2>
 <div>
 <div>
 <h2 id="N">
-N<a class="mrdocs-anchor" href="#N" aria-label="Permalink">#</a>
-</h2>
+N</h2>
 </div>
 <h2>
 Types</h2>
@@ -51,8 +49,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="N-S">
-N::S<a class="mrdocs-anchor" href="#N-S" aria-label="Permalink">#</a>
-</h2>
+N::S</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/record-1.html
+++ b/test-files/golden-tests/symbols/record/record-1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -93,8 +91,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="T-U1">
-T::U1<a class="mrdocs-anchor" href="#T-U1" aria-label="Permalink">#</a>
-</h2>
+T::U1</h2>
 </div>
 <div>
 <h3>
@@ -107,8 +104,7 @@ Declared in <code>&lt;record-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="T-U2">
-T::U2<a class="mrdocs-anchor" href="#T-U2" aria-label="Permalink">#</a>
-</h2>
+T::U2</h2>
 </div>
 <div>
 <h3>
@@ -121,8 +117,7 @@ Declared in <code>&lt;record-1.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="T-f1">
-T::f1<a class="mrdocs-anchor" href="#T-f1" aria-label="Permalink">#</a>
-</h2>
+T::f1</h2>
 </div>
 <div>
 <h3>
@@ -136,8 +131,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="T-f2">
-T::f2<a class="mrdocs-anchor" href="#T-f2" aria-label="Permalink">#</a>
-</h2>
+T::f2</h2>
 </div>
 <div>
 <h3>
@@ -151,8 +145,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="T-f3">
-T::f3<a class="mrdocs-anchor" href="#T-f3" aria-label="Permalink">#</a>
-</h2>
+T::f3</h2>
 </div>
 <div>
 <h3>
@@ -166,8 +159,7 @@ f3();</code></pre>
 <div>
 <div>
 <h2 id="T-g1">
-T::g1<a class="mrdocs-anchor" href="#T-g1" aria-label="Permalink">#</a>
-</h2>
+T::g1</h2>
 <div>
 <p>brief-g1</p>
 </div>
@@ -189,8 +181,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="T-g2">
-T::g2<a class="mrdocs-anchor" href="#T-g2" aria-label="Permalink">#</a>
-</h2>
+T::g2</h2>
 <div>
 <p>brief-g2</p>
 </div>
@@ -212,8 +203,7 @@ the number 2
 <div>
 <div>
 <h2 id="T-g3">
-T::g3<a class="mrdocs-anchor" href="#T-g3" aria-label="Permalink">#</a>
-</h2>
+T::g3</h2>
 <div>
 <p>brief-g3</p>
 </div>

--- a/test-files/golden-tests/symbols/record/record-access.html
+++ b/test-files/golden-tests/symbols/record/record-access.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -32,8 +31,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="C0">
-C0<a class="mrdocs-anchor" href="#C0" aria-label="Permalink">#</a>
-</h2>
+C0</h2>
 </div>
 <div>
 <h3>
@@ -90,8 +88,7 @@ Private Member Functions</h2>
 <div>
 <div>
 <h2 id="C0-f2">
-C0::f2<a class="mrdocs-anchor" href="#C0-f2" aria-label="Permalink">#</a>
-</h2>
+C0::f2</h2>
 </div>
 <div>
 <h3>
@@ -105,8 +102,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="C0-f1">
-C0::f1<a class="mrdocs-anchor" href="#C0-f1" aria-label="Permalink">#</a>
-</h2>
+C0::f1</h2>
 </div>
 <div>
 <h3>
@@ -120,8 +116,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="C0-f0">
-C0::f0<a class="mrdocs-anchor" href="#C0-f0" aria-label="Permalink">#</a>
-</h2>
+C0::f0</h2>
 </div>
 <div>
 <h3>
@@ -135,8 +130,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0">
-S0<a class="mrdocs-anchor" href="#S0" aria-label="Permalink">#</a>
-</h2>
+S0</h2>
 </div>
 <div>
 <h3>
@@ -193,8 +187,7 @@ Private Member Functions</h2>
 <div>
 <div>
 <h2 id="S0-f0">
-S0::f0<a class="mrdocs-anchor" href="#S0-f0" aria-label="Permalink">#</a>
-</h2>
+S0::f0</h2>
 </div>
 <div>
 <h3>
@@ -208,8 +201,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="S0-f1">
-S0::f1<a class="mrdocs-anchor" href="#S0-f1" aria-label="Permalink">#</a>
-</h2>
+S0::f1</h2>
 </div>
 <div>
 <h3>
@@ -223,8 +215,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="S0-f2">
-S0::f2<a class="mrdocs-anchor" href="#S0-f2" aria-label="Permalink">#</a>
-</h2>
+S0::f2</h2>
 </div>
 <div>
 <h3>
@@ -238,8 +229,7 @@ f2();</code></pre>
 <div>
 <div>
 <h2 id="U0">
-U0<a class="mrdocs-anchor" href="#U0" aria-label="Permalink">#</a>
-</h2>
+U0</h2>
 </div>
 <div>
 <h3>
@@ -296,8 +286,7 @@ Private Member Functions</h2>
 <div>
 <div>
 <h2 id="U0-f0">
-U0::f0<a class="mrdocs-anchor" href="#U0-f0" aria-label="Permalink">#</a>
-</h2>
+U0::f0</h2>
 </div>
 <div>
 <h3>
@@ -311,8 +300,7 @@ f0();</code></pre>
 <div>
 <div>
 <h2 id="U0-f1">
-U0::f1<a class="mrdocs-anchor" href="#U0-f1" aria-label="Permalink">#</a>
-</h2>
+U0::f1</h2>
 </div>
 <div>
 <h3>
@@ -326,8 +314,7 @@ f1();</code></pre>
 <div>
 <div>
 <h2 id="U0-f2">
-U0::f2<a class="mrdocs-anchor" href="#U0-f2" aria-label="Permalink">#</a>
-</h2>
+U0::f2</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/record-data.html
+++ b/test-files/golden-tests/symbols/record/record-data.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -34,8 +33,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -68,8 +66,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="T-i">
-T::i<a class="mrdocs-anchor" href="#T-i" aria-label="Permalink">#</a>
-</h2>
+T::i</h2>
 </div>
 <div>
 <h3>
@@ -82,8 +79,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="T-j">
-T::j<a class="mrdocs-anchor" href="#T-j" aria-label="Permalink">#</a>
-</h2>
+T::j</h2>
 </div>
 <div>
 <h3>
@@ -96,8 +92,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="T-k">
-T::k<a class="mrdocs-anchor" href="#T-k" aria-label="Permalink">#</a>
-</h2>
+T::k</h2>
 </div>
 <div>
 <h3>
@@ -111,8 +106,7 @@ int k;</code></pre>
 <div>
 <div>
 <h2 id="T-l">
-T::l<a class="mrdocs-anchor" href="#T-l" aria-label="Permalink">#</a>
-</h2>
+T::l</h2>
 </div>
 <div>
 <h3>
@@ -125,8 +119,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="T-m">
-T::m<a class="mrdocs-anchor" href="#T-m" aria-label="Permalink">#</a>
-</h2>
+T::m</h2>
 </div>
 <div>
 <h3>
@@ -139,8 +132,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U">
-U<a class="mrdocs-anchor" href="#U" aria-label="Permalink">#</a>
-</h2>
+U</h2>
 </div>
 <div>
 <h3>
@@ -169,8 +161,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="U-t">
-U::t<a class="mrdocs-anchor" href="#U-t" aria-label="Permalink">#</a>
-</h2>
+U::t</h2>
 </div>
 <div>
 <h3>
@@ -183,8 +174,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="V">
-V<a class="mrdocs-anchor" href="#V" aria-label="Permalink">#</a>
-</h2>
+V</h2>
 </div>
 <div>
 <h3>
@@ -228,8 +218,7 @@ Private Data Members</h2>
 <div>
 <div>
 <h2 id="V-j">
-V::j<a class="mrdocs-anchor" href="#V-j" aria-label="Permalink">#</a>
-</h2>
+V::j</h2>
 </div>
 <div>
 <h3>
@@ -242,8 +231,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="V-i">
-V::i<a class="mrdocs-anchor" href="#V-i" aria-label="Permalink">#</a>
-</h2>
+V::i</h2>
 </div>
 <div>
 <h3>
@@ -256,8 +244,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="V-k">
-V::k<a class="mrdocs-anchor" href="#V-k" aria-label="Permalink">#</a>
-</h2>
+V::k</h2>
 </div>
 <div>
 <h3>
@@ -270,8 +257,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="W">
-W<a class="mrdocs-anchor" href="#W" aria-label="Permalink">#</a>
-</h2>
+W</h2>
 </div>
 <div>
 <h3>
@@ -300,8 +286,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="W-buf">
-W::buf<a class="mrdocs-anchor" href="#W-buf" aria-label="Permalink">#</a>
-</h2>
+W::buf</h2>
 </div>
 <div>
 <h3>
@@ -314,8 +299,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X">
-X<a class="mrdocs-anchor" href="#X" aria-label="Permalink">#</a>
-</h2>
+X</h2>
 </div>
 <div>
 <h3>
@@ -365,8 +349,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="X-Q">
-X::Q<a class="mrdocs-anchor" href="#X-Q" aria-label="Permalink">#</a>
-</h2>
+X::Q</h2>
 </div>
 <div>
 <h3>
@@ -379,8 +362,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-x0">
-X::x0<a class="mrdocs-anchor" href="#X-x0" aria-label="Permalink">#</a>
-</h2>
+X::x0</h2>
 </div>
 <div>
 <h3>
@@ -393,8 +375,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-x1">
-X::x1<a class="mrdocs-anchor" href="#X-x1" aria-label="Permalink">#</a>
-</h2>
+X::x1</h2>
 </div>
 <div>
 <h3>
@@ -407,8 +388,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-x2">
-X::x2<a class="mrdocs-anchor" href="#X-x2" aria-label="Permalink">#</a>
-</h2>
+X::x2</h2>
 </div>
 <div>
 <h3>
@@ -421,8 +401,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-x3">
-X::x3<a class="mrdocs-anchor" href="#X-x3" aria-label="Permalink">#</a>
-</h2>
+X::x3</h2>
 </div>
 <div>
 <h3>
@@ -435,8 +414,7 @@ Declared in <code>&lt;record-data.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X-x4">
-X::x4<a class="mrdocs-anchor" href="#X-x4" aria-label="Permalink">#</a>
-</h2>
+X::x4</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/record-inheritance.html
+++ b/test-files/golden-tests/symbols/record/record-inheritance.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="C0">
-C0<a class="mrdocs-anchor" href="#C0" aria-label="Permalink">#</a>
-</h2>
+C0</h2>
 </div>
 <div>
 <h3>
@@ -77,8 +75,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="C1">
-C1<a class="mrdocs-anchor" href="#C1" aria-label="Permalink">#</a>
-</h2>
+C1</h2>
 </div>
 <div>
 <h3>
@@ -94,8 +91,7 @@ Declared in <code>&lt;record-inheritance.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C2">
-C2<a class="mrdocs-anchor" href="#C2" aria-label="Permalink">#</a>
-</h2>
+C2</h2>
 </div>
 <div>
 <h3>
@@ -126,8 +122,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="C3">
-C3<a class="mrdocs-anchor" href="#C3" aria-label="Permalink">#</a>
-</h2>
+C3</h2>
 </div>
 <div>
 <h3>
@@ -158,8 +153,7 @@ Protected Base Classes</h2>
 <div>
 <div>
 <h2 id="C4">
-C4<a class="mrdocs-anchor" href="#C4" aria-label="Permalink">#</a>
-</h2>
+C4</h2>
 </div>
 <div>
 <h3>
@@ -175,8 +169,7 @@ Declared in <code>&lt;record-inheritance.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="C5">
-C5<a class="mrdocs-anchor" href="#C5" aria-label="Permalink">#</a>
-</h2>
+C5</h2>
 </div>
 <div>
 <h3>
@@ -208,8 +201,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="C6">
-C6<a class="mrdocs-anchor" href="#C6" aria-label="Permalink">#</a>
-</h2>
+C6</h2>
 </div>
 <div>
 <h3>
@@ -241,8 +233,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="C7">
-C7<a class="mrdocs-anchor" href="#C7" aria-label="Permalink">#</a>
-</h2>
+C7</h2>
 </div>
 <div>
 <h3>
@@ -275,8 +266,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="S0">
-S0<a class="mrdocs-anchor" href="#S0" aria-label="Permalink">#</a>
-</h2>
+S0</h2>
 </div>
 <div>
 <h3>
@@ -307,8 +297,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S1">
-S1<a class="mrdocs-anchor" href="#S1" aria-label="Permalink">#</a>
-</h2>
+S1</h2>
 </div>
 <div>
 <h3>
@@ -339,8 +328,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S2">
-S2<a class="mrdocs-anchor" href="#S2" aria-label="Permalink">#</a>
-</h2>
+S2</h2>
 </div>
 <div>
 <h3>
@@ -387,8 +375,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S3">
-S3<a class="mrdocs-anchor" href="#S3" aria-label="Permalink">#</a>
-</h2>
+S3</h2>
 </div>
 <div>
 <h3>
@@ -435,8 +422,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S4">
-S4<a class="mrdocs-anchor" href="#S4" aria-label="Permalink">#</a>
-</h2>
+S4</h2>
 </div>
 <div>
 <h3>
@@ -469,8 +455,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="S5">
-S5<a class="mrdocs-anchor" href="#S5" aria-label="Permalink">#</a>
-</h2>
+S5</h2>
 </div>
 <div>
 <h3>
@@ -502,8 +487,7 @@ Protected Base Classes</h2>
 <div>
 <div>
 <h2 id="S6">
-S6<a class="mrdocs-anchor" href="#S6" aria-label="Permalink">#</a>
-</h2>
+S6</h2>
 </div>
 <div>
 <h3>
@@ -535,8 +519,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="U0">
-U0<a class="mrdocs-anchor" href="#U0" aria-label="Permalink">#</a>
-</h2>
+U0</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/template-specialization-inheritance.html
+++ b/test-files/golden-tests/symbols/record/template-specialization-inheritance.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -40,8 +39,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="U1">
-U1<a class="mrdocs-anchor" href="#U1" aria-label="Permalink">#</a>
-</h2>
+U1</h2>
 </div>
 <div>
 <h3>
@@ -54,8 +52,7 @@ Declared in <code>&lt;template-specialization-inheritance.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U2">
-U2<a class="mrdocs-anchor" href="#U2" aria-label="Permalink">#</a>
-</h2>
+U2</h2>
 </div>
 <div>
 <h3>
@@ -68,8 +65,7 @@ Declared in <code>&lt;template-specialization-inheritance.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U3">
-U3<a class="mrdocs-anchor" href="#U3" aria-label="Permalink">#</a>
-</h2>
+U3</h2>
 </div>
 <div>
 <h3>
@@ -82,8 +78,7 @@ Declared in <code>&lt;template-specialization-inheritance.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="R0">
-R0<a class="mrdocs-anchor" href="#R0" aria-label="Permalink">#</a>
-</h2>
+R0</h2>
 </div>
 <div>
 <h3>
@@ -128,8 +123,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="R1">
-R1<a class="mrdocs-anchor" href="#R1" aria-label="Permalink">#</a>
-</h2>
+R1</h2>
 </div>
 <div>
 <h3>
@@ -160,8 +154,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="R2">
-R2<a class="mrdocs-anchor" href="#R2" aria-label="Permalink">#</a>
-</h2>
+R2</h2>
 </div>
 <div>
 <h3>
@@ -192,8 +185,7 @@ Base Classes</h2>
 <div>
 <div>
 <h2 id="S0-0cf">
-S0<a class="mrdocs-anchor" href="#S0-0cf" aria-label="Permalink">#</a>
-</h2>
+S0</h2>
 </div>
 <div>
 <h3>
@@ -241,8 +233,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0cf-S1">
-S0::S1<a class="mrdocs-anchor" href="#S0-0cf-S1" aria-label="Permalink">#</a>
-</h2>
+S0::S1</h2>
 </div>
 <div>
 <h3>
@@ -257,8 +248,7 @@ Declared in <code>&lt;template-specialization-inheritance.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-09">
-S0&lt;2&gt;<a class="mrdocs-anchor" href="#S0-09" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2&gt;</h2>
 </div>
 <div>
 <h3>
@@ -288,8 +278,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="S0-09-S1">
-S0&lt;2&gt;::S1<a class="mrdocs-anchor" href="#S0-09-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;2&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -320,8 +309,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-073">
-S0&lt;3&gt;<a class="mrdocs-anchor" href="#S0-073" aria-label="Permalink">#</a>
-</h2>
+S0&lt;3&gt;</h2>
 </div>
 <div>
 <h3>
@@ -353,8 +341,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="S0-0e">
-S0&lt;5&gt;<a class="mrdocs-anchor" href="#S0-0e" aria-label="Permalink">#</a>
-</h2>
+S0&lt;5&gt;</h2>
 </div>
 <div>
 <h3>
@@ -384,8 +371,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="S0-0e-S1">
-S0&lt;5&gt;::S1<a class="mrdocs-anchor" href="#S0-0e-S1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;5&gt;::S1</h2>
 </div>
 <div>
 <h3>
@@ -400,8 +386,7 @@ Declared in <code>&lt;template-specialization-inheritance.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-07e">
-S0&lt;6&gt;<a class="mrdocs-anchor" href="#S0-07e" aria-label="Permalink">#</a>
-</h2>
+S0&lt;6&gt;</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/union.html
+++ b/test-files/golden-tests/symbols/record/union.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +60,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="A-x">
-A::x<a class="mrdocs-anchor" href="#A-x" aria-label="Permalink">#</a>
-</h2>
+A::x</h2>
 </div>
 <div>
 <h3>
@@ -76,8 +73,7 @@ Declared in <code>&lt;union.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-y">
-A::y<a class="mrdocs-anchor" href="#A-y" aria-label="Permalink">#</a>
-</h2>
+A::y</h2>
 </div>
 <div>
 <h3>
@@ -90,8 +86,7 @@ Declared in <code>&lt;union.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -122,8 +117,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="B-x">
-B::x<a class="mrdocs-anchor" href="#B-x" aria-label="Permalink">#</a>
-</h2>
+B::x</h2>
 </div>
 <div>
 <h3>
@@ -136,8 +130,7 @@ Declared in <code>&lt;union.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="B-y">
-B::y<a class="mrdocs-anchor" href="#B-y" aria-label="Permalink">#</a>
-</h2>
+B::y</h2>
 </div>
 <div>
 <h3>
@@ -150,8 +143,7 @@ Declared in <code>&lt;union.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="B-z">
-B::z<a class="mrdocs-anchor" href="#B-z" aria-label="Permalink">#</a>
-</h2>
+B::z</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/record/unnamed.html
+++ b/test-files/golden-tests/symbols/record/unnamed.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -47,8 +46,7 @@ Variables</h2>
 <div>
 <div>
 <h2 id="_01record-01">
-Index<a class="mrdocs-anchor" href="#_01record-01" aria-label="Permalink">#</a>
-</h2>
+Index</h2>
 </div>
 <div>
 <h3>
@@ -77,8 +75,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="_01record-01-operator_call">
-Index::operator()<a class="mrdocs-anchor" href="#_01record-01-operator_call" aria-label="Permalink">#</a>
-</h2>
+Index::operator()</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +89,7 @@ operator()() const;</code></pre>
 <div>
 <div>
 <h2 id="_01record-0f">
-Index<a class="mrdocs-anchor" href="#_01record-0f" aria-label="Permalink">#</a>
-</h2>
+Index</h2>
 <div>
 <p>A test unnamed class.</p>
 </div>
@@ -125,8 +121,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="_01record-0f-a">
-Index::a<a class="mrdocs-anchor" href="#_01record-0f-a" aria-label="Permalink">#</a>
-</h2>
+Index::a</h2>
 <div>
 <p>A test field.</p>
 </div>
@@ -142,8 +137,7 @@ Declared in <code>&lt;unnamed.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="F">
-F<a class="mrdocs-anchor" href="#F" aria-label="Permalink">#</a>
-</h2>
+F</h2>
 </div>
 <div>
 <h3>
@@ -156,8 +150,7 @@ Declared in <code>&lt;unnamed.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="x">
-x<a class="mrdocs-anchor" href="#x" aria-label="Permalink">#</a>
-</h2>
+x</h2>
 <div>
 <p>A test variable named &#x27;x&#x27;</p>
 </div>
@@ -174,8 +167,7 @@ Declared in <code>&lt;unnamed.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="y">
-y<a class="mrdocs-anchor" href="#y" aria-label="Permalink">#</a>
-</h2>
+y</h2>
 <div>
 <p>A test variable named &#x27;y&#x27;</p>
 </div>

--- a/test-files/golden-tests/symbols/typedef/alias-template.html
+++ b/test-files/golden-tests/symbols/typedef/alias-template.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -33,8 +32,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="C">
-C<a class="mrdocs-anchor" href="#C" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 </div>
 <div>
 <h3>
@@ -48,8 +46,7 @@ using C = <a href="#A">A&lt;T&gt;</a>;</code></pre>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -65,8 +62,7 @@ struct A;</code></pre>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -84,8 +80,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="D">
-D<a class="mrdocs-anchor" href="#D" aria-label="Permalink">#</a>
-</h2>
+D</h2>
 </div>
 <div>
 <h3>
@@ -115,8 +110,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="D-E">
-D::E<a class="mrdocs-anchor" href="#D-E" aria-label="Permalink">#</a>
-</h2>
+D::E</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/typedef/decay-to-primary.html
+++ b/test-files/golden-tests/symbols/typedef/decay-to-primary.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -34,8 +33,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A0">
-A0<a class="mrdocs-anchor" href="#A0" aria-label="Permalink">#</a>
-</h2>
+A0</h2>
 </div>
 <div>
 <h3>
@@ -48,8 +46,7 @@ Declared in <code>&lt;decay-to-primary.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A1">
-A1<a class="mrdocs-anchor" href="#A1" aria-label="Permalink">#</a>
-</h2>
+A1</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +59,7 @@ Declared in <code>&lt;decay-to-primary.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-03">
-S0<a class="mrdocs-anchor" href="#S0-03" aria-label="Permalink">#</a>
-</h2>
+S0</h2>
 </div>
 <div>
 <h3>
@@ -94,8 +90,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="S0-03-M0">
-S0::M0<a class="mrdocs-anchor" href="#S0-03-M0" aria-label="Permalink">#</a>
-</h2>
+S0::M0</h2>
 </div>
 <div>
 <h3>
@@ -108,8 +103,7 @@ Declared in <code>&lt;decay-to-primary.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-03-M1">
-S0::M1<a class="mrdocs-anchor" href="#S0-03-M1" aria-label="Permalink">#</a>
-</h2>
+S0::M1</h2>
 </div>
 <div>
 <h3>
@@ -123,8 +117,7 @@ using M1 = <a href="#S0-03">S0&lt;U&gt;</a>;</code></pre>
 <div>
 <div>
 <h2 id="S0-00">
-S0&lt;void&gt;<a class="mrdocs-anchor" href="#S0-00" aria-label="Permalink">#</a>
-</h2>
+S0&lt;void&gt;</h2>
 </div>
 <div>
 <h3>
@@ -155,8 +148,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="S0-00-M0">
-S0&lt;void&gt;::M0<a class="mrdocs-anchor" href="#S0-00-M0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;void&gt;::M0</h2>
 </div>
 <div>
 <h3>
@@ -169,8 +161,7 @@ Declared in <code>&lt;decay-to-primary.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-00-M1">
-S0&lt;void&gt;::M1<a class="mrdocs-anchor" href="#S0-00-M1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;void&gt;::M1</h2>
 </div>
 <div>
 <h3>
@@ -184,8 +175,7 @@ using M1 = <a href="#S0-03">S0&lt;U&gt;</a>;</code></pre>
 <div>
 <div>
 <h2 id="S0-09">
-S0&lt;short&gt;<a class="mrdocs-anchor" href="#S0-09" aria-label="Permalink">#</a>
-</h2>
+S0&lt;short&gt;</h2>
 </div>
 <div>
 <h3>
@@ -216,8 +206,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="S0-09-M0">
-S0&lt;short&gt;::M0<a class="mrdocs-anchor" href="#S0-09-M0" aria-label="Permalink">#</a>
-</h2>
+S0&lt;short&gt;::M0</h2>
 </div>
 <div>
 <h3>
@@ -230,8 +219,7 @@ Declared in <code>&lt;decay-to-primary.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-09-M1">
-S0&lt;short&gt;::M1<a class="mrdocs-anchor" href="#S0-09-M1" aria-label="Permalink">#</a>
-</h2>
+S0&lt;short&gt;::M1</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/typedef/dependency-propagation.html
+++ b/test-files/golden-tests/symbols/typedef/dependency-propagation.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="N">
-N<a class="mrdocs-anchor" href="#N" aria-label="Permalink">#</a>
-</h2>
+N</h2>
 </div>
 <h2>
 Types</h2>
@@ -68,8 +66,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="N-B">
-N::B<a class="mrdocs-anchor" href="#N-B" aria-label="Permalink">#</a>
-</h2>
+N::B</h2>
 </div>
 <div>
 <h3>
@@ -83,8 +80,7 @@ using B = <a href="#N-A-03">A&lt;T&gt;</a>;</code></pre>
 <div>
 <div>
 <h2 id="N-C">
-N::C<a class="mrdocs-anchor" href="#N-C" aria-label="Permalink">#</a>
-</h2>
+N::C</h2>
 </div>
 <div>
 <h3>
@@ -98,8 +94,7 @@ using C = <a href="#N-B">B&lt;T&gt;</a>;</code></pre>
 <div>
 <div>
 <h2 id="N-A-03">
-N::A<a class="mrdocs-anchor" href="#N-A-03" aria-label="Permalink">#</a>
-</h2>
+N::A</h2>
 </div>
 <div>
 <h3>
@@ -115,8 +110,7 @@ struct A;</code></pre>
 <div>
 <div>
 <h2 id="N-D">
-N::D<a class="mrdocs-anchor" href="#N-D" aria-label="Permalink">#</a>
-</h2>
+N::D</h2>
 </div>
 <div>
 <h3>
@@ -131,8 +125,7 @@ Declared in <code>&lt;dependency-propagation.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="E">
-E<a class="mrdocs-anchor" href="#E" aria-label="Permalink">#</a>
-</h2>
+E</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/typedef/implicit-instantiation-member-ref.html
+++ b/test-files/golden-tests/symbols/typedef/implicit-instantiation-member-ref.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -33,8 +32,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A5">
-A5<a class="mrdocs-anchor" href="#A5" aria-label="Permalink">#</a>
-</h2>
+A5</h2>
 </div>
 <div>
 <h3>
@@ -47,8 +45,7 @@ Declared in <code>&lt;implicit-instantiation-member-ref.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A9">
-A9<a class="mrdocs-anchor" href="#A9" aria-label="Permalink">#</a>
-</h2>
+A9</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +58,7 @@ Declared in <code>&lt;implicit-instantiation-member-ref.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-03">
-S0<a class="mrdocs-anchor" href="#S0-03" aria-label="Permalink">#</a>
-</h2>
+S0</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +88,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="S0-03-S2">
-S0::S2<a class="mrdocs-anchor" href="#S0-03-S2" aria-label="Permalink">#</a>
-</h2>
+S0::S2</h2>
 </div>
 <div>
 <h3>
@@ -124,8 +119,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="S0-03-S2-M2">
-S0::S2::M2<a class="mrdocs-anchor" href="#S0-03-S2-M2" aria-label="Permalink">#</a>
-</h2>
+S0::S2::M2</h2>
 </div>
 <div>
 <h3>
@@ -138,8 +132,7 @@ Declared in <code>&lt;implicit-instantiation-member-ref.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-03-S2-M3">
-S0::S2::M3<a class="mrdocs-anchor" href="#S0-03-S2-M3" aria-label="Permalink">#</a>
-</h2>
+S0::S2::M3</h2>
 </div>
 <div>
 <h3>
@@ -153,8 +146,7 @@ using M3 = <a href="#S0-03-S2">S2&lt;U&gt;</a>;</code></pre>
 <div>
 <div>
 <h2 id="S0-00">
-S0&lt;void&gt;<a class="mrdocs-anchor" href="#S0-00" aria-label="Permalink">#</a>
-</h2>
+S0&lt;void&gt;</h2>
 </div>
 <div>
 <h3>
@@ -185,8 +177,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="S0-00-S2-0d">
-S0&lt;void&gt;::S2<a class="mrdocs-anchor" href="#S0-00-S2-0d" aria-label="Permalink">#</a>
-</h2>
+S0&lt;void&gt;::S2</h2>
 </div>
 <div>
 <h3>
@@ -202,8 +193,7 @@ struct S2;</code></pre>
 <div>
 <div>
 <h2 id="S0-00-S2-02">
-S0&lt;void&gt;::S2&lt;char&gt;<a class="mrdocs-anchor" href="#S0-00-S2-02" aria-label="Permalink">#</a>
-</h2>
+S0&lt;void&gt;::S2&lt;char&gt;</h2>
 </div>
 <div>
 <h3>
@@ -234,8 +224,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="S0-00-S2-02-M2">
-S0&lt;void&gt;::S2&lt;char&gt;::M2<a class="mrdocs-anchor" href="#S0-00-S2-02-M2" aria-label="Permalink">#</a>
-</h2>
+S0&lt;void&gt;::S2&lt;char&gt;::M2</h2>
 </div>
 <div>
 <h3>
@@ -248,8 +237,7 @@ Declared in <code>&lt;implicit-instantiation-member-ref.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S0-00-S2-02-M3">
-S0&lt;void&gt;::S2&lt;char&gt;::M3<a class="mrdocs-anchor" href="#S0-00-S2-02-M3" aria-label="Permalink">#</a>
-</h2>
+S0&lt;void&gt;::S2&lt;char&gt;::M3</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/using-directive/using-1.html
+++ b/test-files/golden-tests/symbols/using-directive/using-1.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -48,8 +47,7 @@ Using Namespace Directives</h2>
 <div>
 <div>
 <h2 id="LongName">
-LongName<a class="mrdocs-anchor" href="#LongName" aria-label="Permalink">#</a>
-</h2>
+LongName</h2>
 </div>
 <h2>
 Types</h2>
@@ -69,8 +67,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="LongName-A">
-LongName::A<a class="mrdocs-anchor" href="#LongName-A" aria-label="Permalink">#</a>
-</h2>
+LongName::A</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/using-enum/using-enum-in-ns.html
+++ b/test-files/golden-tests/symbols/using-enum/using-enum-in-ns.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Enums</h2>
@@ -65,8 +63,7 @@ Enums</h2>
 <div>
 <div>
 <h2 id="A-E">
-A::E<a class="mrdocs-anchor" href="#A-E" aria-label="Permalink">#</a>
-</h2>
+A::E</h2>
 </div>
 <div>
 <h3>
@@ -93,8 +90,7 @@ Members</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/using-enum/using-enum-in-record.html
+++ b/test-files/golden-tests/symbols/using-enum/using-enum-in-record.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -58,8 +57,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Enums</h2>
@@ -79,8 +77,7 @@ Enums</h2>
 <div>
 <div>
 <h2 id="A-E">
-A::E<a class="mrdocs-anchor" href="#A-E" aria-label="Permalink">#</a>
-</h2>
+A::E</h2>
 </div>
 <div>
 <h3>
@@ -107,8 +104,7 @@ Members</h2>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -123,8 +119,7 @@ Declared in <code>&lt;using-enum-in-record.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="g">
-g<a class="mrdocs-anchor" href="#g" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/using/using-alias-template-dependent.html
+++ b/test-files/golden-tests/symbols/using/using-alias-template-dependent.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -34,8 +33,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="_UniqAssignable">
-_UniqAssignable<a class="mrdocs-anchor" href="#_UniqAssignable" aria-label="Permalink">#</a>
-</h2>
+_UniqAssignable</h2>
 </div>
 <div>
 <h3>
@@ -51,8 +49,7 @@ using _UniqAssignable = int;</code></pre>
 <div>
 <div>
 <h2 id="_UniqCompatible">
-_UniqCompatible<a class="mrdocs-anchor" href="#_UniqCompatible" aria-label="Permalink">#</a>
-</h2>
+_UniqCompatible</h2>
 </div>
 <div>
 <h3>
@@ -69,8 +66,7 @@ using _UniqCompatible = _Res;</code></pre>
 <div>
 <div>
 <h2 id="enable_if-03">
-enable_if<a class="mrdocs-anchor" href="#enable_if-03" aria-label="Permalink">#</a>
-</h2>
+enable_if</h2>
 </div>
 <div>
 <h3>
@@ -102,8 +98,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="enable_if-03-type">
-enable_if::type<a class="mrdocs-anchor" href="#enable_if-03-type" aria-label="Permalink">#</a>
-</h2>
+enable_if::type</h2>
 </div>
 <div>
 <h3>
@@ -116,8 +111,7 @@ Declared in <code>&lt;using-alias-template-dependent.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="enable_if-0e">
-enable_if&lt;false, T&gt;<a class="mrdocs-anchor" href="#enable_if-0e" aria-label="Permalink">#</a>
-</h2>
+enable_if&lt;false, T&gt;</h2>
 </div>
 <div>
 <h3>
@@ -133,8 +127,7 @@ struct <a href="#enable_if-03">enable_if</a>&lt;false, T&gt;;</code></pre>
 <div>
 <div>
 <h2 id="is_match">
-is_match<a class="mrdocs-anchor" href="#is_match" aria-label="Permalink">#</a>
-</h2>
+is_match</h2>
 </div>
 <div>
 <h3>
@@ -164,8 +157,7 @@ Enums</h2>
 <div>
 <div>
 <h2 id="is_match-_04enum">
-is_match::Index<a class="mrdocs-anchor" href="#is_match-_04enum" aria-label="Permalink">#</a>
-</h2>
+is_match::Index</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/using/using-function-after.html
+++ b/test-files/golden-tests/symbols/using/using-function-after.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Using Declarations</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Functions</h2>
@@ -65,8 +63,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A-f-08">
-A::f<a class="mrdocs-anchor" href="#A-f-08" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p><code>f</code> overloads</p>
 </div>
@@ -91,8 +88,7 @@ Declared in <code>&lt;using-function-after.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-f-00">
-A::f<a class="mrdocs-anchor" href="#A-f-00" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>A non-shadowing declaration</p>
 </div>
@@ -115,8 +111,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="A-f-01">
-A::f<a class="mrdocs-anchor" href="#A-f-01" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>A shadow declaration</p>
 </div>
@@ -133,8 +128,7 @@ f(int);</code></pre>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>f overloads are also available in the global namespace</p>
 </div>

--- a/test-files/golden-tests/symbols/using/using-function-and-type.html
+++ b/test-files/golden-tests/symbols/using/using-function-and-type.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Using Declarations</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Types</h2>
@@ -79,8 +77,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A-f-05">
-A::f<a class="mrdocs-anchor" href="#A-f-05" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>A record</p>
 </div>
@@ -98,8 +95,7 @@ Declared in <code>&lt;using-function-and-type.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-f-01">
-A::f<a class="mrdocs-anchor" href="#A-f-01" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>A function</p>
 </div>
@@ -116,8 +112,7 @@ f(int);</code></pre>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>A using declaration that shadows a function and the record.</p>
 </div>

--- a/test-files/golden-tests/symbols/using/using-function-excluded.html
+++ b/test-files/golden-tests/symbols/using/using-function-excluded.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Using Declarations</h2>
@@ -30,8 +29,7 @@ Using Declarations</h2>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Using excluded function f</p>
 </div>

--- a/test-files/golden-tests/symbols/using/using-function-local-overloads.html
+++ b/test-files/golden-tests/symbols/using/using-function-local-overloads.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -58,8 +57,7 @@ Using Declarations</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Functions</h2>
@@ -79,8 +77,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A-f-08">
-A::f<a class="mrdocs-anchor" href="#A-f-08" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p><code>f</code> overloads</p>
 </div>
@@ -112,8 +109,7 @@ Declared in <code>&lt;using-function-local-overloads.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-f-039">
-A::f<a class="mrdocs-anchor" href="#A-f-039" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>Second overload</p>
 </div>
@@ -130,8 +126,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-f-01">
-A::f<a class="mrdocs-anchor" href="#A-f-01" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>First overload</p>
 </div>
@@ -148,8 +143,7 @@ f(int);</code></pre>
 <div>
 <div>
 <h2 id="A-f-037">
-A::f<a class="mrdocs-anchor" href="#A-f-037" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>Third overload</p>
 </div>
@@ -168,8 +162,7 @@ f(
 <div>
 <div>
 <h2 id="f-0f">
-f<a class="mrdocs-anchor" href="#f-0f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Local overload</p>
 </div>
@@ -186,8 +179,7 @@ f(double);</code></pre>
 <div>
 <div>
 <h2 id="f-02">
-f<a class="mrdocs-anchor" href="#f-02" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/using/using-function-overloads.html
+++ b/test-files/golden-tests/symbols/using/using-function-overloads.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Using Declarations</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Functions</h2>
@@ -65,8 +63,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A-f-08">
-A::f<a class="mrdocs-anchor" href="#A-f-08" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p><code>f</code> overloads</p>
 </div>
@@ -98,8 +95,7 @@ Declared in <code>&lt;using-function-overloads.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="A-f-039">
-A::f<a class="mrdocs-anchor" href="#A-f-039" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>Second overload</p>
 </div>
@@ -116,8 +112,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-f-01">
-A::f<a class="mrdocs-anchor" href="#A-f-01" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>First overload</p>
 </div>
@@ -134,8 +129,7 @@ f(int);</code></pre>
 <div>
 <div>
 <h2 id="A-f-037">
-A::f<a class="mrdocs-anchor" href="#A-f-037" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>Third overload</p>
 </div>
@@ -154,8 +148,7 @@ f(
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>Using the overloads from namespace A</p>
 </div>

--- a/test-files/golden-tests/symbols/using/using-function.html
+++ b/test-files/golden-tests/symbols/using/using-function.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Using Declarations</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Functions</h2>
@@ -65,8 +63,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A-f">
-A::f<a class="mrdocs-anchor" href="#A-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>Function being used</p>
 </div>
@@ -83,8 +80,7 @@ f(int);</code></pre>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 <div>
 <p>f is also available in the global namespace</p>
 </div>

--- a/test-files/golden-tests/symbols/using/using-member-conversion.html
+++ b/test-files/golden-tests/symbols/using/using-member-conversion.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -32,8 +31,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="fun_ptr">
-fun_ptr<a class="mrdocs-anchor" href="#fun_ptr" aria-label="Permalink">#</a>
-</h2>
+fun_ptr</h2>
 <div>
 <p>A pointer to function typedef</p>
 </div>
@@ -49,8 +47,7 @@ Declared in <code>&lt;using-member-conversion.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="X">
-X<a class="mrdocs-anchor" href="#X" aria-label="Permalink">#</a>
-</h2>
+X</h2>
 <div>
 <p>This struct will be inherited as public</p>
 </div>
@@ -98,8 +95,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="X-2conversion">
-X::operator fun_ptr<a class="mrdocs-anchor" href="#X-2conversion" aria-label="Permalink">#</a>
-</h2>
+X::operator fun_ptr</h2>
 <div>
 <p>Conversion operator to function pointer.</p>
 </div>
@@ -120,8 +116,7 @@ A pointer to function typedef
 <div>
 <div>
 <h2 id="Y">
-Y<a class="mrdocs-anchor" href="#Y" aria-label="Permalink">#</a>
-</h2>
+Y</h2>
 <div>
 <p>This struct inherits from X</p>
 </div>
@@ -183,8 +178,7 @@ Using Declarations</h2>
 <div>
 <div>
 <h2 id="Y-2conversion">
-Y::operator void(*)()<a class="mrdocs-anchor" href="#Y-2conversion" aria-label="Permalink">#</a>
-</h2>
+Y::operator void(*)()</h2>
 <div>
 <p>Bring X::operator fun_ptr into Y.</p>
 </div>

--- a/test-files/golden-tests/symbols/using/using-member-function.html
+++ b/test-files/golden-tests/symbols/using/using-member-function.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -37,8 +36,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 <div>
 <p>This struct will be inherited as public</p>
 </div>
@@ -86,8 +84,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="A-f">
-A::f<a class="mrdocs-anchor" href="#A-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 <div>
 <p>Public member function f taking a Tag&lt;0&gt;.</p>
 </div>
@@ -109,8 +106,7 @@ Description</h3>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 <div>
 <p>This struct will be inherited as public</p>
 </div>
@@ -158,8 +154,7 @@ Derived Classes</h2>
 <div>
 <div>
 <h2 id="B-f">
-B::f<a class="mrdocs-anchor" href="#B-f" aria-label="Permalink">#</a>
-</h2>
+B::f</h2>
 <div>
 <p>Protected member function f taking a Tag&lt;1&gt;.</p>
 </div>
@@ -176,8 +171,7 @@ f(<a href="#Tag">Tag&lt;1&gt;</a>);</code></pre>
 <div>
 <div>
 <h2 id="C">
-C<a class="mrdocs-anchor" href="#C" aria-label="Permalink">#</a>
-</h2>
+C</h2>
 <div>
 <p>This struct will be inherited as protected</p>
 </div>
@@ -209,8 +203,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="C-f">
-C::f<a class="mrdocs-anchor" href="#C-f" aria-label="Permalink">#</a>
-</h2>
+C::f</h2>
 <div>
 <p>Public member function f taking a Tag&lt;2&gt;.</p>
 </div>
@@ -227,8 +220,7 @@ f(<a href="#Tag">Tag&lt;2&gt;</a>);</code></pre>
 <div>
 <div>
 <h2 id="D">
-D<a class="mrdocs-anchor" href="#D" aria-label="Permalink">#</a>
-</h2>
+D</h2>
 <div>
 <p>This struct will be inherited as protected</p>
 </div>
@@ -260,8 +252,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="D-f">
-D::f<a class="mrdocs-anchor" href="#D-f" aria-label="Permalink">#</a>
-</h2>
+D::f</h2>
 <div>
 <p>Protected member function f taking a Tag&lt;3&gt;.</p>
 </div>
@@ -278,8 +269,7 @@ f(<a href="#Tag">Tag&lt;3&gt;</a>);</code></pre>
 <div>
 <div>
 <h2 id="E">
-E<a class="mrdocs-anchor" href="#E" aria-label="Permalink">#</a>
-</h2>
+E</h2>
 <div>
 <p>This struct will be inherited as private</p>
 </div>
@@ -311,8 +301,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="E-f">
-E::f<a class="mrdocs-anchor" href="#E-f" aria-label="Permalink">#</a>
-</h2>
+E::f</h2>
 <div>
 <p>Public member function f taking a Tag&lt;4&gt;.</p>
 </div>
@@ -329,8 +318,7 @@ f(<a href="#Tag">Tag&lt;4&gt;</a>);</code></pre>
 <div>
 <div>
 <h2 id="F">
-F<a class="mrdocs-anchor" href="#F" aria-label="Permalink">#</a>
-</h2>
+F</h2>
 <div>
 <p>This struct will be inherited as private</p>
 </div>
@@ -362,8 +350,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="F-f">
-F::f<a class="mrdocs-anchor" href="#F-f" aria-label="Permalink">#</a>
-</h2>
+F::f</h2>
 <div>
 <p>Protected member function f taking a Tag&lt;5&gt;.</p>
 </div>
@@ -380,8 +367,7 @@ f(<a href="#Tag">Tag&lt;5&gt;</a>);</code></pre>
 <div>
 <div>
 <h2 id="Tag">
-Tag<a class="mrdocs-anchor" href="#Tag" aria-label="Permalink">#</a>
-</h2>
+Tag</h2>
 <div>
 <p>A tag template to create distinct f functions.</p>
 </div>
@@ -400,8 +386,7 @@ struct Tag;</code></pre>
 <div>
 <div>
 <h2 id="U">
-U<a class="mrdocs-anchor" href="#U" aria-label="Permalink">#</a>
-</h2>
+U</h2>
 <div>
 <p>This struct inherits from A, B, C, D, E, and F in various ways,</p>
 </div>
@@ -513,8 +498,7 @@ Protected Member Functions</h2>
 <div>
 <div>
 <h2 id="U-U-0a">
-U::U<a class="mrdocs-anchor" href="#U-U-0a" aria-label="Permalink">#</a>
-</h2>
+U::U</h2>
 <div>
 <p>Bring all the A::A constructors into U.</p>
 </div>
@@ -530,8 +514,7 @@ Declared in <code>&lt;using-member-function.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U-U-01b">
-U::U<a class="mrdocs-anchor" href="#U-U-01b" aria-label="Permalink">#</a>
-</h2>
+U::U</h2>
 <div>
 <p>Bring all the B::B constructors into U.</p>
 </div>
@@ -547,8 +530,7 @@ Declared in <code>&lt;using-member-function.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U-U-01d">
-U::U<a class="mrdocs-anchor" href="#U-U-01d" aria-label="Permalink">#</a>
-</h2>
+U::U</h2>
 <div>
 <p>Bring all the C::C constructors into U.</p>
 </div>
@@ -564,8 +546,7 @@ Declared in <code>&lt;using-member-function.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U-U-0c">
-U::U<a class="mrdocs-anchor" href="#U-U-0c" aria-label="Permalink">#</a>
-</h2>
+U::U</h2>
 <div>
 <p>Bring all the D::D constructors into U.</p>
 </div>
@@ -581,8 +562,7 @@ Declared in <code>&lt;using-member-function.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U-U-04">
-U::U<a class="mrdocs-anchor" href="#U-U-04" aria-label="Permalink">#</a>
-</h2>
+U::U</h2>
 <div>
 <p>Bring all the E::E constructors into U.</p>
 </div>
@@ -598,8 +578,7 @@ Declared in <code>&lt;using-member-function.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U-U-06">
-U::U<a class="mrdocs-anchor" href="#U-U-06" aria-label="Permalink">#</a>
-</h2>
+U::U</h2>
 <div>
 <p>Bring all the F::F constructors into U.</p>
 </div>
@@ -615,8 +594,7 @@ Declared in <code>&lt;using-member-function.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="U-f-00c">
-U::f<a class="mrdocs-anchor" href="#U-f-00c" aria-label="Permalink">#</a>
-</h2>
+U::f</h2>
 <div>
 <p>Bring all the A::f functions into U.</p>
 </div>
@@ -651,8 +629,7 @@ Introduced Symbols</h3>
 <div>
 <div>
 <h2 id="U-f-0be">
-U::f<a class="mrdocs-anchor" href="#U-f-0be" aria-label="Permalink">#</a>
-</h2>
+U::f</h2>
 <div>
 <p>Bring all the B::f functions into U.</p>
 </div>
@@ -687,8 +664,7 @@ Introduced Symbols</h3>
 <div>
 <div>
 <h2 id="U-f-0f">
-U::f<a class="mrdocs-anchor" href="#U-f-0f" aria-label="Permalink">#</a>
-</h2>
+U::f</h2>
 <div>
 <p>Bring all the C::f functions into U.</p>
 </div>
@@ -723,8 +699,7 @@ Introduced Symbols</h3>
 <div>
 <div>
 <h2 id="U-f-009">
-U::f<a class="mrdocs-anchor" href="#U-f-009" aria-label="Permalink">#</a>
-</h2>
+U::f</h2>
 <div>
 <p>Bring all the D::f functions into U.</p>
 </div>
@@ -759,8 +734,7 @@ Introduced Symbols</h3>
 <div>
 <div>
 <h2 id="U-f-0bd">
-U::f<a class="mrdocs-anchor" href="#U-f-0bd" aria-label="Permalink">#</a>
-</h2>
+U::f</h2>
 <div>
 <p>Bring all the E::f functions into U.</p>
 </div>
@@ -795,8 +769,7 @@ Introduced Symbols</h3>
 <div>
 <div>
 <h2 id="U-f-02">
-U::f<a class="mrdocs-anchor" href="#U-f-02" aria-label="Permalink">#</a>
-</h2>
+U::f</h2>
 <div>
 <p>Bring all the F::f functions into U.</p>
 </div>
@@ -831,8 +804,7 @@ Introduced Symbols</h3>
 <div>
 <div>
 <h2 id="U-f-07">
-U::f<a class="mrdocs-anchor" href="#U-f-07" aria-label="Permalink">#</a>
-</h2>
+U::f</h2>
 <div>
 <p><code>f</code> overloads</p>
 </div>
@@ -862,8 +834,7 @@ Declared in <code>&lt;using-member-function.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="B-f">
-B::f<a class="mrdocs-anchor" href="#B-f" aria-label="Permalink">#</a>
-</h2>
+B::f</h2>
 <div>
 <p>Protected member function f taking a Tag&lt;1&gt;.</p>
 </div>
@@ -880,8 +851,7 @@ f(<a href="#Tag">Tag&lt;1&gt;</a>);</code></pre>
 <div>
 <div>
 <h2 id="C-f">
-C::f<a class="mrdocs-anchor" href="#C-f" aria-label="Permalink">#</a>
-</h2>
+C::f</h2>
 <div>
 <p>Public member function f taking a Tag&lt;2&gt;.</p>
 </div>
@@ -898,8 +868,7 @@ f(<a href="#Tag">Tag&lt;2&gt;</a>);</code></pre>
 <div>
 <div>
 <h2 id="D-f">
-D::f<a class="mrdocs-anchor" href="#D-f" aria-label="Permalink">#</a>
-</h2>
+D::f</h2>
 <div>
 <p>Protected member function f taking a Tag&lt;3&gt;.</p>
 </div>

--- a/test-files/golden-tests/symbols/using/using-multi.html
+++ b/test-files/golden-tests/symbols/using/using-multi.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -45,8 +44,7 @@ Using Declarations</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Functions</h2>
@@ -67,8 +65,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A-f">
-A::f<a class="mrdocs-anchor" href="#A-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -82,8 +79,7 @@ f(int);</code></pre>
 <div>
 <div>
 <h2 id="A-g">
-A::g<a class="mrdocs-anchor" href="#A-g" aria-label="Permalink">#</a>
-</h2>
+A::g</h2>
 </div>
 <div>
 <h3>
@@ -97,8 +93,7 @@ g(int);</code></pre>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -128,8 +123,7 @@ Introduced Symbols</h3>
 <div>
 <div>
 <h2 id="g">
-g<a class="mrdocs-anchor" href="#g" aria-label="Permalink">#</a>
-</h2>
+g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/using/using-struct-template.html
+++ b/test-files/golden-tests/symbols/using/using-struct-template.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -45,8 +44,7 @@ Using Declarations</h2>
 <div>
 <div>
 <h2 id="LongName">
-LongName<a class="mrdocs-anchor" href="#LongName" aria-label="Permalink">#</a>
-</h2>
+LongName</h2>
 </div>
 <h2>
 Types</h2>
@@ -67,8 +65,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="LongName-S1">
-LongName::S1<a class="mrdocs-anchor" href="#LongName-S1" aria-label="Permalink">#</a>
-</h2>
+LongName::S1</h2>
 </div>
 <div>
 <h3>
@@ -83,8 +80,7 @@ Declared in <code>&lt;using-struct-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="LongName-S2">
-LongName::S2<a class="mrdocs-anchor" href="#LongName-S2" aria-label="Permalink">#</a>
-</h2>
+LongName::S2</h2>
 </div>
 <div>
 <h3>
@@ -99,8 +95,7 @@ Declared in <code>&lt;using-struct-template.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S1">
-S1<a class="mrdocs-anchor" href="#S1" aria-label="Permalink">#</a>
-</h2>
+S1</h2>
 </div>
 <div>
 <h3>
@@ -130,8 +125,7 @@ Introduced Symbols</h3>
 <div>
 <div>
 <h2 id="S2">
-S2<a class="mrdocs-anchor" href="#S2" aria-label="Permalink">#</a>
-</h2>
+S2</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/using/using-struct.html
+++ b/test-files/golden-tests/symbols/using/using-struct.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -45,8 +44,7 @@ Using Declarations</h2>
 <div>
 <div>
 <h2 id="LongName">
-LongName<a class="mrdocs-anchor" href="#LongName" aria-label="Permalink">#</a>
-</h2>
+LongName</h2>
 </div>
 <h2>
 Types</h2>
@@ -67,8 +65,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="LongName-S1">
-LongName::S1<a class="mrdocs-anchor" href="#LongName-S1" aria-label="Permalink">#</a>
-</h2>
+LongName::S1</h2>
 </div>
 <div>
 <h3>
@@ -83,8 +80,7 @@ Declared in <code>&lt;using-struct.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="LongName-S2">
-LongName::S2<a class="mrdocs-anchor" href="#LongName-S2" aria-label="Permalink">#</a>
-</h2>
+LongName::S2</h2>
 </div>
 <div>
 <h3>
@@ -99,8 +95,7 @@ Declared in <code>&lt;using-struct.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="S1">
-S1<a class="mrdocs-anchor" href="#S1" aria-label="Permalink">#</a>
-</h2>
+S1</h2>
 </div>
 <div>
 <h3>
@@ -130,8 +125,7 @@ Introduced Symbols</h3>
 <div>
 <div>
 <h2 id="S2">
-S2<a class="mrdocs-anchor" href="#S2" aria-label="Permalink">#</a>
-</h2>
+S2</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/using/using-template-function.html
+++ b/test-files/golden-tests/symbols/using/using-template-function.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Namespaces</h2>
@@ -44,8 +43,7 @@ Using Declarations</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <h2>
 Functions</h2>
@@ -65,8 +63,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A-f">
-A::f<a class="mrdocs-anchor" href="#A-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -80,8 +77,7 @@ f(int);</code></pre>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/using/using-typename.html
+++ b/test-files/golden-tests/symbols/using/using-typename.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="Base">
-Base<a class="mrdocs-anchor" href="#Base" aria-label="Permalink">#</a>
-</h2>
+Base</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +60,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="Base-V">
-Base::V<a class="mrdocs-anchor" href="#Base-V" aria-label="Permalink">#</a>
-</h2>
+Base::V</h2>
 </div>
 <div>
 <h3>
@@ -76,8 +73,7 @@ Declared in <code>&lt;using-typename.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="Derived">
-Derived<a class="mrdocs-anchor" href="#Derived" aria-label="Permalink">#</a>
-</h2>
+Derived</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/variable/no_unique_address.html
+++ b/test-files/golden-tests/symbols/variable/no_unique_address.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="Empty">
-Empty<a class="mrdocs-anchor" href="#Empty" aria-label="Permalink">#</a>
-</h2>
+Empty</h2>
 </div>
 <div>
 <h3>
@@ -47,8 +45,7 @@ Declared in <code>&lt;no_unique_address.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -78,8 +75,7 @@ Data Members</h2>
 <div>
 <div>
 <h2 id="T-e">
-T::e<a class="mrdocs-anchor" href="#T-e" aria-label="Permalink">#</a>
-</h2>
+T::e</h2>
 </div>
 <div>
 <h3>
@@ -93,8 +89,7 @@ Declared in <code>&lt;no_unique_address.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="T-i">
-T::i<a class="mrdocs-anchor" href="#T-i" aria-label="Permalink">#</a>
-</h2>
+T::i</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/variable/ns-variables.html
+++ b/test-files/golden-tests/symbols/variable/ns-variables.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -52,8 +51,7 @@ Variables</h2>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -68,8 +66,7 @@ Declared in <code>&lt;ns-variables.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="i">
-i<a class="mrdocs-anchor" href="#i" aria-label="Permalink">#</a>
-</h2>
+i</h2>
 </div>
 <div>
 <h3>
@@ -82,8 +79,7 @@ Declared in <code>&lt;ns-variables.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="j">
-j<a class="mrdocs-anchor" href="#j" aria-label="Permalink">#</a>
-</h2>
+j</h2>
 </div>
 <div>
 <h3>
@@ -96,8 +92,7 @@ Declared in <code>&lt;ns-variables.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="k">
-k<a class="mrdocs-anchor" href="#k" aria-label="Permalink">#</a>
-</h2>
+k</h2>
 </div>
 <div>
 <h3>
@@ -111,8 +106,7 @@ int k = 1;</code></pre>
 <div>
 <div>
 <h2 id="l">
-l<a class="mrdocs-anchor" href="#l" aria-label="Permalink">#</a>
-</h2>
+l</h2>
 </div>
 <div>
 <h3>
@@ -126,8 +120,7 @@ int l = 1;</code></pre>
 <div>
 <div>
 <h2 id="pi">
-pi<a class="mrdocs-anchor" href="#pi" aria-label="Permalink">#</a>
-</h2>
+pi</h2>
 </div>
 <div>
 <h3>
@@ -140,8 +133,7 @@ Declared in <code>&lt;ns-variables.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="t">
-t<a class="mrdocs-anchor" href="#t" aria-label="Permalink">#</a>
-</h2>
+t</h2>
 </div>
 <div>
 <h3>
@@ -155,8 +147,7 @@ Declared in <code>&lt;ns-variables.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="x0">
-x0<a class="mrdocs-anchor" href="#x0" aria-label="Permalink">#</a>
-</h2>
+x0</h2>
 </div>
 <div>
 <h3>
@@ -170,8 +161,7 @@ int x0 = 0;</code></pre>
 <div>
 <div>
 <h2 id="x1">
-x1<a class="mrdocs-anchor" href="#x1" aria-label="Permalink">#</a>
-</h2>
+x1</h2>
 </div>
 <div>
 <h3>
@@ -186,8 +176,7 @@ int x1 = 0;</code></pre>
 <div>
 <div>
 <h2 id="x2">
-x2<a class="mrdocs-anchor" href="#x2" aria-label="Permalink">#</a>
-</h2>
+x2</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/variable/static-data-def-constexpr.html
+++ b/test-files/golden-tests/symbols/variable/static-data-def-constexpr.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="S">
-S<a class="mrdocs-anchor" href="#S" aria-label="Permalink">#</a>
-</h2>
+S</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Static Data Members</h2>
 <div>
 <div>
 <h2 id="S-s">
-S::s<a class="mrdocs-anchor" href="#S-s" aria-label="Permalink">#</a>
-</h2>
+S::s</h2>
 </div>
 <div>
 <h3>
@@ -76,8 +73,7 @@ Declared in <code>&lt;static-data-def-constexpr.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="T">
-T<a class="mrdocs-anchor" href="#T" aria-label="Permalink">#</a>
-</h2>
+T</h2>
 </div>
 <div>
 <h3>
@@ -106,8 +102,7 @@ Static Data Members</h2>
 <div>
 <div>
 <h2 id="T-t">
-T::t<a class="mrdocs-anchor" href="#T-t" aria-label="Permalink">#</a>
-</h2>
+T::t</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/variable/static-data-def.html
+++ b/test-files/golden-tests/symbols/variable/static-data-def.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -45,8 +44,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -83,8 +81,7 @@ Static Data Members</h2>
 <div>
 <div>
 <h2 id="A-v0">
-A::v0<a class="mrdocs-anchor" href="#A-v0" aria-label="Permalink">#</a>
-</h2>
+A::v0</h2>
 </div>
 <div>
 <h3>
@@ -98,8 +95,7 @@ int v0 = 0;</code></pre>
 <div>
 <div>
 <h2 id="A-v1">
-A::v1<a class="mrdocs-anchor" href="#A-v1" aria-label="Permalink">#</a>
-</h2>
+A::v1</h2>
 </div>
 <div>
 <h3>
@@ -113,8 +109,7 @@ int v1 = 1;</code></pre>
 <div>
 <div>
 <h2 id="A-v2">
-A::v2<a class="mrdocs-anchor" href="#A-v2" aria-label="Permalink">#</a>
-</h2>
+A::v2</h2>
 </div>
 <div>
 <h3>
@@ -128,8 +123,7 @@ int v2 = 2;</code></pre>
 <div>
 <div>
 <h2 id="A-v3">
-A::v3<a class="mrdocs-anchor" href="#A-v3" aria-label="Permalink">#</a>
-</h2>
+A::v3</h2>
 </div>
 <div>
 <h3>
@@ -143,8 +137,7 @@ int const v3 = 3;</code></pre>
 <div>
 <div>
 <h2 id="A-v4">
-A::v4<a class="mrdocs-anchor" href="#A-v4" aria-label="Permalink">#</a>
-</h2>
+A::v4</h2>
 </div>
 <div>
 <h3>
@@ -158,8 +151,7 @@ int const v4 = 4;</code></pre>
 <div>
 <div>
 <h2 id="A-v5">
-A::v5<a class="mrdocs-anchor" href="#A-v5" aria-label="Permalink">#</a>
-</h2>
+A::v5</h2>
 </div>
 <div>
 <h3>
@@ -173,8 +165,7 @@ int v5 = 5;</code></pre>
 <div>
 <div>
 <h2 id="A-v6">
-A::v6<a class="mrdocs-anchor" href="#A-v6" aria-label="Permalink">#</a>
-</h2>
+A::v6</h2>
 </div>
 <div>
 <h3>
@@ -188,8 +179,7 @@ int const v6 = 6;</code></pre>
 <div>
 <div>
 <h2 id="A-v7">
-A::v7<a class="mrdocs-anchor" href="#A-v7" aria-label="Permalink">#</a>
-</h2>
+A::v7</h2>
 </div>
 <div>
 <h3>
@@ -203,8 +193,7 @@ int v7 = 7;</code></pre>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -234,8 +223,7 @@ Static Data Members</h2>
 <div>
 <div>
 <h2 id="B-x0">
-B::x0<a class="mrdocs-anchor" href="#B-x0" aria-label="Permalink">#</a>
-</h2>
+B::x0</h2>
 </div>
 <div>
 <h3>
@@ -250,8 +238,7 @@ int const x0 = 0;</code></pre>
 <div>
 <div>
 <h2 id="B-x1">
-B::x1<a class="mrdocs-anchor" href="#B-x1" aria-label="Permalink">#</a>
-</h2>
+B::x1</h2>
 </div>
 <div>
 <h3>
@@ -266,8 +253,7 @@ int x1 = 0;</code></pre>
 <div>
 <div>
 <h2 id="f">
-f<a class="mrdocs-anchor" href="#f" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/variable/static-data-template.html
+++ b/test-files/golden-tests/symbols/variable/static-data-template.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -63,8 +61,7 @@ Static Data Members</h2>
 <div>
 <div>
 <h2 id="A-x-05">
-A::x<a class="mrdocs-anchor" href="#A-x-05" aria-label="Permalink">#</a>
-</h2>
+A::x</h2>
 </div>
 <div>
 <h3>
@@ -81,8 +78,7 @@ T x = 0;</code></pre>
 <div>
 <div>
 <h2 id="A-x-07">
-A::x&lt;T, long&gt;<a class="mrdocs-anchor" href="#A-x-07" aria-label="Permalink">#</a>
-</h2>
+A::x&lt;T, long&gt;</h2>
 </div>
 <div>
 <h3>
@@ -97,8 +93,7 @@ bool x&lt;T, long&gt; = 2;</code></pre>
 <div>
 <div>
 <h2 id="A-x-0a">
-A::x&lt;U*, T&gt;<a class="mrdocs-anchor" href="#A-x-0a" aria-label="Permalink">#</a>
-</h2>
+A::x&lt;U*, T&gt;</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/variable/var-inline-constexpr.html
+++ b/test-files/golden-tests/symbols/variable/var-inline-constexpr.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Variables</h2>
@@ -39,8 +38,7 @@ Variables</h2>
 <div>
 <div>
 <h2 id="var">
-var<a class="mrdocs-anchor" href="#var" aria-label="Permalink">#</a>
-</h2>
+var</h2>
 </div>
 <div>
 <h3>
@@ -53,8 +51,7 @@ Declared in <code>&lt;var-inline-constexpr.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="var_const">
-var_const<a class="mrdocs-anchor" href="#var_const" aria-label="Permalink">#</a>
-</h2>
+var_const</h2>
 </div>
 <div>
 <h3>
@@ -67,8 +64,7 @@ Declared in <code>&lt;var-inline-constexpr.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="var_const_t">
-var_const_t<a class="mrdocs-anchor" href="#var_const_t" aria-label="Permalink">#</a>
-</h2>
+var_const_t</h2>
 </div>
 <div>
 <h3>
@@ -82,8 +78,7 @@ T const var_const_t;</code></pre>
 <div>
 <div>
 <h2 id="var_constexpr">
-var_constexpr<a class="mrdocs-anchor" href="#var_constexpr" aria-label="Permalink">#</a>
-</h2>
+var_constexpr</h2>
 </div>
 <div>
 <h3>
@@ -96,8 +91,7 @@ Declared in <code>&lt;var-inline-constexpr.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="var_constexpr_t">
-var_constexpr_t<a class="mrdocs-anchor" href="#var_constexpr_t" aria-label="Permalink">#</a>
-</h2>
+var_constexpr_t</h2>
 </div>
 <div>
 <h3>
@@ -111,8 +105,7 @@ constexpr T var_constexpr_t;</code></pre>
 <div>
 <div>
 <h2 id="var_inline_const">
-var_inline_const<a class="mrdocs-anchor" href="#var_inline_const" aria-label="Permalink">#</a>
-</h2>
+var_inline_const</h2>
 </div>
 <div>
 <h3>
@@ -125,8 +118,7 @@ Declared in <code>&lt;var-inline-constexpr.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="var_inline_const_t">
-var_inline_const_t<a class="mrdocs-anchor" href="#var_inline_const_t" aria-label="Permalink">#</a>
-</h2>
+var_inline_const_t</h2>
 </div>
 <div>
 <h3>
@@ -140,8 +132,7 @@ inline T const var_inline_const_t;</code></pre>
 <div>
 <div>
 <h2 id="var_inline_constexpr">
-var_inline_constexpr<a class="mrdocs-anchor" href="#var_inline_constexpr" aria-label="Permalink">#</a>
-</h2>
+var_inline_constexpr</h2>
 </div>
 <div>
 <h3>
@@ -154,8 +145,7 @@ Declared in <code>&lt;var-inline-constexpr.cpp&gt;</code></div>
 <div>
 <div>
 <h2 id="var_inline_constexpr_t">
-var_inline_constexpr_t<a class="mrdocs-anchor" href="#var_inline_constexpr_t" aria-label="Permalink">#</a>
-</h2>
+var_inline_constexpr_t</h2>
 </div>
 <div>
 <h3>
@@ -169,8 +159,7 @@ inline constexpr T var_inline_constexpr_t;</code></pre>
 <div>
 <div>
 <h2 id="var_t">
-var_t<a class="mrdocs-anchor" href="#var_t" aria-label="Permalink">#</a>
-</h2>
+var_t</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/symbols/variable/var-template.html
+++ b/test-files/golden-tests/symbols/variable/var-template.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -46,8 +45,7 @@ Variables</h2>
 <div>
 <div>
 <h2 id="B">
-B<a class="mrdocs-anchor" href="#B" aria-label="Permalink">#</a>
-</h2>
+B</h2>
 </div>
 <div>
 <h3>
@@ -78,8 +76,7 @@ Static Data Members</h2>
 <div>
 <div>
 <h2 id="B-C-09">
-B::C<a class="mrdocs-anchor" href="#B-C-09" aria-label="Permalink">#</a>
-</h2>
+B::C</h2>
 </div>
 <div>
 <h3>
@@ -94,8 +91,7 @@ unsigned int C = 0;</code></pre>
 <div>
 <div>
 <h2 id="B-C-05">
-B::C&lt;int&gt;<a class="mrdocs-anchor" href="#B-C-05" aria-label="Permalink">#</a>
-</h2>
+B::C&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -110,8 +106,7 @@ unsigned int C&lt;int&gt; = -1;</code></pre>
 <div>
 <div>
 <h2 id="B-C-0c">
-B::C&lt;T*&gt;<a class="mrdocs-anchor" href="#B-C-0c" aria-label="Permalink">#</a>
-</h2>
+B::C&lt;T*&gt;</h2>
 </div>
 <div>
 <h3>
@@ -126,8 +121,7 @@ unsigned int C&lt;T*&gt; = sizeof(T);</code></pre>
 <div>
 <div>
 <h2 id="A-0c">
-A<a class="mrdocs-anchor" href="#A-0c" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -141,8 +135,7 @@ unsigned int A = sizeof(T);</code></pre>
 <div>
 <div>
 <h2 id="A-08">
-A&lt;void&gt;<a class="mrdocs-anchor" href="#A-08" aria-label="Permalink">#</a>
-</h2>
+A&lt;void&gt;</h2>
 </div>
 <div>
 <h3>
@@ -156,8 +149,7 @@ unsigned int A&lt;void&gt; = 0;</code></pre>
 <div>
 <div>
 <h2 id="A-01">
-A&lt;T&&gt;<a class="mrdocs-anchor" href="#A-01" aria-label="Permalink">#</a>
-</h2>
+A&lt;T&&gt;</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/at_dtst.html
+++ b/test-files/golden-tests/templates/at_dtst.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/c_mct_expl_inline.html
+++ b/test-files/golden-tests/templates/c_mct_expl_inline.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-B-04">
-A::B<a class="mrdocs-anchor" href="#A-B-04" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +89,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-B-04-f">
-A::B::f<a class="mrdocs-anchor" href="#A-B-04-f" aria-label="Permalink">#</a>
-</h2>
+A::B::f</h2>
 </div>
 <div>
 <h3>
@@ -107,8 +103,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-B-01">
-A::B&lt;int&gt;<a class="mrdocs-anchor" href="#A-B-01" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -138,8 +133,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-B-01-g">
-A::B&lt;int&gt;::g<a class="mrdocs-anchor" href="#A-B-01-g" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;int&gt;::g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/c_mct_expl_outside.html
+++ b/test-files/golden-tests/templates/c_mct_expl_outside.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-B-04">
-A::B<a class="mrdocs-anchor" href="#A-B-04" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +89,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-B-04-f">
-A::B::f<a class="mrdocs-anchor" href="#A-B-04-f" aria-label="Permalink">#</a>
-</h2>
+A::B::f</h2>
 </div>
 <div>
 <h3>
@@ -107,8 +103,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-B-01">
-A::B&lt;int&gt;<a class="mrdocs-anchor" href="#A-B-01" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -138,8 +133,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-B-01-g">
-A::B&lt;int&gt;::g<a class="mrdocs-anchor" href="#A-B-01-g" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;int&gt;::g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/c_mft_expl_inline.html
+++ b/test-files/golden-tests/templates/c_mft_expl_inline.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -60,8 +58,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-f-07">
-A::f<a class="mrdocs-anchor" href="#A-f-07" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -85,8 +82,7 @@ void
 <div>
 <div>
 <h2 id="A-f-0e">
-A::f<a class="mrdocs-anchor" href="#A-f-0e" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -101,8 +97,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-f-0b">
-A::f&lt;int&gt;<a class="mrdocs-anchor" href="#A-f-0b" aria-label="Permalink">#</a>
-</h2>
+A::f&lt;int&gt;</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/c_mft_expl_outside.html
+++ b/test-files/golden-tests/templates/c_mft_expl_outside.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -60,8 +58,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-f-07">
-A::f<a class="mrdocs-anchor" href="#A-f-07" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -85,8 +82,7 @@ void
 <div>
 <div>
 <h2 id="A-f-0e">
-A::f<a class="mrdocs-anchor" href="#A-f-0e" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -101,8 +97,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-f-0b">
-A::f&lt;int&gt;<a class="mrdocs-anchor" href="#A-f-0b" aria-label="Permalink">#</a>
-</h2>
+A::f&lt;int&gt;</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_expl.html
+++ b/test-files/golden-tests/templates/ct_expl.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e">
-A<a class="mrdocs-anchor" href="#A-0e" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +60,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0e-f">
-A::f<a class="mrdocs-anchor" href="#A-0e-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -77,8 +74,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-00">
-A&lt;int&gt;<a class="mrdocs-anchor" href="#A-00" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -108,8 +104,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-00-g">
-A&lt;int&gt;::g<a class="mrdocs-anchor" href="#A-00-g" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_expl_dependency.html
+++ b/test-files/golden-tests/templates/ct_expl_dependency.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A&lt;int&gt;<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-g">
-A&lt;int&gt;::g<a class="mrdocs-anchor" href="#A-g" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_mc.html
+++ b/test-files/golden-tests/templates/ct_mc.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-B">
-A::B<a class="mrdocs-anchor" href="#A-B" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 </div>
 <div>
 <h3>
@@ -91,8 +88,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-B-f">
-A::B::f<a class="mrdocs-anchor" href="#A-B-f" aria-label="Permalink">#</a>
-</h2>
+A::B::f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_mc_expl_outside.html
+++ b/test-files/golden-tests/templates/ct_mc_expl_outside.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e">
-A<a class="mrdocs-anchor" href="#A-0e" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +60,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e-B">
-A::B<a class="mrdocs-anchor" href="#A-0e-B" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +89,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0e-B-f">
-A::B::f<a class="mrdocs-anchor" href="#A-0e-B-f" aria-label="Permalink">#</a>
-</h2>
+A::B::f</h2>
 </div>
 <div>
 <h3>
@@ -107,8 +103,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-00">
-A&lt;int&gt;<a class="mrdocs-anchor" href="#A-00" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -138,8 +133,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-00-B">
-A&lt;int&gt;::B<a class="mrdocs-anchor" href="#A-00-B" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::B</h2>
 </div>
 <div>
 <h3>
@@ -168,8 +162,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-00-B-g">
-A&lt;int&gt;::B::g<a class="mrdocs-anchor" href="#A-00-B-g" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::B::g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_mct.html
+++ b/test-files/golden-tests/templates/ct_mct.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-B">
-A::B<a class="mrdocs-anchor" href="#A-B" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 </div>
 <div>
 <h3>
@@ -92,8 +89,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-B-f">
-A::B::f<a class="mrdocs-anchor" href="#A-B-f" aria-label="Permalink">#</a>
-</h2>
+A::B::f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_mct_expl_inline.html
+++ b/test-files/golden-tests/templates/ct_mct_expl_inline.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +60,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-B-07">
-A::B<a class="mrdocs-anchor" href="#A-B-07" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 </div>
 <div>
 <h3>
@@ -93,8 +90,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-B-07-f">
-A::B::f<a class="mrdocs-anchor" href="#A-B-07-f" aria-label="Permalink">#</a>
-</h2>
+A::B::f</h2>
 </div>
 <div>
 <h3>
@@ -108,8 +104,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-B-06">
-A::B&lt;int&gt;<a class="mrdocs-anchor" href="#A-B-06" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -139,8 +134,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-B-06-g">
-A::B&lt;int&gt;::g<a class="mrdocs-anchor" href="#A-B-06-g" aria-label="Permalink">#</a>
-</h2>
+A::B&lt;int&gt;::g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_mct_expl_outside.html
+++ b/test-files/golden-tests/templates/ct_mct_expl_outside.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e">
-A<a class="mrdocs-anchor" href="#A-0e" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +60,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e-B">
-A::B<a class="mrdocs-anchor" href="#A-0e-B" aria-label="Permalink">#</a>
-</h2>
+A::B</h2>
 </div>
 <div>
 <h3>
@@ -93,8 +90,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0e-B-f">
-A::B::f<a class="mrdocs-anchor" href="#A-0e-B-f" aria-label="Permalink">#</a>
-</h2>
+A::B::f</h2>
 </div>
 <div>
 <h3>
@@ -108,8 +104,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-00">
-A&lt;int&gt;<a class="mrdocs-anchor" href="#A-00" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -140,8 +135,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-00-B-03">
-A&lt;int&gt;::B<a class="mrdocs-anchor" href="#A-00-B-03" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::B</h2>
 </div>
 <div>
 <h3>
@@ -157,8 +151,7 @@ struct B;</code></pre>
 <div>
 <div>
 <h2 id="A-00-B-02">
-A&lt;int&gt;::B&lt;int&gt;<a class="mrdocs-anchor" href="#A-00-B-02" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::B&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -188,8 +181,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-00-B-02-g">
-A&lt;int&gt;::B&lt;int&gt;::g<a class="mrdocs-anchor" href="#A-00-B-02-g" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::B&lt;int&gt;::g</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_mf.html
+++ b/test-files/golden-tests/templates/ct_mf.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-f">
-A::f<a class="mrdocs-anchor" href="#A-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_mf_expl_outside.html
+++ b/test-files/golden-tests/templates/ct_mf_expl_outside.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e">
-A<a class="mrdocs-anchor" href="#A-0e" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +60,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0e-f">
-A::f<a class="mrdocs-anchor" href="#A-0e-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -77,8 +74,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-00">
-A&lt;int&gt;<a class="mrdocs-anchor" href="#A-00" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -108,8 +104,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-00-f">
-A&lt;int&gt;::f<a class="mrdocs-anchor" href="#A-00-f" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_mft.html
+++ b/test-files/golden-tests/templates/ct_mft.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-f">
-A::f<a class="mrdocs-anchor" href="#A-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_mft_expl_inline.html
+++ b/test-files/golden-tests/templates/ct_mft_expl_inline.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -30,8 +29,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A">
-A<a class="mrdocs-anchor" href="#A" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -61,8 +59,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-f-00">
-A::f<a class="mrdocs-anchor" href="#A-f-00" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -86,8 +83,7 @@ void
 <div>
 <div>
 <h2 id="A-f-07">
-A::f<a class="mrdocs-anchor" href="#A-f-07" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -102,8 +98,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-f-04">
-A::f&lt;int&gt;<a class="mrdocs-anchor" href="#A-f-04" aria-label="Permalink">#</a>
-</h2>
+A::f&lt;int&gt;</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ct_mft_expl_outside.html
+++ b/test-files/golden-tests/templates/ct_mft_expl_outside.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Types</h2>
@@ -31,8 +30,7 @@ Types</h2>
 <div>
 <div>
 <h2 id="A-0e">
-A<a class="mrdocs-anchor" href="#A-0e" aria-label="Permalink">#</a>
-</h2>
+A</h2>
 </div>
 <div>
 <h3>
@@ -62,8 +60,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-0e-f">
-A::f<a class="mrdocs-anchor" href="#A-0e-f" aria-label="Permalink">#</a>
-</h2>
+A::f</h2>
 </div>
 <div>
 <h3>
@@ -78,8 +75,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-00">
-A&lt;int&gt;<a class="mrdocs-anchor" href="#A-00" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;</h2>
 </div>
 <div>
 <h3>
@@ -109,8 +105,7 @@ Member Functions</h2>
 <div>
 <div>
 <h2 id="A-00-f-0a">
-A&lt;int&gt;::f<a class="mrdocs-anchor" href="#A-00-f-0a" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::f</h2>
 </div>
 <div>
 <h3>
@@ -134,8 +129,7 @@ void
 <div>
 <div>
 <h2 id="A-00-f-03">
-A&lt;int&gt;::f<a class="mrdocs-anchor" href="#A-00-f-03" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::f</h2>
 </div>
 <div>
 <h3>
@@ -150,8 +144,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="A-00-f-07">
-A&lt;int&gt;::f&lt;int&gt;<a class="mrdocs-anchor" href="#A-00-f-07" aria-label="Permalink">#</a>
-</h2>
+A&lt;int&gt;::f&lt;int&gt;</h2>
 </div>
 <div>
 <h3>

--- a/test-files/golden-tests/templates/ft_expl.html
+++ b/test-files/golden-tests/templates/ft_expl.html
@@ -9,8 +9,7 @@
 <div>
 <div>
 <h2 id="index">
-Global Namespace<a class="mrdocs-anchor" href="#index" aria-label="Permalink">#</a>
-</h2>
+Global Namespace</h2>
 </div>
 <h2>
 Functions</h2>
@@ -30,8 +29,7 @@ Functions</h2>
 <div>
 <div>
 <h2 id="f-0c7">
-f<a class="mrdocs-anchor" href="#f-0c7" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -55,8 +53,7 @@ void
 <div>
 <div>
 <h2 id="f-03">
-f<a class="mrdocs-anchor" href="#f-03" aria-label="Permalink">#</a>
-</h2>
+f</h2>
 </div>
 <div>
 <h3>
@@ -71,8 +68,7 @@ f();</code></pre>
 <div>
 <div>
 <h2 id="f-0ca">
-f&lt;int&gt;<a class="mrdocs-anchor" href="#f-0ca" aria-label="Permalink">#</a>
-</h2>
+f&lt;int&gt;</h2>
 </div>
 <div>
 <h3>


### PR DESCRIPTION
Add installGenerator() and findGenerator() functions to the public Generator.hpp header, allowing plugins to register custom generators without accessing internal implementation details.

- Move Generators class to private GeneratorRegistry
- Add thread-safe installGenerator() and findGenerator() functions
- Add unit tests for the new public API

fix #313