### PR TITLE
fix(ci): name rolling release packages after the branch, not the version number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1082,11 +1082,32 @@ jobs:
           limit: 150
           update-summary: ${{ runner.os == 'Linux' && 'true' || 'false' }}
 
+      # For non-tag publishes (the develop-release and master-release
+      # rolling releases), strip the project version out of the package
+      # filenames and insert the branch name instead. Subsequent pushes
+      # to the same branch then overwrite the existing GitHub-release
+      # assets cleanly; without this, a version bump would leave the
+      # previous version's files behind as stale assets. Tag releases
+      # keep their versioned filenames.
+      - name: Rebrand branch packages with the ref name
+        if: env.IS_PUBLISH_REF == 'true' && !startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euxo pipefail
+          cd packages
+          for f in MrDocs-*.*.*-*.*; do
+            [ -e "$f" ] || continue
+            new=$(echo "$f" | sed -E 's|^MrDocs-[0-9]+\.[0-9]+\.[0-9]+-|MrDocs-${{ github.ref_name }}-|')
+            mv -- "$f" "$new"
+          done
+
       - name: Create GitHub Package Release
         if: env.IS_PUBLISH_REF == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          files: packages/MrDocs-*.*.*-*.*
+          # After the rebrand step, branch packages have the form
+          # MrDocs-<ref>-<platform>.<ext> (no semver), so the glob
+          # is broader than the historical MrDocs-*.*.*-*.*.
+          files: packages/MrDocs-*-*.*
           fail_on_unmatched_files: true
           name: ${{ github.ref_name || github.ref }}
           tag_name: ${{ github.ref_name || github.ref }}${{ ((!startsWith(github.ref, 'refs/tags/')) && '-release') || '' }}


### PR DESCRIPTION
The install page (<https://www.mrdocs.com/docs/mrdocs/install.html>)
reads the rolling-release assets via the GitHub API and picks one per
platform by filename suffix. Because each develop push named its
packages with the current project version (e.g.
MrDocs-0.8.0-Linux.tar.gz), a version bump produced a new filename and
left the previous version's files behind as stale assets on the
develop-release and master-release rolling releases. The first-match
lookup then happily returned the wrong (older) asset.

Thus, for non-tag publishes, rename each package from

    MrDocs-<semver>-<platform>.<ext>

to

    MrDocs-<ref-name>-<platform>.<ext>

right before the upload step. Subsequent pushes to the same branch now
produce identical filenames, which action-gh-release overwrites in
place. Tag releases, which are immutable per version, keep their
versioned filenames unchanged.

The upload glob is relaxed from `MrDocs-*.*.*-*.*` to `MrDocs-*-*.*` to
accommodate the branch-named form.

A one-time manual cleanup of legacy versioned assets on the existing
develop-release and master-release rolling releases is still required;
subsequent CI runs will keep the state clean on their own.