### PR TITLE
refactor: drive visit() switches from existing X-macro .inc files

### DIFF
--- a/include/mrdocs/Metadata/TArg.hpp
+++ b/include/mrdocs/Metadata/TArg.hpp
@@ -19,6 +19,7 @@
 #include <mrdocs/Metadata/TArg/TArgBase.hpp>
 #include <mrdocs/Metadata/TArg/TemplateTArg.hpp>
 #include <mrdocs/Metadata/TArg/TypeTArg.hpp>
+#include <mrdocs/Support/Visitor.hpp>
 
 namespace mrdocs {
 
@@ -35,20 +36,13 @@ visit(
     F&& f,
     Args&&... args)
 {
+    auto visitor = makeVisitor<TArg>(
+        A, std::forward<F>(f), std::forward<Args>(args)...);
     switch(A.Kind)
     {
-    case TArgKind::Type:
-        return f(static_cast<add_cv_from_t<
-            TArgTy, TypeTArg>&>(A),
-            std::forward<Args>(args)...);
-    case TArgKind::Constant:
-        return f(static_cast<add_cv_from_t<
-            TArgTy, ConstantTArg>&>(A),
-            std::forward<Args>(args)...);
-    case TArgKind::Template:
-        return f(static_cast<add_cv_from_t<
-            TArgTy, TemplateTArg>&>(A),
-            std::forward<Args>(args)...);
+    #define INFO(Type) case TArgKind::Type: \
+        return visitor.template visit<Type##TArg>();
+#include <mrdocs/Metadata/TArg/TArgInfoNodes.inc>
     default:
         MRDOCS_UNREACHABLE();
     }

--- a/include/mrdocs/Metadata/TParam.hpp
+++ b/include/mrdocs/Metadata/TParam.hpp
@@ -19,6 +19,7 @@
 #include <mrdocs/Metadata/TParam/TParamBase.hpp>
 #include <mrdocs/Metadata/TParam/TemplateTParam.hpp>
 #include <mrdocs/Metadata/TParam/TypeTParam.hpp>
+#include <mrdocs/Support/Visitor.hpp>
 
 namespace mrdocs {
 
@@ -40,20 +41,13 @@ visit(
     F&& f,
     Args&&... args)
 {
+    auto visitor = makeVisitor<TParam>(
+        P, std::forward<F>(f), std::forward<Args>(args)...);
     switch(P.Kind)
     {
-    case TParamKind::Type:
-        return f(static_cast<add_cv_from_t<
-            TParamTy, TypeTParam>&>(P),
-            std::forward<Args>(args)...);
-    case TParamKind::Constant:
-        return f(static_cast<add_cv_from_t<
-            TParamTy, ConstantTParam>&>(P),
-            std::forward<Args>(args)...);
-    case TParamKind::Template:
-        return f(static_cast<add_cv_from_t<
-            TParamTy, TemplateTParam>&>(P),
-            std::forward<Args>(args)...);
+    #define INFO(Type) case TParamKind::Type: \
+        return visitor.template visit<Type##TParam>();
+#include <mrdocs/Metadata/TParam/TParamInfoNodes.inc>
     default:
         MRDOCS_UNREACHABLE();
     }

--- a/include/mrdocs/Metadata/Type.hpp
+++ b/include/mrdocs/Metadata/Type.hpp
@@ -25,6 +25,7 @@
 #include <mrdocs/Metadata/Type/RValueReferenceType.hpp>
 #include <mrdocs/Metadata/Type/TypeBase.hpp>
 #include <mrdocs/Support/TypeTraits.hpp>
+#include <mrdocs/Support/Visitor.hpp>
 
 namespace mrdocs {
 
@@ -45,45 +46,14 @@ visit(
     F&& fn,
     Args&&... args)
 {
-    add_cv_from_t<TypeTy, Type>& II = info;
+    auto visitor = makeVisitor<Type>(
+        info, std::forward<F>(fn),
+        std::forward<Args>(args)...);
     switch(info.Kind)
     {
-    case TypeKind::Named:
-        return fn(static_cast<add_cv_from_t<
-            TypeTy, NamedType>&>(II),
-                std::forward<Args>(args)...);
-    case TypeKind::Decltype:
-        return fn(static_cast<add_cv_from_t<
-            TypeTy, DecltypeType>&>(II),
-                std::forward<Args>(args)...);
-    case TypeKind::Auto:
-        return fn(static_cast<add_cv_from_t<
-            TypeTy, AutoType>&>(II),
-                std::forward<Args>(args)...);
-    case TypeKind::LValueReference:
-        return fn(static_cast<add_cv_from_t<
-            TypeTy, LValueReferenceType>&>(II),
-                std::forward<Args>(args)...);
-    case TypeKind::RValueReference:
-        return fn(static_cast<add_cv_from_t<
-            TypeTy, RValueReferenceType>&>(II),
-                std::forward<Args>(args)...);
-    case TypeKind::Pointer:
-        return fn(static_cast<add_cv_from_t<
-            TypeTy, PointerType>&>(II),
-                std::forward<Args>(args)...);
-    case TypeKind::MemberPointer:
-        return fn(static_cast<add_cv_from_t<
-            TypeTy, MemberPointerType>&>(II),
-                std::forward<Args>(args)...);
-    case TypeKind::Array:
-        return fn(static_cast<add_cv_from_t<
-            TypeTy, ArrayType>&>(II),
-                std::forward<Args>(args)...);
-    case TypeKind::Function:
-        return fn(static_cast<add_cv_from_t<
-            TypeTy, FunctionType>&>(II),
-                std::forward<Args>(args)...);
+    #define INFO(T) case TypeKind::T: \
+        return visitor.template visit<T##Type>();
+#include <mrdocs/Metadata/Type/TypeNodes.inc>
     default:
         MRDOCS_UNREACHABLE();
     }


### PR DESCRIPTION
The hand-coded `visit()` switches in Type.hpp, TArg.hpp, and TParam.hpp were duplicating the type list already enumerated by their respective *Nodes.inc X-macro files. This rewrites each to consume the .inc file, instead, matching the pattern Symbol.hpp, Name.hpp, Block.hpp, Inline.hpp already use, so the .inc is the single source of truth.