### PR TITLE
fix: line number anchor in source links

### DIFF
--- a/share/mrdocs/addons/generator/common/partials/location/source.hbs
+++ b/share/mrdocs/addons/generator/common/partials/location/source.hbs
@@ -12,7 +12,7 @@
 --}}
 Declared in {{#>markup/code~}}
     {{ str "<" }}{{#if (and @root.config.base-url dcl.shortPath dcl.sourcePath)~}}
-        {{#>markup/a href=(concat @root.config.base-url dcl.sourcePath '#L' dcl.line)}}{{dcl.shortPath}}{{/markup/a}}
+        {{#>markup/a href=(concat @root.config.base-url dcl.sourcePath '#L' dcl.lineNumber)}}{{dcl.shortPath}}{{/markup/a}}
     {{~else~}}
         {{dcl.shortPath}}
     {{~/if~}}{{ str ">" }}

--- a/test-files/golden-tests/config/base-url/base-url.adoc
+++ b/test-files/golden-tests/config/base-url/base-url.adoc
@@ -1,0 +1,29 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Functions
+
+[cols=1]
+|===
+| Name
+| link:#f[`f`] 
+|===
+
+[#f]
+== f
+
+=== Synopsis
+
+Declared in `&lt;https://example.com/src/base-url.cpp#L6[base&hyphen;url&period;cpp]&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+f();
+----
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/config/base-url/base-url.cpp
+++ b/test-files/golden-tests/config/base-url/base-url.cpp
@@ -1,0 +1,6 @@
+// When the `base-url` config option is set, the generated
+// documentation's Synopsis section carries a link to the source
+// file, with an anchor pointing at the line where the symbol is
+// declared.
+
+void f();

--- a/test-files/golden-tests/config/base-url/base-url.html
+++ b/test-files/golden-tests/config/base-url/base-url.html
@@ -1,0 +1,49 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index">
+Global Namespace</h2>
+</div>
+<h2>
+Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#f"><code>f</code></a> </td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="f">
+f</h2>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;<a href="https://example.com/src/base-url.cpp#L6">base-url.cpp</a>&gt;</code></div>
+<pre><code class="source-code cpp">void
+f();</code></pre>
+</div>
+</div>
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/base-url/base-url.xml
+++ b/test-files/golden-tests/config/base-url/base-url.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace>
+  <source>
+  </source>
+  <kind>namespace</kind>
+  <id>//////////////////////////8=</id>
+  <extraction>regular</extraction>
+  <namespace-tranche>
+    <functions>s6nsa+zVhpzzrN+yUVPP5rvdXqs=</functions>
+  </namespace-tranche>
+</namespace>
+<function>
+  <name>f</name>
+  <source>
+    <location>
+      <short-path>base-url.cpp</short-path>
+      <source-path>base-url.cpp</source-path>
+      <line-number>6</line-number>
+      <column-number>1</column-number>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>s6nsa+zVhpzzrN+yUVPP5rvdXqs=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+</mrdocs>

--- a/test-files/golden-tests/config/base-url/base-url.yml
+++ b/test-files/golden-tests/config/base-url/base-url.yml
@@ -1,0 +1,1 @@
+base-url: https://example.com/src/


### PR DESCRIPTION
The source link in the Synopsis section of each symbol page contained `#Lundefined` anchors. That's because the corresponding Handlebars template used the wrong field name (`dcl.line` instead of `dcl.lineNumber`).

Note that the separate concern of these links pointing at a moving branch rather than at a permalink for the documented commit is tracked in https://github.com/cppalliance/mrdocs/issues/1034.