### PR TITLE
fix: stop auto-brief extraction at headings

### DIFF
--- a/src/lib/Metadata/Finalizers/DocCommentFinalizer.cpp
+++ b/src/lib/Metadata/Finalizers/DocCommentFinalizer.cpp
@@ -475,6 +475,15 @@ setAutoBrief(DocComment& doc) const
 
     for (auto it = doc.Document.begin(); it != doc.Document.end();)
     {
+        // A heading marks the start of a section (as of writing
+        // this, the only way to produce one is an @par with an
+        // explicit title). Anything that follows is the body of
+        // that section, not the symbol's introductory prose, so
+        // stop looking for a brief here. See issue #1162.
+        if ((*it)->Kind == doc::BlockKind::Heading)
+        {
+            return;
+        }
         if (auto& block = *it;
             block->Kind == doc::BlockKind::Paragraph)
         {

--- a/test-files/golden-tests/javadoc/paragraph/par-1.adoc
+++ b/test-files/golden-tests/javadoc/paragraph/par-1.adoc
@@ -17,6 +17,10 @@
 | Brief
 | link:#f4[`f4`] 
 | Brief
+| link:#f5[`f5`] 
+| 
+| link:#f6[`f6`] 
+| A function&period;
 |===
 
 [#f1]
@@ -107,5 +111,41 @@ f4();
 ----
 void f4();
 ----
+[#f5]
+== f5
+
+=== Synopsis
+
+Declared in `&lt;par&hyphen;1&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+f5();
+----
+
+=== Custom par
+
+Paragraph 5
+
+[#f6]
+== f6
+
+A function&period;
+
+=== Synopsis
+
+Declared in `&lt;par&hyphen;1&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+f6();
+----
+
+=== Custom par
+
+Paragraph 6
+
 
 [.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/javadoc/paragraph/par-1.cpp
+++ b/test-files/golden-tests/javadoc/paragraph/par-1.cpp
@@ -41,3 +41,21 @@ void f3();
     @endcode
  */
 void f4();
+
+// No front matter: the body of @par must not be promoted
+// to an auto-brief (issue #1162).
+/**
+
+    @par Custom par
+    Paragraph 5
+ */
+void f5();
+
+// Same shape as f5 but with explicit front matter: the front
+// matter becomes the brief, the @par section is preserved.
+/** A function.
+
+    @par Custom par
+    Paragraph 6
+ */
+void f6();

--- a/test-files/golden-tests/javadoc/paragraph/par-1.html
+++ b/test-files/golden-tests/javadoc/paragraph/par-1.html
@@ -24,7 +24,9 @@ Functions</h2>
 <td><a href="#f1"><code>f1</code></a> </td><td>Brief</td></tr><tr>
 <td><a href="#f2"><code>f2</code></a> </td><td>Brief</td></tr><tr>
 <td><a href="#f3"><code>f3</code></a> </td><td>Brief</td></tr><tr>
-<td><a href="#f4"><code>f4</code></a> </td><td>Brief</td></tr>
+<td><a href="#f4"><code>f4</code></a> </td><td>Brief</td></tr><tr>
+<td><a href="#f5"><code>f5</code></a> </td><td></td></tr><tr>
+<td><a href="#f6"><code>f6</code></a> </td><td>A function.</td></tr>
 </tbody>
 </table>
 
@@ -122,6 +124,47 @@ Custom par</h2>
 <pre><code class="language-cpp">
 void f4();
 </code></pre></div>
+</div>
+<div>
+<div>
+<h2 id="f5">
+f5</h2>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;par-1.cpp&gt;</code></div>
+<pre><code class="source-code cpp">void
+f5();</code></pre>
+</div>
+<div>
+<h2>
+Custom par</h2>
+<p>Paragraph 5</p>
+</div>
+</div>
+<div>
+<div>
+<h2 id="f6">
+f6</h2>
+<div>
+<p>A function.</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;par-1.cpp&gt;</code></div>
+<pre><code class="source-code cpp">void
+f6();</code></pre>
+</div>
+<div>
+<h2>
+Custom par</h2>
+<p>Paragraph 6</p>
+</div>
 </div>
 
 </div>

--- a/test-files/golden-tests/javadoc/paragraph/par-1.xml
+++ b/test-files/golden-tests/javadoc/paragraph/par-1.xml
@@ -12,6 +12,8 @@
     <functions>0MJUv5yGFR9nXWFLeYc+rjOY+iM=</functions>
     <functions>khwJweIqd5FuWAg8T+l+GEljQVc=</functions>
     <functions>5wJFEWD4Ev/Vf3QN/mFlKhtbC6E=</functions>
+    <functions>RnDTZyCZuSqydMEPutN0yG4E/xg=</functions>
+    <functions>NEkWCLiknLGzCD6JnXuBTSAAne8=</functions>
   </namespace-tranche>
 </namespace>
 <function>
@@ -193,6 +195,93 @@
       <text>
         <kind>text</kind>
         <literal>Brief</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+<function>
+  <name>f5</name>
+  <source>
+    <location>
+      <short-path>par-1.cpp</short-path>
+      <source-path>par-1.cpp</source-path>
+      <line-number>52</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>RnDTZyCZuSqydMEPutN0yG4E/xg=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <heading>
+      <kind>heading</kind>
+      <text>
+        <kind>text</kind>
+        <literal>Custom par</literal>
+      </text>
+      <level>1</level>
+    </heading>
+    <paragraph>
+      <kind>paragraph</kind>
+      <text>
+        <kind>text</kind>
+        <literal>Paragraph 5</literal>
+      </text>
+    </paragraph>
+  </doc-comment>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+<function>
+  <name>f6</name>
+  <source>
+    <location>
+      <short-path>par-1.cpp</short-path>
+      <source-path>par-1.cpp</source-path>
+      <line-number>61</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>NEkWCLiknLGzCD6JnXuBTSAAne8=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <heading>
+      <kind>heading</kind>
+      <text>
+        <kind>text</kind>
+        <literal>Custom par</literal>
+      </text>
+      <level>1</level>
+    </heading>
+    <paragraph>
+      <kind>paragraph</kind>
+      <text>
+        <kind>text</kind>
+        <literal>Paragraph 6</literal>
+      </text>
+    </paragraph>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>A function.</literal>
       </text>
     </brief>
   </doc-comment>


### PR DESCRIPTION
When a symbol's documentation begins with a `@par Title` block (with no front matter text before it), parsing emits a `HeadingBlock` for the title followed by a `ParagraphBlock` for the body. The auto-brief pass walked past the heading looking for the first paragraph, promoted the `@par` body to the brief, and left the title rendered as a section with no content.

The fix is to stop iterating at the first HeadingBlock: content under a heading is the body of that section, not the symbol's introductory prose. This is tightly scoped---`HeadingBlock` is only emitted from `@par` today---and preserves the existing behavior when a front matter is present.

The commit adds a regression test covering both shapes (no front matter, and explicit brief paragraph before the `@par` section).

Closes issue #1162.