### PR TITLE
test: regression for the extract-all crash (issue #1195)

### DIFF
--- a/test-files/golden-tests/config/extract-all/warn-when-undocumented.adoc
+++ b/test-files/golden-tests/config/extract-all/warn-when-undocumented.adoc
@@ -1,0 +1,55 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Types
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#Documented[`Documented`] 
+| A documented struct&period;
+|===
+
+=== Functions
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#documentedFunction[`documentedFunction`] 
+| A documented function&period;
+|===
+
+[#Documented]
+== Documented
+
+A documented struct&period;
+
+=== Synopsis
+
+Declared in `&lt;warn&hyphen;when&hyphen;undocumented&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct Documented;
+----
+
+[#documentedFunction]
+== documentedFunction
+
+A documented function&period;
+
+=== Synopsis
+
+Declared in `&lt;warn&hyphen;when&hyphen;undocumented&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+documentedFunction();
+----
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/config/extract-all/warn-when-undocumented.cpp
+++ b/test-files/golden-tests/config/extract-all/warn-when-undocumented.cpp
@@ -1,0 +1,18 @@
+// Regression test for the crash described in
+// https://github.com/cppalliance/mrdocs/issues/1195.
+//
+// Earlier versions of `checkUndocumented` called `undocumented_.erase(it)`
+// without checking `it != end()`. With `extract-all: false` and a documented
+// symbol, the lookup misses (the set is empty under that config) and the
+// unchecked erase is undefined behaviour. `warn-if-undocumented` must be left
+// at its default true here so the buggy block is reached.
+
+/// A documented struct.
+struct Documented {};
+
+struct Undocumented {};
+
+/// A documented function.
+void documentedFunction();
+
+void undocumentedFunction();

--- a/test-files/golden-tests/config/extract-all/warn-when-undocumented.html
+++ b/test-files/golden-tests/config/extract-all/warn-when-undocumented.html
@@ -1,0 +1,84 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index">
+Global Namespace</h2>
+</div>
+<h2>
+Types</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th><th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#Documented"><code>Documented</code></a> </td><td>A documented struct.</td></tr>
+</tbody>
+</table>
+
+<h2>
+Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th><th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#documentedFunction"><code>documentedFunction</code></a> </td><td>A documented function.</td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="Documented">
+Documented</h2>
+<div>
+<p>A documented struct.</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;warn-when-undocumented.cpp&gt;</code></div>
+<pre><code class="source-code cpp">struct Documented;</code></pre>
+</div>
+
+
+</div>
+<div>
+<div>
+<h2 id="documentedFunction">
+documentedFunction</h2>
+<div>
+<p>A documented function.</p>
+</div>
+</div>
+<div>
+<h3>
+Synopsis</h3>
+<div>
+Declared in <code>&lt;warn-when-undocumented.cpp&gt;</code></div>
+<pre><code class="source-code cpp">void
+documentedFunction();</code></pre>
+</div>
+</div>
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/extract-all/warn-when-undocumented.xml
+++ b/test-files/golden-tests/config/extract-all/warn-when-undocumented.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace>
+  <source>
+  </source>
+  <kind>namespace</kind>
+  <id>//////////////////////////8=</id>
+  <extraction>regular</extraction>
+  <namespace-tranche>
+    <records>1Oafq0Qg8PKbrn4hwQwSeK44I44=</records>
+    <functions>IX3R+wr9jgB/i1gRciE8tyKKkOY=</functions>
+  </namespace-tranche>
+</namespace>
+<record>
+  <name>Documented</name>
+  <source>
+    <location>
+      <short-path>warn-when-undocumented.cpp</short-path>
+      <source-path>warn-when-undocumented.cpp</source-path>
+      <line-number>11</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <kind>record</kind>
+  <id>1Oafq0Qg8PKbrn4hwQwSeK44I44=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>A documented struct.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <key-kind>struct</key-kind>
+  <record-interface>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+  </record-interface>
+</record>
+<function>
+  <name>documentedFunction</name>
+  <source>
+    <location>
+      <short-path>warn-when-undocumented.cpp</short-path>
+      <source-path>warn-when-undocumented.cpp</source-path>
+      <line-number>16</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>IX3R+wr9jgB/i1gRciE8tyKKkOY=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>A documented function.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+</mrdocs>

--- a/test-files/golden-tests/config/extract-all/warn-when-undocumented.yml
+++ b/test-files/golden-tests/config/extract-all/warn-when-undocumented.yml
@@ -1,0 +1,2 @@
+extract-all: false
+warn-if-undocumented: true


### PR DESCRIPTION
`checkUndocumented` used to call `undocumented_.erase(it)` without first checking `it != end()`. Under `extract-all: false`, `undocumented_` never gets populated, so for any documented symbol `find()` returned `end()` and the unguarded erase was undefined behavior. A user reported this as a crash in v0.8.0. b103cbac6 fixed this as part of an unrelated restructuring, but the existing fixture in this directory disabled `warn-if-undocumented` and so never reached the crashy block. The new fixture combines `extract-all: false` with the default `warn-if-undocumented: true` and includes a documented record.

Closes issue #1195.