### PR TITLE
fix: empty argument list stripped from template rendering

### DIFF
--- a/share/mrdocs/addons/generator/common/partials/type/name-infos.hbs
+++ b/share/mrdocs/addons/generator/common/partials/type/name-infos.hbs
@@ -27,8 +27,11 @@
         {{! No link, just the name. ~}}
         {{name~}}
     {{/if~}}
-    {{#if args~}}
-        {{! Render the template arguments of the symbol. ~}}
+    {{#if (eq kind "specialization")~}}
+        {{! Render the template arguments of the symbol. The
+            check is on `kind` rather than `args`, since an empty
+            argument list is still meaningful: `T<>` must render
+            as `T<>`, not `T`. ~}}
         {{>template/args args=args link-components-impl=link-components-impl~}}
     {{/if~}}
 {{/if~}}

--- a/test-files/golden-tests/templates/at_dtst.adoc
+++ b/test-files/golden-tests/templates/at_dtst.adoc
@@ -22,7 +22,7 @@ Declared in `&lt;at&lowbar;dtst&period;cpp&gt;`
 [source,cpp,subs="verbatim,replacements,macros,-callouts"]
 ----
 template&lt;class T&gt;
-using A = T::XX;
+using A = T::XX&lt;&gt;;
 ----
 
 

--- a/test-files/golden-tests/templates/at_dtst.html
+++ b/test-files/golden-tests/templates/at_dtst.html
@@ -37,7 +37,7 @@ Synopsis</h3>
 <div>
 Declared in <code>&lt;at_dtst.cpp&gt;</code></div>
 <pre><code class="source-code cpp">template&lt;class T&gt;
-using A = T::XX;</code></pre>
+using A = T::XX&lt;&gt;;</code></pre>
 </div>
 </div>
 

--- a/test-files/golden-tests/templates/empty_template_args.adoc
+++ b/test-files/golden-tests/templates/empty_template_args.adoc
@@ -1,0 +1,50 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Types
+
+[cols=1]
+|===
+| Name
+| link:#Task[`Task`] 
+|===
+
+=== Functions
+
+[cols=1]
+|===
+| Name
+| link:#handshake[`handshake`] 
+|===
+
+[#Task]
+== Task
+
+=== Synopsis
+
+Declared in `&lt;empty&lowbar;template&lowbar;args&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;typename T = int&gt;
+struct Task;
+----
+
+[#handshake]
+== handshake
+
+=== Synopsis
+
+Declared in `&lt;empty&lowbar;template&lowbar;args&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+link:#Task[Task&lt;&gt;]
+handshake();
+----
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/templates/empty_template_args.cpp
+++ b/test-files/golden-tests/templates/empty_template_args.cpp
@@ -1,0 +1,9 @@
+// A class template with a default template argument, used as a
+// function return type via the empty-argument-list specialization
+// `Task<>`. The rendered output should preserve the angle brackets
+// (`Task<>`), not collapse to `Task`. See issue #1184.
+
+template <typename T = int>
+struct Task {};
+
+Task<> handshake();

--- a/test-files/golden-tests/templates/empty_template_args.html
+++ b/test-files/golden-tests/templates/empty_template_args.html
@@ -1,0 +1,79 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index">
+Global Namespace</h2>
+</div>
+<h2>
+Types</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#Task"><code>Task</code></a> </td></tr>
+</tbody>
+</table>
+
+<h2>
+Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#handshake"><code>handshake</code></a> </td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="Task">
+Task</h2>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;empty_template_args.cpp&gt;</code></div>
+<pre><code class="source-code cpp">template&lt;typename T = int&gt;
+struct Task;</code></pre>
+</div>
+
+
+</div>
+<div>
+<div>
+<h2 id="handshake">
+handshake</h2>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;empty_template_args.cpp&gt;</code></div>
+<pre><code class="source-code cpp"><a href="#Task">Task&lt;&gt;</a>
+handshake();</code></pre>
+</div>
+</div>
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/templates/empty_template_args.xml
+++ b/test-files/golden-tests/templates/empty_template_args.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace>
+  <source>
+  </source>
+  <kind>namespace</kind>
+  <id>//////////////////////////8=</id>
+  <extraction>regular</extraction>
+  <namespace-tranche>
+    <records>OaOnBHKCiwPzSl9scjYZHnbbONQ=</records>
+    <functions>l1bUVBI7Kj1W/LknqpflEcOAnWQ=</functions>
+  </namespace-tranche>
+</namespace>
+<record>
+  <name>Task</name>
+  <source>
+    <location>
+      <short-path>empty_template_args.cpp</short-path>
+      <source-path>empty_template_args.cpp</source-path>
+      <line-number>6</line-number>
+      <column-number>1</column-number>
+    </location>
+  </source>
+  <kind>record</kind>
+  <id>OaOnBHKCiwPzSl9scjYZHnbbONQ=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <key-kind>struct</key-kind>
+  <template>
+    <type-tparam>
+      <kind>type</kind>
+      <name>T</name>
+      <type-targ>
+        <kind>type</kind>
+        <named>
+          <name>
+            <kind>identifier</kind>
+            <identifier>int</identifier>
+          </name>
+        </named>
+      </type-targ>
+      <key-kind>typename</key-kind>
+    </type-tparam>
+  </template>
+  <record-interface>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+  </record-interface>
+</record>
+<function>
+  <name>handshake</name>
+  <source>
+    <location>
+      <short-path>empty_template_args.cpp</short-path>
+      <source-path>empty_template_args.cpp</source-path>
+      <line-number>9</line-number>
+      <column-number>1</column-number>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>l1bUVBI7Kj1W/LknqpflEcOAnWQ=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <named>
+    <name>
+      <kind>specialization</kind>
+      <id>OaOnBHKCiwPzSl9scjYZHnbbONQ=</id>
+      <identifier>Task</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+</mrdocs>


### PR DESCRIPTION
`T<>`, a class template specialization with an empty argument list, was incorrectly rendered as `T`.

Closes issue #1184.