### PR TITLE
ci: accept any g++-14 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             msvc: RelWithDebInfo
           install: |
             gcc: git build-essential pkg-config python3 curl unzip openjdk-11-jdk pkg-config libncurses-dev libxml2-utils libxml2-dev
-            clang: git build-essential pkg-config python3 curl unzip openjdk-11-jdk pkg-config libncurses-dev libxml2-utils libxml2-dev g++-14=14.2.0-4ubuntu2~24.04 elfutils
+            clang: git build-essential pkg-config python3 curl unzip openjdk-11-jdk pkg-config libncurses-dev libxml2-utils libxml2-dev g++-14 elfutils
             msvc: ''
           extra-values: |
             use-libcxx: {{#if (and (ieq compiler 'clang') (or msan asan)) }}true{{else}}false{{/if}}


### PR DESCRIPTION
For the clang pipelines, where libstdc++14 is used, adjust the dependency so its satisfied by any g++-14 version.

This fixes a recent breakage where this version is not availale anymore.