### PR TITLE
fix: rendering of Markdown inline formatting and bullet lists (#1156)

### DIFF
--- a/include/mrdocs/ADT/Optional.hpp
+++ b/include/mrdocs/ADT/Optional.hpp
@@ -962,6 +962,8 @@ public:
     constexpr
     bool
     /** Return true because Optional<T&> never allocates storage.
+
+        @return `true` always.
     */
     is_inlined() noexcept
     {

--- a/include/mrdocs/Metadata/DocComment.hpp
+++ b/include/mrdocs/Metadata/DocComment.hpp
@@ -227,6 +227,16 @@ requires std::same_as<T, doc::Block> || std::same_as<T, doc::Inline>
 void
 traverseImpl(T& baseNode, F&& func);
 
+template <bool bottomUp, class F>
+void
+traverseImpl(doc::ListItem& item, F&& func)
+{
+    for (auto& block : item.blocks)
+    {
+        traverseImpl<bottomUp>(block, func);
+    }
+}
+
 // Traverse a derived node
 template <bool bottomUp, DocCommentNode NodeTy, class F>
 requires(!std::same_as<NodeTy, doc::Block> && !std::same_as<NodeTy, doc::Inline>)
@@ -255,6 +265,15 @@ traverseImpl(NodeTy& N, F&& func)
     {
         traverseImpl<bottomUp>(N.exception, func);
     }
+
+    if constexpr (std::same_as<NodeTy, doc::ListBlock>)
+    {
+        for (auto& item: N.items)
+        {
+            traverseImpl<bottomUp>(item, func);
+        }
+    }
+
     if constexpr (bottomUp && std::invocable<F, NodeTy&>)
     {
         func(N);

--- a/share/mrdocs/addons/generator/adoc/partials/doc/block/list.adoc.hbs
+++ b/share/mrdocs/addons/generator/adoc/partials/doc/block/list.adoc.hbs
@@ -1,9 +1,9 @@
 {{#each items}}
-* {{#each blocks}}{{#unless @first}}
+{{{repeat "*" (or ../depth 1)}}} {{#each blocks}}{{#unless @first}}
 
 +
 {{/unless}}
-{{#if (eq kind "paragraph")}}{{> doc/inline-container }}{{else}}{{> doc/block }}{{/if}}
+{{#if (eq kind "paragraph")}}{{> doc/inline-container }}{{else if (eq kind "list")}}{{> doc/block/list depth=(add (or ../../depth 1) 1) }}{{else}}{{> doc/block }}{{/if}}
 {{/each}}
 {{/each}}
 

--- a/share/mrdocs/addons/generator/html/partials/doc/block/code.html.hbs
+++ b/share/mrdocs/addons/generator/html/partials/doc/block/code.html.hbs
@@ -1,3 +1,3 @@
-<code class="language-{{ or info "cpp" }}">
+<pre><code class="language-{{ or info "cpp" }}">
 {{{ replace (replace (replace literal "&" "&amp;") ">" "&gt;") "<" "&lt;" }}}
-</code>
+</code></pre>

--- a/share/mrdocs/addons/generator/html/partials/doc/inline.html.hbs
+++ b/share/mrdocs/addons/generator/html/partials/doc/inline.html.hbs
@@ -1,0 +1,7 @@
+{{~#if (eq kind "text")~}}{{> doc/inline/text}}{{~/if~}}
+{{~#if (eq kind "strong")~}}{{> doc/inline/strong}}{{~/if~}}
+{{~#if (eq kind "emph")~}}{{> doc/inline/emph}}{{~/if~}}
+{{~#if (eq kind "code")~}}{{> doc/inline/code}}{{~/if~}}
+{{~#if (eq kind "link")~}}{{> doc/inline/link}}{{~/if~}}
+{{~#if (eq kind "reference")~}}{{> doc/inline/reference}}{{~/if~}}
+{{~#if (eq kind "copy-details")~}}{{> doc/inline/copy-details}}{{~/if~}}

--- a/share/mrdocs/addons/generator/html/partials/markup/b.html.hbs
+++ b/share/mrdocs/addons/generator/html/partials/markup/b.html.hbs
@@ -1,0 +1,1 @@
+<strong>{{> @partial-block }}</strong>

--- a/src/lib/Metadata/Finalizers/DocCommentFinalizer.cpp
+++ b/src/lib/Metadata/Finalizers/DocCommentFinalizer.cpp
@@ -5,6 +5,7 @@
 //
 // Copyright (c) 2023 Krystian Stasiowski (sdkrystian@gmail.com)
 // Copyright (c) 2025 Alan de Freitas (alandefreitas@gmail.com)
+// Copyright (c) 2026 Gennaro Prota (gennaro.prota@gmail.com)
 //
 // Official repository: https://github.com/cppalliance/mrdocs
 //
@@ -23,6 +24,223 @@
 #include <format>
 
 namespace mrdocs {
+
+namespace {
+
+using InlineIter = std::vector<Polymorphic<doc::Inline>>::iterator;
+using BlockVec   = std::vector<Polymorphic<doc::Block>>;
+using BlockIter  = BlockVec::iterator;
+
+// Check if an inline starts with a Markdown "- " list marker.
+bool
+isMarkdownListMarker(doc::Inline const& inl)
+{
+    if (!inl.isText())
+    {
+        return false;
+    }
+    std::string_view const sv = ltrim(inl.asText().literal);
+    return sv.starts_with("- ");
+}
+
+// Return the text content after stripping the "- " prefix.
+std::string
+textAfterListMarker(std::string_view literal)
+{
+    std::string_view const sv = ltrim(literal);
+    MRDOCS_ASSERT(sv.starts_with("- "));
+    return std::string(sv.substr(2));
+}
+
+// Move non-marker continuation inlines into a paragraph.
+void
+gatherContinuation(
+    doc::ParagraphBlock& para,
+    InlineIter& it,
+    InlineIter end)
+{
+    while (it != end && !isMarkdownListMarker(**it))
+    {
+        para.children.push_back(std::move(*it));
+        ++it;
+    }
+}
+
+// Build one ListItem from a "- " marker and its continuation.
+doc::ListItem
+buildListItem(InlineIter& it, InlineIter end)
+{
+    doc::ParagraphBlock para;
+    std::string const content = textAfterListMarker(
+        (*it)->asText().literal);
+    if (!content.empty())
+    {
+        para.emplace_back<doc::TextInline>(content);
+    }
+    ++it;
+    gatherContinuation(para, it, end);
+    doc::ListItem item;
+    item.blocks.emplace_back(std::move(para));
+    return item;
+}
+
+// Build a ListBlock from all "- " items in [first, last).
+doc::ListBlock
+buildListFromRange(InlineIter first, InlineIter last)
+{
+    doc::ListBlock list;
+    while (first != last)
+    {
+        if (isMarkdownListMarker(**first))
+        {
+            list.items.push_back(buildListItem(first, last));
+        }
+        else
+        {
+            ++first;
+        }
+    }
+    return list;
+}
+
+// Find the first "- " marker among a paragraph's children.
+InlineIter
+findFirstMarker(doc::ParagraphBlock& para)
+{
+    return std::find_if(
+        para.children.begin(),
+        para.children.end(),
+        [](Polymorphic<doc::Inline> const& el) {
+            return isMarkdownListMarker(*el);
+        });
+}
+
+// Trim trailing whitespace and remove empty inlines.
+void
+cleanupParagraph(doc::ParagraphBlock& para)
+{
+    doc::rtrim(para.asInlineContainer());
+    std::erase_if(
+        para.children,
+        [](Polymorphic<doc::Inline> const& el) {
+            return doc::isEmpty(el);
+        });
+}
+
+// Extract a ListBlock from a paragraph's "- " markers.
+// Returns std::nullopt if no markers are found.
+Optional<doc::ListBlock>
+extractList(doc::ParagraphBlock& para)
+{
+    InlineIter const marker = findFirstMarker(para);
+    if (marker == para.children.end())
+    {
+        return std::nullopt;
+    }
+    doc::ListBlock list = buildListFromRange(
+        marker, para.children.end());
+    para.children.erase(marker, para.children.end());
+    cleanupParagraph(para);
+    return list;
+}
+
+// Insert a list block, replacing or following the paragraph.
+// Returns an iterator past the inserted list.
+BlockIter
+insertList(BlockVec& blocks, BlockIter it, doc::ListBlock&& list)
+{
+    if ((*it)->asParagraph().empty())
+    {
+        it = blocks.erase(it);
+    }
+    else
+    {
+        ++it;
+    }
+    it = blocks.emplace(it, std::move(list));
+    return ++it;
+}
+
+// Scan paragraphs in a block vector and split any that
+// contain "- " markers into a prefix paragraph and a ListBlock.
+void
+splitParagraphsAtMarkers(BlockVec& blocks)
+{
+    for (BlockIter it = blocks.begin(); it != blocks.end(); )
+    {
+        if (!(*it)->isParagraph())
+        {
+            ++it;
+            continue;
+        }
+        Optional<doc::ListBlock> list = extractList(
+            (*it)->asParagraph());
+        if (!list)
+        {
+            ++it;
+            continue;
+        }
+        it = insertList(blocks, it, std::move(*list));
+    }
+}
+
+// Parse inline Markdown (bold, italic, code, etc.) in a
+// single InlineContainer's immediate text children.
+// Does *not* recurse: topDownTraverse() already visits every
+// InlineContainer in the tree, so each node is processed
+// exactly once.
+void
+parseInlinesInContainer(doc::InlineContainer& node)
+{
+    // Reserve enough capacity so child inserts during parsing
+    // cannot reallocate and invalidate pointers held by the
+    // parser state.
+    std::size_t extra = 0;
+    for (auto const& child : node.children)
+    {
+        if (child->isText())
+        {
+            extra += child->asText().literal.size();
+        }
+    }
+    if (extra > 0)
+    {
+        node.children.reserve(
+            node.children.size() + 2 * extra + 16);
+    }
+
+    auto it = node.children.begin();
+    while (it != node.children.end())
+    {
+        Polymorphic<doc::Inline>& el = *it;
+
+        if (!el->isText())
+        {
+            ++it;
+            continue;
+        }
+
+        auto& textEl = el->asText();
+        doc::InlineContainer v;
+        ParseResult r = parse(textEl.literal, v);
+
+        if (!r)
+        {
+            ++it;
+            continue;
+        }
+
+        it = node.children.erase(it);
+
+        for (auto& child : v.children)
+        {
+            it = node.children.insert(it, std::move(child));
+            ++it;
+        }
+    }
+}
+
+}
 
 void
 DocCommentFinalizer::
@@ -107,6 +325,12 @@ build()
         processRelates(I);
     }
 
+    // Parse inlines in terminal text nodes
+    for (auto& I : infos)
+    {
+        parseInlines(I);
+    }
+
     // Normalize siblings
     for (auto& I : infos)
     {
@@ -117,12 +341,6 @@ build()
     for (auto& I : infos)
     {
         tidyUp(I);
-    }
-
-    // Parse inlines in terminal text nodes
-    for (auto& I : infos)
-    {
-        parseInlines(I);
     }
 
     // Remove invalid references
@@ -1327,73 +1545,55 @@ void
 DocCommentFinalizer::
 parseInlines(DocComment& doc)
 {
-    bottomUpTraverse(doc, []<std::derived_from<doc::InlineContainer> NodeTy>(NodeTy& node) {
-        if constexpr (requires { { node.children } -> range_of<Polymorphic<doc::Inline>>; })
+    // Single top-down traversal of the entire DocComment tree.
+    //
+    // At each node the visitor does two things in order:
+    //   (1) Split paragraphs at "- " markers (block restructure).
+    //   (2) Parse inline Markdown (bold, italic, code, etc.).
+    //
+    // Top-down ordering is essential: list splitting must run
+    // on raw text *before* inline parsing, because parse() merges
+    // text across line boundaries, burying "- " markers inside
+    // TextInline nodes where isMarkdownListMarker() cannot find
+    // them.
+    //
+    // topDownTraverse() calls the visitor before iterating
+    // children, so the range-for loops see the already-modified
+    // vectors. This is safe because the visitor returns before
+    // the loops capture begin()/end().
+    topDownTraverse(doc, []<class NodeTy>(NodeTy& node) {
+        // (1) Block restructure: split paragraphs containing
+        //     "- " markers into a prefix paragraph + ListBlock.
+        if constexpr (
+            requires {
+                { node.Document } ->
+                    range_of<Polymorphic<doc::Block>>;
+            })
         {
-            // Reserve enough capacity up-front so child inserts during parsing
-            // cannot reallocate and invalidate InlineContainer pointers held
-            // by the parser state.
-            std::size_t extra = 0;
-            for (auto const& child : node.children)
+            splitParagraphsAtMarkers(node.Document);
+        }
+        if constexpr (
+            requires {
+                { node.blocks } ->
+                    range_of<Polymorphic<doc::Block>>;
+            })
+        {
+            splitParagraphsAtMarkers(node.blocks);
+        }
+        if constexpr (std::same_as<NodeTy, doc::ListBlock>)
+        {
+            for (doc::ListItem& item : node.items)
             {
-                if (child->isText())
-                {
-                    extra += child->asText().literal.size();
-                }
+                splitParagraphsAtMarkers(item.blocks);
             }
-            if (extra > 0)
-            {
-                // Over-reserve generously to avoid any reallocation while the
-                // parser keeps pointers into these containers.
-                node.children.reserve(
-                    node.children.size() + 2 * extra + 16);
-            }
+        }
 
-            auto it = node.children.begin();
-            while (it != node.children.end())
-            {
-                Polymorphic<doc::Inline>& el = *it;
-
-                // Advance when doesn't text
-                if (!el->isText()) {
-                    ++it;
-                    continue;
-                }
-
-                auto& textEl = el->asText();
-                doc::InlineContainer v;
-                ParseResult r;
-                try
-                {
-                    r = parse(textEl.literal, v);
-                }
-                catch (std::bad_alloc const&)
-                {
-                    // Skip parsing this text node if it explodes memory;
-                    // leave the raw text in place.
-                    ++it;
-                    continue;
-                }
-
-                // advance on parse failure
-                if (!r)
-                {
-                    ++it;
-                    continue;
-                }
-
-                // Remove the original text node; 'it' becomes the
-                // insertion position.
-                it = node.children.erase(it);
-
-                // Move-insert each parsed child;
-                // advance using returned iterators.
-                for (auto& child : v.children)
-                {
-                    it = node.children.insert(it, std::move(child));
-                    ++it;
-                }
-            }
+        // (2) Inline parsing: parse bold, italic, code,
+        //     links, etc. in text nodes.
+        if constexpr (
+            std::derived_from<NodeTy, doc::InlineContainer>)
+        {
+            parseInlinesInContainer(node);
         }
     });
 }

--- a/src/lib/Metadata/Finalizers/DocCommentFinalizer.cpp
+++ b/src/lib/Metadata/Finalizers/DocCommentFinalizer.cpp
@@ -91,14 +91,8 @@ buildListFromRange(InlineIter first, InlineIter last)
     doc::ListBlock list;
     while (first != last)
     {
-        if (isMarkdownListMarker(**first))
-        {
-            list.items.push_back(buildListItem(first, last));
-        }
-        else
-        {
-            ++first;
-        }
+        MRDOCS_ASSERT(isMarkdownListMarker(**first));
+        list.items.push_back(buildListItem(first, last));
     }
     return list;
 }

--- a/test-files/golden-tests/javadoc/brief/brief-1.html
+++ b/test-files/golden-tests/javadoc/brief/brief-1.html
@@ -21,7 +21,7 @@ Functions</h2>
 </thead>
 <tbody>
 <tr>
-<td><a href="#f5"><code>f5</code></a> </td><td>brief bold it continues to the line.</td></tr><tr>
+<td><a href="#f5"><code>f5</code></a> </td><td>brief <strong>bold</strong> it continues to the line.</td></tr><tr>
 <td><a href="#f6"><code>f6</code></a> </td><td>brief</td></tr>
 </tbody>
 </table>
@@ -32,7 +32,7 @@ Functions</h2>
 <h2 id="f5">
 f5</h2>
 <div>
-<p>brief bold it continues to the line.</p>
+<p>brief <strong>bold</strong> it continues to the line.</p>
 </div>
 </div>
 <div>
@@ -63,7 +63,7 @@ f6();</code></pre>
 <div>
 <h3>
 Description</h3>
-<p>many lined bold what will happen?</p>
+<p>many lined <strong>bold</strong> what will happen?</p>
 </div>
 </div>
 

--- a/test-files/golden-tests/javadoc/code/code.html
+++ b/test-files/golden-tests/javadoc/code/code.html
@@ -46,7 +46,7 @@ f();</code></pre>
 <h3>
 Description</h3>
 <p>This description contains code:</p>
-<code class="language-cpp">
+<pre><code class="language-cpp">
 // code comment
 // code comment
 template &lt; class T &gt;
@@ -56,7 +56,7 @@ algorithm( T&amp;&amp; v = {} ) -&gt;
 {
     return v.result();
 }
-</code></div>
+</code></pre></div>
 </div>
 
 </div>

--- a/test-files/golden-tests/javadoc/inline/styled.html
+++ b/test-files/golden-tests/javadoc/inline/styled.html
@@ -44,7 +44,7 @@ Declared in <code>&lt;styled.cpp&gt;</code></div>
 <div>
 <h3>
 Description</h3>
-<p>Paragraph with <code>code</code>, bold text, and italic text.</p>
+<p>Paragraph with <code>code</code>, <strong>bold</strong> text, and italic text.</p>
 <p>We can also escape these markers: &#x60;, *, and _.</p>
 </div>
 <h2>

--- a/test-files/golden-tests/javadoc/markdown-list/markdown-list.adoc
+++ b/test-files/golden-tests/javadoc/markdown-list/markdown-list.adoc
@@ -13,6 +13,8 @@
 | A simple list with Markdown bold&period;
 | link:#B[`B`] 
 | A list with inline code and list items containing &quot;&hyphen; &quot;&period;
+| link:#C[`C`] 
+| A list with no preceding text&period;
 |===
 
 === Functions
@@ -24,6 +26,12 @@
 | A list with Markdown bold and code&period;
 | link:#g[`g`] 
 | A list with Markdown code and a nested list&period;
+| link:#h[`h`] 
+| A function with a list inside a note&period;
+| link:#i[`i`] 
+| Marker with styled continuation only&period;
+| link:#j[`j`] 
+| Brief text&period;
 |===
 
 [#A]
@@ -69,6 +77,25 @@ A sentence with `inline code`&period; Now a list&colon;
 * `bar()` &sol; `baz()` &hyphen; Other two functions&period;
 * `qux()` &hyphen; Yet another function&period;
 * `quux()` &hyphen; Guess what?
+
+[#C]
+== C
+
+A list with no preceding text&period;
+
+=== Synopsis
+
+Declared in `&lt;markdown&hyphen;list&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+class C;
+----
+
+=== Description
+
+* First item&period;
+* Second item&period;
 
 [#f]
 == f
@@ -117,6 +144,72 @@ g();
 ** This `is` another list item&period;
 
 
+
+[#h]
+== h
+
+A function with a list inside a note&period;
+
+=== Synopsis
+
+Declared in `&lt;markdown&hyphen;list&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+h();
+----
+
+=== Description
+
+[NOTE]
+====
+Important points&colon;
+
+* First point&period;
+* Second point&period;
+
+====
+
+[#i]
+== i
+
+Marker with styled continuation only&period;
+
+=== Synopsis
+
+Declared in `&lt;markdown&hyphen;list&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+i();
+----
+
+=== Description
+
+* *All bold item&period;*
+* `All code item&period;`
+
+[#j]
+== j
+
+Brief text&period;
+
+=== Synopsis
+
+Declared in `&lt;markdown&hyphen;list&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+j();
+----
+
+=== Description
+
+* `foo` does something&period;
+* `bar` does something else&period;
 
 
 [.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/javadoc/markdown-list/markdown-list.adoc
+++ b/test-files/golden-tests/javadoc/markdown-list/markdown-list.adoc
@@ -1,0 +1,122 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Types
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#A[`A`] 
+| A simple list with Markdown bold&period;
+| link:#B[`B`] 
+| A list with inline code and list items containing &quot;&hyphen; &quot;&period;
+|===
+
+=== Functions
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#f[`f`] 
+| A list with Markdown bold and code&period;
+| link:#g[`g`] 
+| A list with Markdown code and a nested list&period;
+|===
+
+[#A]
+== A
+
+A simple list with Markdown bold&period;
+
+=== Synopsis
+
+Declared in `&lt;markdown&hyphen;list&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+class A;
+----
+
+=== Description
+
+Here&apos;s the list&colon;
+
+* *Bold text*&colon; Description 1&period;
+* *Bold text*&colon; Description 2&period;
+
+[#B]
+== B
+
+A list with inline code and list items containing &quot;&hyphen; &quot;&period;
+
+=== Synopsis
+
+Declared in `&lt;markdown&hyphen;list&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+class B;
+----
+
+=== Description
+
+A sentence with `inline code`&period; Now a list&colon;
+
+* `foo()` &hyphen; A dummy function&period;
+* `bar()` &sol; `baz()` &hyphen; Other two functions&period;
+* `qux()` &hyphen; Yet another function&period;
+* `quux()` &hyphen; Guess what?
+
+[#f]
+== f
+
+A list with Markdown bold and code&period;
+
+=== Synopsis
+
+Declared in `&lt;markdown&hyphen;list&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+f();
+----
+
+=== Description
+
+This is a list&colon;
+
+* *Bold* blah blah blah&period;
+* *Bold* and `code`&period;
+
+[#g]
+== g
+
+A list with Markdown code and a nested list&period;
+
+=== Synopsis
+
+Declared in `&lt;markdown&hyphen;list&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+g();
+----
+
+=== This is a paragraph
+
+* `code` followed by normal text&colon;
+
+
++
+** This is a `nested` list with `code`&period;
+** This `is` another list item&period;
+
+
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/javadoc/markdown-list/markdown-list.cpp
+++ b/test-files/golden-tests/javadoc/markdown-list/markdown-list.cpp
@@ -16,6 +16,13 @@ class A;
 */
 class B;
 
+/** A list with no preceding text.
+
+    - First item.
+    - Second item.
+*/
+class C;
+
 /** A list with Markdown bold and code.
 
     This is a list:
@@ -32,3 +39,25 @@ void f();
        - This `is` another list item.
 */
 void g();
+
+/** A function with a list inside a note.
+
+    @note Important points:
+    - First point.
+    - Second point.
+*/
+void h();
+
+/** Marker with styled continuation only.
+
+    - **All bold item.**
+    - `All code item.`
+*/
+void i();
+
+/** Brief text.
+
+    - @c foo does something.
+    - @c bar does something else.
+*/
+void j();

--- a/test-files/golden-tests/javadoc/markdown-list/markdown-list.cpp
+++ b/test-files/golden-tests/javadoc/markdown-list/markdown-list.cpp
@@ -1,0 +1,34 @@
+/** A simple list with Markdown bold.
+
+    Here's the list:
+    - **Bold text**: Description 1.
+    - **Bold text**: Description 2.
+*/
+class A;
+
+/** A list with inline code and list items containing "- ".
+
+    A sentence with `inline code`. Now a list:
+    - `foo()` - A dummy function.
+    - `bar()` / `baz()` - Other two functions.
+    - `qux()` - Yet another function.
+    - `quux()` - Guess what?
+*/
+class B;
+
+/** A list with Markdown bold and code.
+
+    This is a list:
+    - **Bold** blah blah blah.
+    - **Bold** and `code`.
+*/
+void f();
+
+/** A list with Markdown code and a nested list.
+
+   @par This is a paragraph
+   @li `code` followed by normal text:
+       - This is a `nested` list with `code`.
+       - This `is` another list item.
+*/
+void g();

--- a/test-files/golden-tests/javadoc/markdown-list/markdown-list.html
+++ b/test-files/golden-tests/javadoc/markdown-list/markdown-list.html
@@ -22,7 +22,8 @@ Types</h2>
 <tbody>
 <tr>
 <td><a href="#A"><code>A</code></a> </td><td>A simple list with Markdown bold.</td></tr><tr>
-<td><a href="#B"><code>B</code></a> </td><td>A list with inline code and list items containing &quot;- &quot;.</td></tr>
+<td><a href="#B"><code>B</code></a> </td><td>A list with inline code and list items containing &quot;- &quot;.</td></tr><tr>
+<td><a href="#C"><code>C</code></a> </td><td>A list with no preceding text.</td></tr>
 </tbody>
 </table>
 
@@ -37,7 +38,10 @@ Functions</h2>
 <tbody>
 <tr>
 <td><a href="#f"><code>f</code></a> </td><td>A list with Markdown bold and code.</td></tr><tr>
-<td><a href="#g"><code>g</code></a> </td><td>A list with Markdown code and a nested list.</td></tr>
+<td><a href="#g"><code>g</code></a> </td><td>A list with Markdown code and a nested list.</td></tr><tr>
+<td><a href="#h"><code>h</code></a> </td><td>A function with a list inside a note.</td></tr><tr>
+<td><a href="#i"><code>i</code></a> </td><td>Marker with styled continuation only.</td></tr><tr>
+<td><a href="#j"><code>j</code></a> </td><td>Brief text.</td></tr>
 </tbody>
 </table>
 
@@ -104,6 +108,33 @@ Description</h3>
 </div>
 <div>
 <div>
+<h2 id="C">
+C</h2>
+<div>
+<p>A list with no preceding text.</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;markdown-list.cpp&gt;</code></div>
+<pre><code class="source-code cpp">class C;</code></pre>
+</div>
+<div>
+<h3>
+Description</h3>
+<ul>
+<li><p>First item.</p>
+</li>
+<li><p>Second item.</p>
+</li>
+</ul></div>
+
+
+</div>
+<div>
+<div>
 <h2 id="f">
 f</h2>
 <div>
@@ -156,6 +187,89 @@ This is a paragraph</h2>
 <li><p>This <code>is</code> another list item.</p>
 </li>
 </ul></li>
+</ul></div>
+</div>
+<div>
+<div>
+<h2 id="h">
+h</h2>
+<div>
+<p>A function with a list inside a note.</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;markdown-list.cpp&gt;</code></div>
+<pre><code class="source-code cpp">void
+h();</code></pre>
+</div>
+<div>
+<h3>
+Description</h3>
+<div class="admonition">
+<h4>NOTE</h4>
+<div>
+<p>Important points:</p>
+<ul>
+<li><p>First point.</p>
+</li>
+<li><p>Second point.</p>
+</li>
+</ul></div>
+</div></div>
+</div>
+<div>
+<div>
+<h2 id="i">
+i</h2>
+<div>
+<p>Marker with styled continuation only.</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;markdown-list.cpp&gt;</code></div>
+<pre><code class="source-code cpp">void
+i();</code></pre>
+</div>
+<div>
+<h3>
+Description</h3>
+<ul>
+<li><p><strong>All bold item.</strong></p>
+</li>
+<li><p><code>All code item.</code></p>
+</li>
+</ul></div>
+</div>
+<div>
+<div>
+<h2 id="j">
+j</h2>
+<div>
+<p>Brief text.</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;markdown-list.cpp&gt;</code></div>
+<pre><code class="source-code cpp">void
+j();</code></pre>
+</div>
+<div>
+<h3>
+Description</h3>
+<ul>
+<li><p><code>foo</code> does something.</p>
+</li>
+<li><p><code>bar</code> does something else.</p>
+</li>
 </ul></div>
 </div>
 

--- a/test-files/golden-tests/javadoc/markdown-list/markdown-list.html
+++ b/test-files/golden-tests/javadoc/markdown-list/markdown-list.html
@@ -1,0 +1,167 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index">
+Global Namespace</h2>
+</div>
+<h2>
+Types</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th><th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#A"><code>A</code></a> </td><td>A simple list with Markdown bold.</td></tr><tr>
+<td><a href="#B"><code>B</code></a> </td><td>A list with inline code and list items containing &quot;- &quot;.</td></tr>
+</tbody>
+</table>
+
+<h2>
+Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th><th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#f"><code>f</code></a> </td><td>A list with Markdown bold and code.</td></tr><tr>
+<td><a href="#g"><code>g</code></a> </td><td>A list with Markdown code and a nested list.</td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="A">
+A</h2>
+<div>
+<p>A simple list with Markdown bold.</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;markdown-list.cpp&gt;</code></div>
+<pre><code class="source-code cpp">class A;</code></pre>
+</div>
+<div>
+<h3>
+Description</h3>
+<p>Here&#x27;s the list:</p>
+<ul>
+<li><p><strong>Bold text</strong>: Description 1.</p>
+</li>
+<li><p><strong>Bold text</strong>: Description 2.</p>
+</li>
+</ul></div>
+
+
+</div>
+<div>
+<div>
+<h2 id="B">
+B</h2>
+<div>
+<p>A list with inline code and list items containing &quot;- &quot;.</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;markdown-list.cpp&gt;</code></div>
+<pre><code class="source-code cpp">class B;</code></pre>
+</div>
+<div>
+<h3>
+Description</h3>
+<p>A sentence with <code>inline code</code>. Now a list:</p>
+<ul>
+<li><p><code>foo()</code> - A dummy function.</p>
+</li>
+<li><p><code>bar()</code> / <code>baz()</code> - Other two functions.</p>
+</li>
+<li><p><code>qux()</code> - Yet another function.</p>
+</li>
+<li><p><code>quux()</code> - Guess what?</p>
+</li>
+</ul></div>
+
+
+</div>
+<div>
+<div>
+<h2 id="f">
+f</h2>
+<div>
+<p>A list with Markdown bold and code.</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;markdown-list.cpp&gt;</code></div>
+<pre><code class="source-code cpp">void
+f();</code></pre>
+</div>
+<div>
+<h3>
+Description</h3>
+<p>This is a list:</p>
+<ul>
+<li><p><strong>Bold</strong> blah blah blah.</p>
+</li>
+<li><p><strong>Bold</strong> and <code>code</code>.</p>
+</li>
+</ul></div>
+</div>
+<div>
+<div>
+<h2 id="g">
+g</h2>
+<div>
+<p>A list with Markdown code and a nested list.</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;markdown-list.cpp&gt;</code></div>
+<pre><code class="source-code cpp">void
+g();</code></pre>
+</div>
+<div>
+<h2>
+This is a paragraph</h2>
+<ul>
+<li><p><code>code</code> followed by normal text:</p>
+<ul>
+<li><p>This is a <code>nested</code> list with <code>code</code>.</p>
+</li>
+<li><p>This <code>is</code> another list item.</p>
+</li>
+</ul></li>
+</ul></div>
+</div>
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/javadoc/markdown-list/markdown-list.xml
+++ b/test-files/golden-tests/javadoc/markdown-list/markdown-list.xml
@@ -9,8 +9,12 @@
   <namespace-tranche>
     <records>YrPSaKAbmXgzCAX5WByx4eVoqBM=</records>
     <records>3JsK1DO0O+wZhv+0meptQrbs3fY=</records>
+    <records>BrX2oZup9qgy4SfJloKCuUYZshA=</records>
     <functions>s6nsa+zVhpzzrN+yUVPP5rvdXqs=</functions>
     <functions>43ASI/aC9fCLy8T+1gn7pUdis+g=</functions>
+    <functions>rvT6OxIrrSI0KxJ2nkfEgBz/Lz4=</functions>
+    <functions>MHBBKAqB60b5SalK1SWHxln9gBw=</functions>
+    <functions>z6+WhUUlKbViODzMahmqRooQOm8=</functions>
   </namespace-tranche>
 </namespace>
 <record>
@@ -217,13 +221,67 @@
     </record-tranche>
   </record-interface>
 </record>
+<record>
+  <name>C</name>
+  <source>
+    <location>
+      <short-path>markdown-list.cpp</short-path>
+      <source-path>markdown-list.cpp</source-path>
+      <line-number>24</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <id>BrX2oZup9qgy4SfJloKCuUYZshA=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <list>
+      <kind>list</kind>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <text>
+            <kind>text</kind>
+            <literal>First item.</literal>
+          </text>
+        </paragraph>
+      </list-item>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <text>
+            <kind>text</kind>
+            <literal>Second item.</literal>
+          </text>
+        </paragraph>
+      </list-item>
+    </list>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>A list with no preceding text.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <key-kind>class</key-kind>
+  <record-interface>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+  </record-interface>
+</record>
 <function>
   <name>f</name>
   <source>
     <location>
       <short-path>markdown-list.cpp</short-path>
       <source-path>markdown-list.cpp</source-path>
-      <line-number>25</line-number>
+      <line-number>32</line-number>
       <column-number>1</column-number>
       <documented>1</documented>
     </location>
@@ -306,7 +364,7 @@
     <location>
       <short-path>markdown-list.cpp</short-path>
       <source-path>markdown-list.cpp</source-path>
-      <line-number>34</line-number>
+      <line-number>41</line-number>
       <column-number>1</column-number>
       <documented>1</documented>
     </location>
@@ -401,6 +459,190 @@
       <text>
         <kind>text</kind>
         <literal>A list with Markdown code and a nested list.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <named>
+    <name>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+<function>
+  <name>h</name>
+  <source>
+    <location>
+      <short-path>markdown-list.cpp</short-path>
+      <source-path>markdown-list.cpp</source-path>
+      <line-number>49</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <id>rvT6OxIrrSI0KxJ2nkfEgBz/Lz4=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <admonition>
+      <kind>admonition</kind>
+      <paragraph>
+        <kind>paragraph</kind>
+        <text>
+          <kind>text</kind>
+          <literal>Important points:</literal>
+        </text>
+      </paragraph>
+      <list>
+        <kind>list</kind>
+        <list-item>
+          <paragraph>
+            <kind>paragraph</kind>
+            <text>
+              <kind>text</kind>
+              <literal>First point.</literal>
+            </text>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <paragraph>
+            <kind>paragraph</kind>
+            <text>
+              <kind>text</kind>
+              <literal>Second point.</literal>
+            </text>
+          </paragraph>
+        </list-item>
+      </list>
+      <admonish>note</admonish>
+    </admonition>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>A function with a list inside a note.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <named>
+    <name>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+<function>
+  <name>i</name>
+  <source>
+    <location>
+      <short-path>markdown-list.cpp</short-path>
+      <source-path>markdown-list.cpp</source-path>
+      <line-number>56</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <id>MHBBKAqB60b5SalK1SWHxln9gBw=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <list>
+      <kind>list</kind>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <strong>
+            <kind>strong</kind>
+            <text>
+              <kind>text</kind>
+              <literal>All bold item.</literal>
+            </text>
+          </strong>
+        </paragraph>
+      </list-item>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <code>
+            <kind>code</kind>
+            <text>
+              <kind>text</kind>
+              <literal>All code item.</literal>
+            </text>
+          </code>
+        </paragraph>
+      </list-item>
+    </list>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>Marker with styled continuation only.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <named>
+    <name>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+<function>
+  <name>j</name>
+  <source>
+    <location>
+      <short-path>markdown-list.cpp</short-path>
+      <source-path>markdown-list.cpp</source-path>
+      <line-number>63</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <id>z6+WhUUlKbViODzMahmqRooQOm8=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <list>
+      <kind>list</kind>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <code>
+            <kind>code</kind>
+            <text>
+              <kind>text</kind>
+              <literal>foo</literal>
+            </text>
+          </code>
+          <text>
+            <kind>text</kind>
+            <literal> does something.</literal>
+          </text>
+        </paragraph>
+      </list-item>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <code>
+            <kind>code</kind>
+            <text>
+              <kind>text</kind>
+              <literal>bar</literal>
+            </text>
+          </code>
+          <text>
+            <kind>text</kind>
+            <literal> does something else.</literal>
+          </text>
+        </paragraph>
+      </list-item>
+    </list>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>Brief text.</literal>
       </text>
     </brief>
   </doc-comment>

--- a/test-files/golden-tests/javadoc/markdown-list/markdown-list.xml
+++ b/test-files/golden-tests/javadoc/markdown-list/markdown-list.xml
@@ -40,18 +40,32 @@
       <list-item>
         <paragraph>
           <kind>paragraph</kind>
+          <strong>
+            <kind>strong</kind>
+            <text>
+              <kind>text</kind>
+              <literal>Bold text</literal>
+            </text>
+          </strong>
           <text>
             <kind>text</kind>
-            <literal>**Bold text**: Description 1.</literal>
+            <literal>: Description 1.</literal>
           </text>
         </paragraph>
       </list-item>
       <list-item>
         <paragraph>
           <kind>paragraph</kind>
+          <strong>
+            <kind>strong</kind>
+            <text>
+              <kind>text</kind>
+              <literal>Bold text</literal>
+            </text>
+          </strong>
           <text>
             <kind>text</kind>
-            <literal>**Bold text**: Description 2.</literal>
+            <literal>: Description 2.</literal>
           </text>
         </paragraph>
       </list-item>
@@ -112,36 +126,75 @@
       <list-item>
         <paragraph>
           <kind>paragraph</kind>
+          <code>
+            <kind>code</kind>
+            <text>
+              <kind>text</kind>
+              <literal>foo()</literal>
+            </text>
+          </code>
           <text>
             <kind>text</kind>
-            <literal>`foo()` - A dummy function.</literal>
+            <literal> - A dummy function.</literal>
           </text>
         </paragraph>
       </list-item>
       <list-item>
         <paragraph>
           <kind>paragraph</kind>
+          <code>
+            <kind>code</kind>
+            <text>
+              <kind>text</kind>
+              <literal>bar()</literal>
+            </text>
+          </code>
           <text>
             <kind>text</kind>
-            <literal>`bar()` / `baz()` - Other two functions.</literal>
+            <literal> / </literal>
+          </text>
+          <code>
+            <kind>code</kind>
+            <text>
+              <kind>text</kind>
+              <literal>baz()</literal>
+            </text>
+          </code>
+          <text>
+            <kind>text</kind>
+            <literal> - Other two functions.</literal>
           </text>
         </paragraph>
       </list-item>
       <list-item>
         <paragraph>
           <kind>paragraph</kind>
+          <code>
+            <kind>code</kind>
+            <text>
+              <kind>text</kind>
+              <literal>qux()</literal>
+            </text>
+          </code>
           <text>
             <kind>text</kind>
-            <literal>`qux()` - Yet another function.</literal>
+            <literal> - Yet another function.</literal>
           </text>
         </paragraph>
       </list-item>
       <list-item>
         <paragraph>
           <kind>paragraph</kind>
+          <code>
+            <kind>code</kind>
+            <text>
+              <kind>text</kind>
+              <literal>quux()</literal>
+            </text>
+          </code>
           <text>
             <kind>text</kind>
-            <literal>`quux()` - Guess what?</literal>
+            <literal> - Guess what?</literal>
           </text>
         </paragraph>
       </list-item>
@@ -191,18 +244,43 @@
       <list-item>
         <paragraph>
           <kind>paragraph</kind>
+          <strong>
+            <kind>strong</kind>
+            <text>
+              <kind>text</kind>
+              <literal>Bold</literal>
+            </text>
+          </strong>
           <text>
             <kind>text</kind>
-            <literal>**Bold** blah blah blah.</literal>
+            <literal> blah blah blah.</literal>
           </text>
         </paragraph>
       </list-item>
       <list-item>
         <paragraph>
           <kind>paragraph</kind>
+          <strong>
+            <kind>strong</kind>
+            <text>
+              <kind>text</kind>
+              <literal>Bold</literal>
+            </text>
+          </strong>
           <text>
             <kind>text</kind>
-            <literal>**Bold** and `code`.</literal>
+            <literal> and </literal>
+          </text>
+          <code>
+            <kind>code</kind>
+            <text>
+              <kind>text</kind>
+              <literal>code</literal>
+            </text>
+          </code>
+          <text>
+            <kind>text</kind>
+            <literal>.</literal>
           </text>
         </paragraph>
       </list-item>
@@ -250,9 +328,16 @@
       <list-item>
         <paragraph>
           <kind>paragraph</kind>
+          <code>
+            <kind>code</kind>
+            <text>
+              <kind>text</kind>
+              <literal>code</literal>
+            </text>
+          </code>
           <text>
             <kind>text</kind>
-            <literal>`code` followed by normal text:</literal>
+            <literal> followed by normal text:</literal>
           </text>
         </paragraph>
         <list>
@@ -262,7 +347,29 @@
               <kind>paragraph</kind>
               <text>
                 <kind>text</kind>
-                <literal>This is a `nested` list with `code`.</literal>
+                <literal>This is a </literal>
+              </text>
+              <code>
+                <kind>code</kind>
+                <text>
+                  <kind>text</kind>
+                  <literal>nested</literal>
+                </text>
+              </code>
+              <text>
+                <kind>text</kind>
+                <literal> list with </literal>
+              </text>
+              <code>
+                <kind>code</kind>
+                <text>
+                  <kind>text</kind>
+                  <literal>code</literal>
+                </text>
+              </code>
+              <text>
+                <kind>text</kind>
+                <literal>.</literal>
               </text>
             </paragraph>
           </list-item>
@@ -271,7 +378,18 @@
               <kind>paragraph</kind>
               <text>
                 <kind>text</kind>
-                <literal>This `is` another list item.</literal>
+                <literal>This </literal>
+              </text>
+              <code>
+                <kind>code</kind>
+                <text>
+                  <kind>text</kind>
+                  <literal>is</literal>
+                </text>
+              </code>
+              <text>
+                <kind>text</kind>
+                <literal> another list item.</literal>
               </text>
             </paragraph>
           </list-item>

--- a/test-files/golden-tests/javadoc/markdown-list/markdown-list.xml
+++ b/test-files/golden-tests/javadoc/markdown-list/markdown-list.xml
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace>
+  <source>
+  </source>
+  <id>//////////////////////////8=</id>
+  <extraction>regular</extraction>
+  <namespace-tranche>
+    <records>YrPSaKAbmXgzCAX5WByx4eVoqBM=</records>
+    <records>3JsK1DO0O+wZhv+0meptQrbs3fY=</records>
+    <functions>s6nsa+zVhpzzrN+yUVPP5rvdXqs=</functions>
+    <functions>43ASI/aC9fCLy8T+1gn7pUdis+g=</functions>
+  </namespace-tranche>
+</namespace>
+<record>
+  <name>A</name>
+  <source>
+    <location>
+      <short-path>markdown-list.cpp</short-path>
+      <source-path>markdown-list.cpp</source-path>
+      <line-number>7</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <id>YrPSaKAbmXgzCAX5WByx4eVoqBM=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <paragraph>
+      <kind>paragraph</kind>
+      <text>
+        <kind>text</kind>
+        <literal>Here&apos;s the list:</literal>
+      </text>
+    </paragraph>
+    <list>
+      <kind>list</kind>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <text>
+            <kind>text</kind>
+            <literal>**Bold text**: Description 1.</literal>
+          </text>
+        </paragraph>
+      </list-item>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <text>
+            <kind>text</kind>
+            <literal>**Bold text**: Description 2.</literal>
+          </text>
+        </paragraph>
+      </list-item>
+    </list>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>A simple list with Markdown bold.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <key-kind>class</key-kind>
+  <record-interface>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+  </record-interface>
+</record>
+<record>
+  <name>B</name>
+  <source>
+    <location>
+      <short-path>markdown-list.cpp</short-path>
+      <source-path>markdown-list.cpp</source-path>
+      <line-number>17</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <id>3JsK1DO0O+wZhv+0meptQrbs3fY=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <paragraph>
+      <kind>paragraph</kind>
+      <text>
+        <kind>text</kind>
+        <literal>A sentence with </literal>
+      </text>
+      <code>
+        <kind>code</kind>
+        <text>
+          <kind>text</kind>
+          <literal>inline code</literal>
+        </text>
+      </code>
+      <text>
+        <kind>text</kind>
+        <literal>. Now a list:</literal>
+      </text>
+    </paragraph>
+    <list>
+      <kind>list</kind>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <text>
+            <kind>text</kind>
+            <literal>`foo()` - A dummy function.</literal>
+          </text>
+        </paragraph>
+      </list-item>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <text>
+            <kind>text</kind>
+            <literal>`bar()` / `baz()` - Other two functions.</literal>
+          </text>
+        </paragraph>
+      </list-item>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <text>
+            <kind>text</kind>
+            <literal>`qux()` - Yet another function.</literal>
+          </text>
+        </paragraph>
+      </list-item>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <text>
+            <kind>text</kind>
+            <literal>`quux()` - Guess what?</literal>
+          </text>
+        </paragraph>
+      </list-item>
+    </list>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>A list with inline code and list items containing &quot;- &quot;.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <key-kind>class</key-kind>
+  <record-interface>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+  </record-interface>
+</record>
+<function>
+  <name>f</name>
+  <source>
+    <location>
+      <short-path>markdown-list.cpp</short-path>
+      <source-path>markdown-list.cpp</source-path>
+      <line-number>25</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <id>s6nsa+zVhpzzrN+yUVPP5rvdXqs=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <paragraph>
+      <kind>paragraph</kind>
+      <text>
+        <kind>text</kind>
+        <literal>This is a list:</literal>
+      </text>
+    </paragraph>
+    <list>
+      <kind>list</kind>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <text>
+            <kind>text</kind>
+            <literal>**Bold** blah blah blah.</literal>
+          </text>
+        </paragraph>
+      </list-item>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <text>
+            <kind>text</kind>
+            <literal>**Bold** and `code`.</literal>
+          </text>
+        </paragraph>
+      </list-item>
+    </list>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>A list with Markdown bold and code.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <named>
+    <name>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+<function>
+  <name>g</name>
+  <source>
+    <location>
+      <short-path>markdown-list.cpp</short-path>
+      <source-path>markdown-list.cpp</source-path>
+      <line-number>34</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <id>43ASI/aC9fCLy8T+1gn7pUdis+g=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <heading>
+      <kind>heading</kind>
+      <text>
+        <kind>text</kind>
+        <literal>This is a paragraph</literal>
+      </text>
+      <level>1</level>
+    </heading>
+    <list>
+      <kind>list</kind>
+      <list-item>
+        <paragraph>
+          <kind>paragraph</kind>
+          <text>
+            <kind>text</kind>
+            <literal>`code` followed by normal text:</literal>
+          </text>
+        </paragraph>
+        <list>
+          <kind>list</kind>
+          <list-item>
+            <paragraph>
+              <kind>paragraph</kind>
+              <text>
+                <kind>text</kind>
+                <literal>This is a `nested` list with `code`.</literal>
+              </text>
+            </paragraph>
+          </list-item>
+          <list-item>
+            <paragraph>
+              <kind>paragraph</kind>
+              <text>
+                <kind>text</kind>
+                <literal>This `is` another list item.</literal>
+              </text>
+            </paragraph>
+          </list-item>
+        </list>
+      </list-item>
+    </list>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>A list with Markdown code and a nested list.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <named>
+    <name>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+</mrdocs>

--- a/test-files/golden-tests/javadoc/paragraph/par-1.html
+++ b/test-files/golden-tests/javadoc/paragraph/par-1.html
@@ -49,9 +49,9 @@ f1();</code></pre>
 <h2>
 Custom par</h2>
 <p>Paragraph 1</p>
-<code class="language-cpp">
+<pre><code class="language-cpp">
 void f1();
-</code></div>
+</code></pre></div>
 </div>
 <div>
 <div>
@@ -73,9 +73,9 @@ f2();</code></pre>
 <h2>
 Custom par</h2>
 <p>Paragraph 2</p>
-<code class="language-cpp">
+<pre><code class="language-cpp">
 void f2();
-</code></div>
+</code></pre></div>
 </div>
 <div>
 <div>
@@ -96,9 +96,9 @@ f3();</code></pre>
 <div>
 <h2>
 Custom par</h2>
-<code class="language-cpp">
+<pre><code class="language-cpp">
 void f3();
-</code></div>
+</code></pre></div>
 </div>
 <div>
 <div>
@@ -119,9 +119,9 @@ f4();</code></pre>
 <div>
 <h2>
 Custom par</h2>
-<code class="language-cpp">
+<pre><code class="language-cpp">
 void f4();
-</code></div>
+</code></pre></div>
 </div>
 
 </div>


### PR DESCRIPTION
**Note**: The comments below are out of date. Please refer to the PR commits for up to date info.

@alandefreitas: This patch covers the current Capy needs but, as I said on Slack, it is ad-hoc. The only long term solution is what Vinnie suggested: a Clang hook to take over comment processing entirely. A bit reluctantly, given the time I spent on it, I'd say we shouldn't merge it. We can extract the fix to inline.html.hbs from it, though, which is a genuine bug fix and doesn't depend on the Clang hook.

---

Markdown inline formatting (**bold**, *italic*, `code`) and bullet lists using "- " markers were not rendered in the HTML output.

Inline formatting:

- Add `appendMarkdownInlines()` to parse **bold**, *italic*, and `code` spans in text nodes, producing `StrongInline`, `EmphInline`, and `CodeInline` nodes respectively.

- Call it from `visitText()` so all text nodes are processed.

- Add a markup/b.html.hbs partial to render `<strong>` tags.

- Add doc/inline.html.hbs to dispatch text, strong, emph, and code inline kinds to their partials without emitting extraneous blank lines.

List detection and conversion:

- Add list marker detection functions that recognize "- " at the start of text, after newlines, after ":" or "." punctuation, and at trailing positions within already-started lists.

- Add `convertParagraphWithLists()` to split a paragraph containing list markers into a prefix paragraph and a `ListBlock`.

- Apply list detection in `visitParagraph()`, `@par` blocks, and `@li` blocks so that Markdown lists are converted in all contexts.