### PR TITLE
fix: use if/else instead of or helper for array bounds rendering

### DIFF
--- a/share/mrdocs/addons/generator/common/partials/type/declarator-suffix.hbs
+++ b/share/mrdocs/addons/generator/common/partials/type/declarator-suffix.hbs
@@ -23,7 +23,7 @@
     {{~>type/declarator-suffix pointeeType link-components-impl=link-components-impl~}}
 {{else if (eq kind "array")~}}
     {{! Array declarator suffix includes bounds and array element suffix ~}}
-    [{{or boundsValue boundsExpr}}]
+    [{{#if boundsValue}}{{boundsValue}}{{else}}{{boundsExpr}}{{/if}}]
     {{~>type/declarator-suffix elementType link-components-impl=link-components-impl~}}
 {{else if (eq kind "function")~}}
     {{! Function declarator suffix includes parameter types and cv-qualifiers ~}}


### PR DESCRIPTION
The Handlebars `or` helper returns the boolean `false` when both arguments are falsy, which renders as the literal text "false" inside array brackets (e.g. `int arr[false]`). Replace `{{or boundsValue boundsExpr}}` with an explicit `{{#if}}`/`{{else}}` so that empty bounds render as `[]`.