### PR TITLE
feat: move template specializations and deduction guides off parent scope page

### DIFF
--- a/include/mrdocs/Metadata/Symbol/Function.hpp
+++ b/include/mrdocs/Metadata/Symbol/Function.hpp
@@ -22,6 +22,7 @@
 #include <mrdocs/Metadata/Symbol/SymbolBase.hpp>
 #include <mrdocs/Metadata/Template.hpp>
 #include <mrdocs/Support/Describe.hpp>
+#include <mrdocs/Support/MapReflectedType.hpp>
 #include <string>
 #include <vector>
 
@@ -137,6 +138,36 @@ struct FunctionSymbol final
     */
     Optional<SymbolID> FunctionObjectImpl;
 
+    /** Whether this function is listed on its primary's page.
+
+        A presentation-layer flag set by `SpecializationFinalizer`
+        when *both* conditions hold:
+
+          1. This function is a template specialization (AST-local,
+             equivalent to `Template->specializationKind() != Primary`).
+          2. Its primary is being extracted in
+             @ref ExtractionMode::Regular (cross-symbol, needs the
+             corpus).
+
+        When set, the function is rendered in its primary's
+        "Specializations" section and suppressed from the parent
+        scope's listing. Orphan specializations (primary excluded
+        from extraction) fail condition 2 and keep the flag `false`,
+        so they remain reachable from the parent scope. The name
+        deliberately encodes the resulting placement rather than
+        the AST property in 1, which `Template` already exposes.
+    */
+    bool IsListedOnPrimary = false;
+
+    /** Specializations whose primary is this function.
+
+        Populated by `SpecializationFinalizer` with the IDs of
+        function-template specializations referring to this
+        function as their primary. Sorted by referent name
+        then ID.
+    */
+    std::vector<SymbolID> Specializations;
+
     //--------------------------------------------
 
     /** Construct a function symbol with its ID.
@@ -161,7 +192,8 @@ MRDOCS_DESCRIBE_STRUCT(
      IsNodiscard, IsExplicitObjectMemberFunction, Constexpr,
      OverloadedOperator, StorageClass, IsRecordMethod, IsVirtual,
      IsVirtualAsWritten, IsPure, IsConst, IsVolatile, IsFinal,
-     RefQualifier, Explicit, Attributes, FunctionObjectImpl)
+     RefQualifier, Explicit, Attributes, FunctionObjectImpl,
+     IsListedOnPrimary, Specializations)
 )
 
 /** Map a vector of parameters to a @ref dom::Value object.

--- a/include/mrdocs/Metadata/Symbol/Record.hpp
+++ b/include/mrdocs/Metadata/Symbol/Record.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (c) 2023 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Gennaro Prota (gennaro.prota@gmail.com)
 //
 // Official repository: https://github.com/cppalliance/mrdocs
 //
@@ -74,6 +75,43 @@ struct RecordSymbol final
     */
     std::vector<FriendInfo> Friends;
 
+    /** Whether this record is listed on its primary's page.
+
+        A presentation-layer flag set by `SpecializationFinalizer`
+        when *both* conditions hold:
+
+          1. This record is a template specialization (AST-local,
+             equivalent to `Template->specializationKind() != Primary`).
+          2. Its primary is being extracted in
+             @ref ExtractionMode::Regular (cross-symbol, needs the
+             corpus).
+
+        When set, the record is rendered in its primary's
+        "Specializations" section and suppressed from the parent
+        scope's listing. Orphan specializations (primary excluded
+        from extraction) fail condition 2 and keep the flag `false`,
+        so they remain reachable from the parent scope. The name
+        deliberately encodes the resulting placement rather than
+        the AST property in 1, which `Template` already exposes.
+    */
+    bool IsListedOnPrimary = false;
+
+    /** Specializations whose primary is this record.
+
+        Populated by `SpecializationFinalizer` with the IDs of
+        class-template specializations referring to this record
+        as their primary. Sorted by referent name then ID.
+    */
+    std::vector<SymbolID> Specializations;
+
+    /** Deduction guides associated with this class template.
+
+        Populated by `SpecializationFinalizer` with the IDs of
+        deduction guides that deduce this record. Sorted by
+        referent name then ID.
+    */
+    std::vector<SymbolID> DeductionGuides;
+
     //--------------------------------------------
 
     /** Create a record symbol bound to an ID.
@@ -93,7 +131,8 @@ MRDOCS_DESCRIBE_STRUCT(
     RecordSymbol,
     (SymbolCommonBase<SymbolKind::Record>),
     (KeyKind, Template, IsTypeDef, IsFinal, IsFinalDestructor,
-     Bases, Derived, Interface, Friends)
+     Bases, Derived, Interface, Friends,
+     IsListedOnPrimary, Specializations, DeductionGuides)
 )
 
 /** Return the default accessibility for a record key kind.

--- a/mrdocs.rnc
+++ b/mrdocs.rnc
@@ -370,7 +370,10 @@ grammar
             BaseInfo*,
             element derived { SymbolID }*,
             RecordInterface?,
-            FriendInfo*
+            FriendInfo*,
+            element is-listed-on-primary { Bool }?,
+            element specializations { SymbolID }*,
+            element deduction-guides { SymbolID }*
         }
 
     BaseInfo =
@@ -445,7 +448,9 @@ grammar
             element ref-qualifier { text }?,
             element explicit { text }?,
             element attributes { text }*,
-            element function-object-impl { SymbolID }?
+            element function-object-impl { SymbolID }?,
+            element is-listed-on-primary { Bool }?,
+            element specializations { SymbolID }*
         }
 
     #---------------------------------------------

--- a/share/mrdocs/addons/generator/common/partials/symbol.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol.hbs
@@ -20,6 +20,8 @@
 {{> symbol/section/base-classes}}
 {{> symbol/section/protected-base-classes}}
 {{> symbol/section/members}}
+{{> symbol/section/specializations}}
+{{> symbol/section/deduction-guides}}
 {{> symbol/section/friends}}
 {{> symbol/section/using-directives}}
 {{> symbol/section/non-member-functions}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/section/deduction-guides.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/section/deduction-guides.hbs
@@ -1,0 +1,4 @@
+{{! Deduction guides for this class template, listed on its own page rather than the parent scope. }}
+{{#if symbol.deductionGuides}}
+{{>symbol/members-table members=symbol.deductionGuides title="Deduction Guides"}}
+{{/if}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/section/specializations.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/section/specializations.hbs
@@ -1,0 +1,4 @@
+{{! Specializations of this primary, listed on its own page rather than the parent scope. }}
+{{#if symbol.specializations}}
+{{>symbol/members-table members=symbol.specializations title="Specializations"}}
+{{/if}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/tranche.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/tranche.hbs
@@ -7,6 +7,10 @@
 
     Each value in the tranche is a list of symbols that belong to the tranche.
 
+    Template specializations and deduction guides are filtered out: they are
+    listed instead on the primary template's own page, via the dedicated
+    "Specializations" / "Deduction Guides" sections.
+
     Expected Context: {Tranche Object}
 
     Example:
@@ -17,21 +21,20 @@
 {{#if is-namespace}}
 {{>symbol/members-table members=tranche.namespaces title="Namespaces"}}
 {{>symbol/members-table members=tranche.namespaceAliases title="Namespace Aliases"}}
-{{>symbol/members-table members=tranche.records title=(concat (select label (concat label " ") "") "Types")}}
+{{>symbol/members-table members=(reject_by tranche.records "isListedOnPrimary") title=(concat (select label (concat label " ") "") "Types")}}
 {{>symbol/members-table members=tranche.typedefs title=(concat (select label (concat label " ") "") "Type Aliases")}}
 {{>symbol/members-table members=tranche.enums title=(concat (select label (concat label " ") "") "Enums")}}
-{{>symbol/members-table members=tranche.functions title="Functions"}}
+{{>symbol/members-table members=(reject_by tranche.functions "isListedOnPrimary") title="Functions"}}
 {{>symbol/members-table members=tranche.variables title="Variables"}}
 {{>symbol/members-table members=tranche.concepts title="Concepts"}}
-{{>symbol/members-table members=tranche.guides title=(concat (select label (concat label " ") "") "Deduction Guides")}}
 {{>symbol/members-table members=tranche.usings title=(concat (select label (concat label " ") "") "Using Declarations")}}
 {{else}}
 {{>symbol/members-table members=tranche.namespaceAliases title="Namespace Aliases"}}
-{{>symbol/members-table members=tranche.records title=(concat (select label (concat label " ") "") "Types")}}
+{{>symbol/members-table members=(reject_by tranche.records "isListedOnPrimary") title=(concat (select label (concat label " ") "") "Types")}}
 {{>symbol/members-table members=tranche.typedefs title=(concat (select label (concat label " ") "") "Type Aliases")}}
 {{>symbol/members-table members=tranche.enums title=(concat (select label (concat label " ") "") "Enums")}}
-{{>symbol/members-table members=tranche.functions title=(concat (select label (concat label " ") "") "Member Functions")}}
-{{>symbol/members-table members=tranche.staticFunctions title=(concat (select label (concat label " ") "") "Static Member Functions")}}
+{{>symbol/members-table members=(reject_by tranche.functions "isListedOnPrimary") title=(concat (select label (concat label " ") "") "Member Functions")}}
+{{>symbol/members-table members=(reject_by tranche.staticFunctions "isListedOnPrimary") title=(concat (select label (concat label " ") "") "Static Member Functions")}}
 {{>symbol/members-table members=tranche.variables title=(concat (select label (concat label " ") "") "Data Members")}}
 {{>symbol/members-table members=tranche.staticVariables title=(concat (select label (concat label " ") "") "Static Data Members")}}
 {{>symbol/members-table members=tranche.aliases title=(concat (select label (concat label " ") "") "Aliases")}}

--- a/src/lib/CorpusImpl.cpp
+++ b/src/lib/CorpusImpl.cpp
@@ -16,6 +16,7 @@
 #include <lib/AST/MissingSymbolSink.hpp>
 #include <lib/AST/MrDocsFileSystem.hpp>
 #include <lib/Metadata/Finalizers/BaseMembersFinalizer.hpp>
+#include <lib/Metadata/Finalizers/SpecializationFinalizer.hpp>
 #include <lib/Metadata/Finalizers/DerivedFinalizer.hpp>
 #include <lib/Metadata/Finalizers/DocCommentFinalizer.hpp>
 #include <lib/Metadata/Finalizers/FunctionObjectFinalizer.hpp>
@@ -1083,6 +1084,14 @@ CorpusImpl::finalize()
     {
         report::debug("  - Finalizing auto-relates");
         DerivedFinalizer finalizer(*this);
+        finalizer.build();
+    }
+
+    // Populate primary -> specialization back-pointers
+    // and the deduction-guide lists on deduced records.
+    {
+        report::debug("  - Finalizing specializations");
+        SpecializationFinalizer finalizer(*this);
         finalizer.build();
     }
 

--- a/src/lib/CorpusImpl.hpp
+++ b/src/lib/CorpusImpl.hpp
@@ -64,6 +64,7 @@ class CorpusImpl final : public Corpus
     friend class NamespacesFinalizer;
     friend class DerivedFinalizer;
     friend class FunctionObjectFinalizer;
+    friend class SpecializationFinalizer;
 
 public:
     /** Constructor.

--- a/src/lib/Metadata/Finalizers/SpecializationFinalizer.cpp
+++ b/src/lib/Metadata/Finalizers/SpecializationFinalizer.cpp
@@ -1,0 +1,171 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Gennaro Prota (gennaro.prota@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#include "SpecializationFinalizer.hpp"
+#include <mrdocs/Support/Assert.hpp>
+#include <algorithm>
+#include <ranges>
+
+namespace mrdocs {
+
+namespace {
+
+// Return the `SymbolID` of the primary class template that a
+// deduction guide deduces, or `SymbolID::invalid` when it
+// cannot be determined.
+SymbolID
+deducedPrimaryID(GuideSymbol const& guide)
+{
+    if (guide.Deduced.valueless_after_move()
+        || !guide.Deduced->isNamed())
+    {
+        return SymbolID::invalid;
+    }
+    NamedType const& namedType = guide.Deduced->asNamed();
+    if (namedType.Name.valueless_after_move())
+    {
+        return SymbolID::invalid;
+    }
+    return namedType.Name->id;
+}
+
+} // (unnamed)
+
+void
+SpecializationFinalizer::
+processRecord(RecordSymbol const& I)
+{
+    if (!I.Template
+        || I.Template->specializationKind() == TemplateSpecKind::Primary)
+    {
+        return;
+    }
+    Symbol* primary = corpus_.find(I.Template->Primary);
+    if (!primary
+        || primary->Extraction != ExtractionMode::Regular
+        || !primary->isRecord())
+    {
+        return;
+    }
+    primary->asRecordPtr()->Specializations.push_back(I.id);
+    Symbol* self = corpus_.find(I.id);
+    MRDOCS_ASSERT(self && self->isRecord());
+    self->asRecordPtr()->IsListedOnPrimary = true;
+}
+
+void
+SpecializationFinalizer::
+processFunction(FunctionSymbol const& I)
+{
+    if (!I.Template
+        || I.Template->specializationKind() == TemplateSpecKind::Primary)
+    {
+        return;
+    }
+    Symbol* primary = corpus_.find(I.Template->Primary);
+    if (!primary
+        || primary->Extraction != ExtractionMode::Regular
+        || !primary->isFunction())
+    {
+        return;
+    }
+    primary->asFunctionPtr()->Specializations.push_back(I.id);
+    Symbol* self = corpus_.find(I.id);
+    MRDOCS_ASSERT(self && self->isFunction());
+    self->asFunctionPtr()->IsListedOnPrimary = true;
+}
+
+void
+SpecializationFinalizer::
+processGuide(GuideSymbol const& I)
+{
+    SymbolID const deducedId = deducedPrimaryID(I);
+    if (!deducedId)
+    {
+        return;
+    }
+    Symbol* deduced = corpus_.find(deducedId);
+    if (!deduced
+        || deduced->Extraction != ExtractionMode::Regular
+        || !deduced->isRecord())
+    {
+        return;
+    }
+    deduced->asRecordPtr()->DeductionGuides.push_back(I.id);
+}
+
+void
+SpecializationFinalizer::
+sortBackPointers()
+{
+    auto byReferentName = [this](SymbolID const& lhs, SymbolID const& rhs)
+    {
+        Symbol const* lhsInfo = corpus_.find(lhs);
+        Symbol const* rhsInfo = corpus_.find(rhs);
+        if (!lhsInfo || !rhsInfo)
+        {
+            return lhs < rhs;
+        }
+        if (lhsInfo->Name != rhsInfo->Name)
+        {
+            return lhsInfo->Name < rhsInfo->Name;
+        }
+        return lhs < rhs;
+    };
+    for (Symbol const& I : corpus_)
+    {
+        if (I.isRecord())
+        {
+            RecordSymbol const& R = I.asRecord();
+            if (!R.Specializations.empty() || !R.DeductionGuides.empty())
+            {
+                RecordSymbol* mut = corpus_.find(I.id)->asRecordPtr();
+                std::ranges::sort(mut->Specializations, byReferentName);
+                std::ranges::sort(mut->DeductionGuides, byReferentName);
+            }
+        }
+        else if (I.isFunction())
+        {
+            FunctionSymbol const& F = I.asFunction();
+            if (!F.Specializations.empty())
+            {
+                FunctionSymbol* mut = corpus_.find(I.id)->asFunctionPtr();
+                std::ranges::sort(mut->Specializations, byReferentName);
+            }
+        }
+    }
+}
+
+void
+SpecializationFinalizer::
+build()
+{
+    for (Symbol const& I : corpus_)
+    {
+        if (I.Extraction == ExtractionMode::Regular)
+        {
+            if (I.isRecord())
+            {
+                processRecord(I.asRecord());
+            }
+            else if (I.isFunction())
+            {
+                processFunction(I.asFunction());
+            }
+            else if (I.isGuide())
+            {
+                processGuide(I.asGuide());
+            }
+        }
+    }
+    sortBackPointers();
+}
+
+} // mrdocs

--- a/src/lib/Metadata/Finalizers/SpecializationFinalizer.hpp
+++ b/src/lib/Metadata/Finalizers/SpecializationFinalizer.hpp
@@ -1,0 +1,68 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Gennaro Prota (gennaro.prota@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_LIB_METADATA_FINALIZERS_SPECIALIZATIONFINALIZER_HPP
+#define MRDOCS_LIB_METADATA_FINALIZERS_SPECIALIZATIONFINALIZER_HPP
+
+#include <lib/CorpusImpl.hpp>
+
+namespace mrdocs {
+
+/** Populate the back-pointers from primaries to their specializations.
+
+    For each class- or function-template specialization extracted
+    in @ref ExtractionMode::Regular whose primary is also `Regular`,
+    appends the specialization's ID to the primary's
+    `Specializations` list and sets the specialization's
+    `IsListedOnPrimary` flag. For each `Regular` deduction guide,
+    appends its ID to the deduced record's `DeductionGuides`
+    list. The populated lists are sorted by referent name then ID.
+
+    Orphan specializations - those whose primary is not extracted
+    in `Regular` mode - keep `IsListedOnPrimary` `false` so they
+    remain reachable from the parent scope's listing.
+*/
+class SpecializationFinalizer
+{
+    CorpusImpl& corpus_;
+
+    void processRecord(RecordSymbol const& I);
+    void processFunction(FunctionSymbol const& I);
+    void processGuide(GuideSymbol const& I);
+
+    void sortBackPointers();
+
+public:
+    /** Construct the finalizer bound to a corpus.
+
+        @param corpus The corpus whose specialization and deduction-guide
+            back-pointers will be populated by `build`.
+    */
+    explicit
+    SpecializationFinalizer(CorpusImpl& corpus) noexcept
+        : corpus_(corpus)
+    {
+    }
+
+    /** Populate the back-pointers and sort them.
+
+        Walks the corpus once, appending each `Regular` specialization
+        to its primary's `Specializations` list (when the primary is
+        also regular) and each `Regular` deduction guide to its deduced
+        record's `DeductionGuides` list. Specializations whose primary
+        will be rendered also get their `IsListedOnPrimary` flag set.
+        Finally sorts every populated vector by referent name then ID.
+    */
+    void build();
+};
+
+} // mrdocs
+
+#endif // MRDOCS_LIB_METADATA_FINALIZERS_SPECIALIZATIONFINALIZER_HPP

--- a/src/lib/Support/Handlebars.cpp
+++ b/src/lib/Support/Handlebars.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (c) 2023 Alan de Freitas (alandefreitas@gmail.com)
+// Copyright (c) 2026 Gennaro Prota (gennaro.prota@gmail.com)
 //
 // Official repository: https://github.com/cppalliance/mrdocs
 //
@@ -6472,6 +6473,60 @@ registerContainerHelpers(Handlebars& hbs)
     });
 
     hbs.registerHelper("filter_by", filter_by_fn);
+
+    static auto reject_by_fn = dom::makeVariadicInvocable([](
+        dom::Array const& arguments) -> dom::Value
+    {
+        dom::Value container = arguments.at(0);
+        std::vector<dom::Value> keys;
+        for (std::size_t i = 1; i < arguments.size() - 1; ++i)
+        {
+            dom::Value key = arguments.at(i);
+            keys.push_back(key);
+        }
+
+        // Given an array of objects, reject (exclude) those whose
+        // value at any of the given keys is truthy. Inverse of
+        // `filter_by`: non-object elements are kept, since they
+        // have no keys to test.
+        if (container.isArray())
+        {
+            dom::Array const& arr = container.getArray();
+
+            std::vector<dom::Value> res;
+            std::size_t const n = arr.size();
+            for (std::size_t i = 0; i < n; ++i) {
+                dom::Value el = arr.at(i);
+
+                if (!el.isObject())
+                {
+                    res.emplace_back(el);
+                    continue;
+                }
+
+                auto const matchIt = std::ranges::find_if(
+                    keys,
+                    [&](dom::Value const& key)
+                    {
+                        return
+                            el.getObject().exists(key.getString()) &&
+                            el.getObject().get(key.getString()).isTruthy();
+                    });
+                if (matchIt != keys.end())
+                {
+                    continue;
+                }
+
+                res.emplace_back(el);
+            }
+            return dom::Array(res);
+        }
+
+        // If the value is not an array, then we can't reject from it
+        return container;
+    });
+
+    hbs.registerHelper("reject_by", reject_by_fn);
 
     static auto any_of_by_fn = dom::makeVariadicInvocable([](
         dom::Array const& arguments) -> dom::Value

--- a/test-files/golden-tests/config/extract-friends/extract-friends.xml
+++ b/test-files/golden-tests/config/extract-friends/extract-friends.xml
@@ -67,6 +67,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>jTCZUvygQOxo6L+VfFZcAI6KU0Y=</specializations>
 </record>
 <record>
   <name>hash</name>
@@ -105,6 +106,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>operator()</name>

--- a/test-files/golden-tests/config/extract-friends/no-extract-friends.xml
+++ b/test-files/golden-tests/config/extract-friends/no-extract-friends.xml
@@ -67,6 +67,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>jTCZUvygQOxo6L+VfFZcAI6KU0Y=</specializations>
 </record>
 <record>
   <name>hash</name>
@@ -105,6 +106,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>operator()</name>

--- a/test-files/golden-tests/config/sfinae/record-two-params.xml
+++ b/test-files/golden-tests/config/sfinae/record-two-params.xml
@@ -107,6 +107,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>E4XI9hgprdQN7ez3dhWgM/Nx9DQ=</specializations>
+  <specializations>5GqWQ5IFiKuJx5FMNsyMUX5/JA0=</specializations>
 </record>
 <record>
   <name>writable_field_traits</name>
@@ -158,6 +160,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>writable_field_traits</name>
@@ -209,5 +212,6 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 </mrdocs>

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.xml
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.xml
@@ -93,6 +93,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>NLoLTepRVq6Wm8kqUGSEoM03TKg=</specializations>
+  <specializations>1gG5jFtdo9Wauh4eNKJFnssDpFU=</specializations>
 </record>
 <record>
   <name>C</name>
@@ -138,6 +140,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -174,6 +177,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -210,6 +214,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>S+FvHbXPEwSCkNHoe9TC9L5a4Yk=</specializations>
+  <specializations>VwFE3CILPejPf11zTv20aat7w8Q=</specializations>
 </record>
 <record>
   <name>B</name>
@@ -255,6 +261,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -305,6 +312,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>A</name>
@@ -1030,6 +1038,7 @@
     </type-tparam>
   </template>
   <func-class>normal</func-class>
+  <specializations>5LjM4cXZ7IywLIZW1RtfpP7tNNk=</specializations>
 </function>
 <function>
   <name>g</name>
@@ -1088,6 +1097,7 @@
     <primary>PEedgXj8uxMWKd/yZk6yqAz6boU=</primary>
   </template>
   <func-class>normal</func-class>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </function>
 <function>
   <name>g</name>

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.xml
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.xml
@@ -101,6 +101,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>S+FvHbXPEwSCkNHoe9TC9L5a4Yk=</specializations>
+  <specializations>VwFE3CILPejPf11zTv20aat7w8Q=</specializations>
 </record>
 <record>
   <name>B</name>
@@ -146,6 +148,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -196,6 +199,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -241,6 +245,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>NLoLTepRVq6Wm8kqUGSEoM03TKg=</specializations>
+  <specializations>1gG5jFtdo9Wauh4eNKJFnssDpFU=</specializations>
 </record>
 <record>
   <name>C</name>
@@ -277,6 +283,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -322,6 +329,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>D</name>
@@ -1202,6 +1210,7 @@
     </type-tparam>
   </template>
   <func-class>normal</func-class>
+  <specializations>5LjM4cXZ7IywLIZW1RtfpP7tNNk=</specializations>
 </function>
 <function>
   <name>g</name>
@@ -1260,6 +1269,7 @@
     <primary>PEedgXj8uxMWKd/yZk6yqAz6boU=</primary>
   </template>
   <func-class>normal</func-class>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </function>
 <function>
   <name>h</name>

--- a/test-files/golden-tests/config/sort/sort-members.xml
+++ b/test-files/golden-tests/config/sort/sort-members.xml
@@ -101,6 +101,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>S+FvHbXPEwSCkNHoe9TC9L5a4Yk=</specializations>
+  <specializations>VwFE3CILPejPf11zTv20aat7w8Q=</specializations>
 </record>
 <record>
   <name>B</name>
@@ -146,6 +148,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -196,6 +199,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -241,6 +245,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>NLoLTepRVq6Wm8kqUGSEoM03TKg=</specializations>
+  <specializations>1gG5jFtdo9Wauh4eNKJFnssDpFU=</specializations>
 </record>
 <record>
   <name>C</name>
@@ -277,6 +283,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -322,6 +329,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>D</name>
@@ -1202,6 +1210,7 @@
     </type-tparam>
   </template>
   <func-class>normal</func-class>
+  <specializations>5LjM4cXZ7IywLIZW1RtfpP7tNNk=</specializations>
 </function>
 <function>
   <name>g</name>
@@ -1260,6 +1269,7 @@
     <primary>PEedgXj8uxMWKd/yZk6yqAz6boU=</primary>
   </template>
   <func-class>normal</func-class>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </function>
 <function>
   <name>h</name>

--- a/test-files/golden-tests/config/sort/unordered.xml
+++ b/test-files/golden-tests/config/sort/unordered.xml
@@ -93,6 +93,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>NLoLTepRVq6Wm8kqUGSEoM03TKg=</specializations>
+  <specializations>1gG5jFtdo9Wauh4eNKJFnssDpFU=</specializations>
 </record>
 <record>
   <name>C</name>
@@ -138,6 +140,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -174,6 +177,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -210,6 +214,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>S+FvHbXPEwSCkNHoe9TC9L5a4Yk=</specializations>
+  <specializations>VwFE3CILPejPf11zTv20aat7w8Q=</specializations>
 </record>
 <record>
   <name>B</name>
@@ -255,6 +261,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -305,6 +312,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>A</name>
@@ -1318,6 +1326,7 @@
     </type-tparam>
   </template>
   <func-class>normal</func-class>
+  <specializations>5LjM4cXZ7IywLIZW1RtfpP7tNNk=</specializations>
 </function>
 <function>
   <name>g</name>
@@ -1376,6 +1385,7 @@
     <primary>PEedgXj8uxMWKd/yZk6yqAz6boU=</primary>
   </template>
   <func-class>normal</func-class>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </function>
 <function>
   <name>g</name>

--- a/test-files/golden-tests/filters/symbol-type/nested-private-template.xml
+++ b/test-files/golden-tests/filters/symbol-type/nested-private-template.xml
@@ -83,6 +83,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>BCRU3eMBRSysyvFsjJj+0yg+Vfc=</specializations>
 </record>
 <record>
   <name>impl</name>
@@ -128,5 +129,6 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 </mrdocs>

--- a/test-files/golden-tests/javadoc/copydoc/template-arguments.xml
+++ b/test-files/golden-tests/javadoc/copydoc/template-arguments.xml
@@ -364,6 +364,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>n2ekv7/9IraylJIibujZeExrML4=</specializations>
+  <specializations>zWh7HJU4uEOW6SQu1/X6/fBkFq0=</specializations>
 </record>
 <record>
   <name>B</name>
@@ -410,6 +412,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -460,6 +463,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -530,6 +534,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>w5ssdgUOfKNpDbPFUfSYesxFAc8=</specializations>
+  <specializations>+AYNfv3bBiQwa6z9A60U/F7dvXE=</specializations>
 </record>
 <record>
   <name>C</name>
@@ -581,6 +587,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -631,6 +638,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>D</name>

--- a/test-files/golden-tests/symbols/function/sfinae.xml
+++ b/test-files/golden-tests/symbols/function/sfinae.xml
@@ -129,6 +129,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>f80OzcD5UlgQ2KOvUj+MvoJcAFE=</specializations>
 </record>
 <record>
   <name>A</name>
@@ -181,6 +182,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S</name>
@@ -237,6 +239,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>g0UNZpdodOU5mGCtcpviXd8o6Vk=</specializations>
 </record>
 <function>
   <name>store</name>
@@ -338,6 +341,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>store</name>

--- a/test-files/golden-tests/symbols/function/spec-mem-implicit-instantiation.xml
+++ b/test-files/golden-tests/symbols/function/spec-mem-implicit-instantiation.xml
@@ -48,6 +48,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>AKwlChAOi+0ttIAPsD7uitS+gk0=</specializations>
+  <specializations>C6fFmGgpPJ7jgwKJA98mfx5cxts=</specializations>
+  <specializations>/vjeowK9rbOfBZNuMjVMRn2iGMo=</specializations>
 </record>
 <record>
   <name>B</name>
@@ -80,6 +83,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>kLfkJ6zwS7/fgRzTYaPfbg3WHg8=</specializations>
 </record>
 <function>
   <name>g</name>
@@ -135,6 +139,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>EyperGIiZ7cSv/PB2BApKjPRQVA=</specializations>
+  <specializations>xYK8qpEgWzczUMGnNUx+ozeBle0=</specializations>
 </record>
 <function>
   <name>h</name>
@@ -222,6 +228,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -323,6 +330,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>j</name>
@@ -396,6 +404,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>j</name>
@@ -482,6 +491,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -550,6 +560,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>g</name>
@@ -678,6 +689,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -851,6 +863,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>27+9TQyh1Vcx+C3POBLdyXJP8bo=</specializations>
 </record>
 <function>
   <name>k</name>
@@ -911,6 +924,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>k</name>

--- a/test-files/golden-tests/symbols/guide/explicit-deduct-guide.xml
+++ b/test-files/golden-tests/symbols/guide/explicit-deduct-guide.xml
@@ -49,6 +49,10 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <deduction-guides>AtQyLakD3CjcM24GabAbHMNgVU4=</deduction-guides>
+  <deduction-guides>YS/v8XQ/9ShQ2spNAh5EY33PN7s=</deduction-guides>
+  <deduction-guides>tkYkUU6H8cbFpCU7yBuvBLkT6dg=</deduction-guides>
+  <deduction-guides>2IF4pOfGcA57GQDlE3PJgs7yeUs=</deduction-guides>
 </record>
 <guide>
   <name>X</name>

--- a/test-files/golden-tests/symbols/record/class-template-array-spec.xml
+++ b/test-files/golden-tests/symbols/record/class-template-array-spec.xml
@@ -86,6 +86,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>BImCLyzY3azoxv/pd8PtoMYhX4k=</specializations>
 </record>
 <record>
   <name>A</name>
@@ -158,5 +159,6 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 </mrdocs>

--- a/test-files/golden-tests/symbols/record/class-template-partial-spec.xml
+++ b/test-files/golden-tests/symbols/record/class-template-partial-spec.xml
@@ -80,6 +80,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>RB9DBMAJDxjxuRQCinQOVPFSNek=</specializations>
+  <specializations>Y/lm1lkT88vf1Ml123mbuN6Fp2Y=</specializations>
 </record>
 <record>
   <name>B</name>
@@ -125,6 +127,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -177,5 +180,6 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 </mrdocs>

--- a/test-files/golden-tests/symbols/record/class-template-spec.xml
+++ b/test-files/golden-tests/symbols/record/class-template-spec.xml
@@ -50,6 +50,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>AKwlChAOi+0ttIAPsD7uitS+gk0=</specializations>
+  <specializations>y/8TvVlacBAIG2ds2aYgZE+zGUU=</specializations>
 </record>
 <function>
   <name>f</name>
@@ -110,6 +112,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>g</name>
@@ -170,6 +173,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>h</name>
@@ -225,6 +229,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>ZjUaxeOoGJ0Jol9Nmn7cGRE7RCo=</specializations>
+  <specializations>dydGCFMdrM4nOwuv3RCXqg2KCUA=</specializations>
 </record>
 <function>
   <name>f</name>
@@ -292,6 +298,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>h</name>
@@ -359,6 +366,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>g</name>
@@ -419,6 +427,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>qrcrkE8Br83XKNMh95Dvwpph/M8=</specializations>
+  <specializations>6zS87fCNnLtFfHbRWEmcdeAT1Zg=</specializations>
 </record>
 <function>
   <name>f</name>
@@ -488,6 +498,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>g</name>
@@ -564,6 +575,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>h</name>

--- a/test-files/golden-tests/symbols/record/class-template-specializations-1.xml
+++ b/test-files/golden-tests/symbols/record/class-template-specializations-1.xml
@@ -219,6 +219,17 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>JnRKKJOV9sM2/Wi7ytI5OenLTcs=</specializations>
+  <specializations>Lu2i8tgrw9I5p6DXmX9LfM8mVSo=</specializations>
+  <specializations>OsUzyKi8NDCZFI1r1y4+Ki/4H0s=</specializations>
+  <specializations>Xes4IqvFnQoGkxPlP4C4wtbjqxQ=</specializations>
+  <specializations>ZyL4aBHmvCmfq+HyxDSySKwRsdA=</specializations>
+  <specializations>eWg27/kfn86dUmPA26mcOo6kkfs=</specializations>
+  <specializations>g2iVCce1Dp6iPMyevfuMN/UU9F0=</specializations>
+  <specializations>p3PhPnVydwdupHBMAXlcrNQuiFo=</specializations>
+  <specializations>tcws+2wcXL0FEmvv7ZVXvxSkAaI=</specializations>
+  <specializations>zpDyI51RjdguXF8/9KXFrICQwEc=</specializations>
+  <specializations>8snJ9gp5ca88/AsWGEnFe6Ln6RQ=</specializations>
 </record>
 <record>
   <name>S3</name>
@@ -318,6 +329,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>J3UZDljdSJ1mGU9Js0JpA3TjVtc=</specializations>
+  <specializations>cV4O7e/J4xug1ZmsOQKwDVjE99M=</specializations>
+  <specializations>yPCRvP9B34hMThomBKlaCzkFM54=</specializations>
 </record>
 <function>
   <name>f4</name>
@@ -439,6 +453,25 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>IhITMrVguwgsTFnxWSalhrn5lnw=</specializations>
+  <specializations>I29LgIfKHs2KVKydoPZ2XncISyM=</specializations>
+  <specializations>NnzxSBCBz0/s6OkCTTL/yDO06Go=</specializations>
+  <specializations>RFQpd+7V+unGQTgk13maA1YEoyY=</specializations>
+  <specializations>XLAZYk894KbFFFIzJpR6c2Fi870=</specializations>
+  <specializations>dO93MwJZmA5Fpzul37ZMH6F1ong=</specializations>
+  <specializations>fpqbvQR9NuaJY4fq9LHbiAsZKzw=</specializations>
+  <specializations>hpAmCOpzad0YvzIs/nrK1blINCo=</specializations>
+  <specializations>j53XjxydcG+wI0iK3mM8/acK5rY=</specializations>
+  <specializations>lmGGu3RmJh5DZfXs5nd811FPf14=</specializations>
+  <specializations>s40Z8yfzcJnCZSeYYV5sYlFzOxs=</specializations>
+  <specializations>tZqwapq24sWOnWsHAcGXH/3yX3Y=</specializations>
+  <specializations>uE1JLlP4kj18/7anYGDOOUyNK5M=</specializations>
+  <specializations>umZ8gPZZ+qTWuYY3zYO/hx1XCGI=</specializations>
+  <specializations>wpJv75dxyLgHOdHJsb50f1IIDVc=</specializations>
+  <specializations>1ro4Sv8wGUNxysGIgXgcl9hcP68=</specializations>
+  <specializations>51FuSsXmA0w505ZBRVkx0q/lmUk=</specializations>
+  <specializations>+J66oroZ92MSPf/1vk3672IXQRM=</specializations>
+  <specializations>+YuAVlOefcnfZIU1wckNM7lfNaA=</specializations>
 </record>
 <record>
   <name>S6</name>
@@ -518,6 +551,17 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>GJK8oH0tb+kOcrLsJD4KLPgW01k=</specializations>
+  <specializations>J7tgsUhd+qpsq/85qkEgF1l14uk=</specializations>
+  <specializations>NkmHmT5oAR5xJObAVl4zdPrTJPk=</specializations>
+  <specializations>VxqDdgdkcw8E86ZiNolpXLlhyWs=</specializations>
+  <specializations>V/H0waQNmYhkbcgX6kBFOODNK64=</specializations>
+  <specializations>pbmVOgtPeZtTL7BQG/AM7NVsNdo=</specializations>
+  <specializations>r7aMtw1PqhcjWuGFP7pwiW2v0ks=</specializations>
+  <specializations>1YtqF4WYT0uK7amUiCmJVk03Oog=</specializations>
+  <specializations>3eTbiMMR3GPY7/xRty3EmJ9bdQU=</specializations>
+  <specializations>3jBuzbuFB0fvpQa1ETvIXevGH2w=</specializations>
+  <specializations>9PQcUNZCJePNJhT5t0prZNV/lHk=</specializations>
 </record>
 <record>
   <name>S8</name>
@@ -617,6 +661,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>CvFJnK9Xu7B2Fbh91NqM0+gKVEU=</specializations>
+  <specializations>hwfbdkFRNunC/3V+s6HA5BwWiSQ=</specializations>
+  <specializations>8PQtbs9xGpu1L+b0VOqfLlE6TnY=</specializations>
 </record>
 <function>
   <name>f9</name>
@@ -1315,6 +1362,17 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>JnRKKJOV9sM2/Wi7ytI5OenLTcs=</specializations>
+  <specializations>Lu2i8tgrw9I5p6DXmX9LfM8mVSo=</specializations>
+  <specializations>OsUzyKi8NDCZFI1r1y4+Ki/4H0s=</specializations>
+  <specializations>Xes4IqvFnQoGkxPlP4C4wtbjqxQ=</specializations>
+  <specializations>ZyL4aBHmvCmfq+HyxDSySKwRsdA=</specializations>
+  <specializations>eWg27/kfn86dUmPA26mcOo6kkfs=</specializations>
+  <specializations>g2iVCce1Dp6iPMyevfuMN/UU9F0=</specializations>
+  <specializations>p3PhPnVydwdupHBMAXlcrNQuiFo=</specializations>
+  <specializations>tcws+2wcXL0FEmvv7ZVXvxSkAaI=</specializations>
+  <specializations>zpDyI51RjdguXF8/9KXFrICQwEc=</specializations>
+  <specializations>8snJ9gp5ca88/AsWGEnFe6Ln6RQ=</specializations>
 </record>
 <record>
   <name>S3</name>
@@ -1414,6 +1472,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>J3UZDljdSJ1mGU9Js0JpA3TjVtc=</specializations>
+  <specializations>cV4O7e/J4xug1ZmsOQKwDVjE99M=</specializations>
+  <specializations>yPCRvP9B34hMThomBKlaCzkFM54=</specializations>
 </record>
 <function>
   <name>f4</name>
@@ -1535,6 +1596,25 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>IhITMrVguwgsTFnxWSalhrn5lnw=</specializations>
+  <specializations>I29LgIfKHs2KVKydoPZ2XncISyM=</specializations>
+  <specializations>NnzxSBCBz0/s6OkCTTL/yDO06Go=</specializations>
+  <specializations>RFQpd+7V+unGQTgk13maA1YEoyY=</specializations>
+  <specializations>XLAZYk894KbFFFIzJpR6c2Fi870=</specializations>
+  <specializations>dO93MwJZmA5Fpzul37ZMH6F1ong=</specializations>
+  <specializations>fpqbvQR9NuaJY4fq9LHbiAsZKzw=</specializations>
+  <specializations>hpAmCOpzad0YvzIs/nrK1blINCo=</specializations>
+  <specializations>j53XjxydcG+wI0iK3mM8/acK5rY=</specializations>
+  <specializations>lmGGu3RmJh5DZfXs5nd811FPf14=</specializations>
+  <specializations>s40Z8yfzcJnCZSeYYV5sYlFzOxs=</specializations>
+  <specializations>tZqwapq24sWOnWsHAcGXH/3yX3Y=</specializations>
+  <specializations>uE1JLlP4kj18/7anYGDOOUyNK5M=</specializations>
+  <specializations>umZ8gPZZ+qTWuYY3zYO/hx1XCGI=</specializations>
+  <specializations>wpJv75dxyLgHOdHJsb50f1IIDVc=</specializations>
+  <specializations>1ro4Sv8wGUNxysGIgXgcl9hcP68=</specializations>
+  <specializations>51FuSsXmA0w505ZBRVkx0q/lmUk=</specializations>
+  <specializations>+J66oroZ92MSPf/1vk3672IXQRM=</specializations>
+  <specializations>+YuAVlOefcnfZIU1wckNM7lfNaA=</specializations>
 </record>
 <record>
   <name>S6</name>
@@ -1614,6 +1694,17 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>GJK8oH0tb+kOcrLsJD4KLPgW01k=</specializations>
+  <specializations>J7tgsUhd+qpsq/85qkEgF1l14uk=</specializations>
+  <specializations>NkmHmT5oAR5xJObAVl4zdPrTJPk=</specializations>
+  <specializations>VxqDdgdkcw8E86ZiNolpXLlhyWs=</specializations>
+  <specializations>V/H0waQNmYhkbcgX6kBFOODNK64=</specializations>
+  <specializations>pbmVOgtPeZtTL7BQG/AM7NVsNdo=</specializations>
+  <specializations>r7aMtw1PqhcjWuGFP7pwiW2v0ks=</specializations>
+  <specializations>1YtqF4WYT0uK7amUiCmJVk03Oog=</specializations>
+  <specializations>3eTbiMMR3GPY7/xRty3EmJ9bdQU=</specializations>
+  <specializations>3jBuzbuFB0fvpQa1ETvIXevGH2w=</specializations>
+  <specializations>9PQcUNZCJePNJhT5t0prZNV/lHk=</specializations>
 </record>
 <record>
   <name>S8</name>
@@ -1713,6 +1804,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>CvFJnK9Xu7B2Fbh91NqM0+gKVEU=</specializations>
+  <specializations>hwfbdkFRNunC/3V+s6HA5BwWiSQ=</specializations>
+  <specializations>8PQtbs9xGpu1L+b0VOqfLlE6TnY=</specializations>
 </record>
 <function>
   <name>f9</name>
@@ -2352,6 +2446,17 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>JnRKKJOV9sM2/Wi7ytI5OenLTcs=</specializations>
+  <specializations>Lu2i8tgrw9I5p6DXmX9LfM8mVSo=</specializations>
+  <specializations>OsUzyKi8NDCZFI1r1y4+Ki/4H0s=</specializations>
+  <specializations>Xes4IqvFnQoGkxPlP4C4wtbjqxQ=</specializations>
+  <specializations>ZyL4aBHmvCmfq+HyxDSySKwRsdA=</specializations>
+  <specializations>eWg27/kfn86dUmPA26mcOo6kkfs=</specializations>
+  <specializations>g2iVCce1Dp6iPMyevfuMN/UU9F0=</specializations>
+  <specializations>p3PhPnVydwdupHBMAXlcrNQuiFo=</specializations>
+  <specializations>tcws+2wcXL0FEmvv7ZVXvxSkAaI=</specializations>
+  <specializations>zpDyI51RjdguXF8/9KXFrICQwEc=</specializations>
+  <specializations>8snJ9gp5ca88/AsWGEnFe6Ln6RQ=</specializations>
 </record>
 <record>
   <name>S3</name>
@@ -2451,6 +2556,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>J3UZDljdSJ1mGU9Js0JpA3TjVtc=</specializations>
+  <specializations>cV4O7e/J4xug1ZmsOQKwDVjE99M=</specializations>
+  <specializations>yPCRvP9B34hMThomBKlaCzkFM54=</specializations>
 </record>
 <function>
   <name>f4</name>
@@ -2572,6 +2680,25 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>IhITMrVguwgsTFnxWSalhrn5lnw=</specializations>
+  <specializations>I29LgIfKHs2KVKydoPZ2XncISyM=</specializations>
+  <specializations>NnzxSBCBz0/s6OkCTTL/yDO06Go=</specializations>
+  <specializations>RFQpd+7V+unGQTgk13maA1YEoyY=</specializations>
+  <specializations>XLAZYk894KbFFFIzJpR6c2Fi870=</specializations>
+  <specializations>dO93MwJZmA5Fpzul37ZMH6F1ong=</specializations>
+  <specializations>fpqbvQR9NuaJY4fq9LHbiAsZKzw=</specializations>
+  <specializations>hpAmCOpzad0YvzIs/nrK1blINCo=</specializations>
+  <specializations>j53XjxydcG+wI0iK3mM8/acK5rY=</specializations>
+  <specializations>lmGGu3RmJh5DZfXs5nd811FPf14=</specializations>
+  <specializations>s40Z8yfzcJnCZSeYYV5sYlFzOxs=</specializations>
+  <specializations>tZqwapq24sWOnWsHAcGXH/3yX3Y=</specializations>
+  <specializations>uE1JLlP4kj18/7anYGDOOUyNK5M=</specializations>
+  <specializations>umZ8gPZZ+qTWuYY3zYO/hx1XCGI=</specializations>
+  <specializations>wpJv75dxyLgHOdHJsb50f1IIDVc=</specializations>
+  <specializations>1ro4Sv8wGUNxysGIgXgcl9hcP68=</specializations>
+  <specializations>51FuSsXmA0w505ZBRVkx0q/lmUk=</specializations>
+  <specializations>+J66oroZ92MSPf/1vk3672IXQRM=</specializations>
+  <specializations>+YuAVlOefcnfZIU1wckNM7lfNaA=</specializations>
 </record>
 <record>
   <name>S6</name>
@@ -2651,6 +2778,17 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>GJK8oH0tb+kOcrLsJD4KLPgW01k=</specializations>
+  <specializations>J7tgsUhd+qpsq/85qkEgF1l14uk=</specializations>
+  <specializations>NkmHmT5oAR5xJObAVl4zdPrTJPk=</specializations>
+  <specializations>VxqDdgdkcw8E86ZiNolpXLlhyWs=</specializations>
+  <specializations>V/H0waQNmYhkbcgX6kBFOODNK64=</specializations>
+  <specializations>pbmVOgtPeZtTL7BQG/AM7NVsNdo=</specializations>
+  <specializations>r7aMtw1PqhcjWuGFP7pwiW2v0ks=</specializations>
+  <specializations>1YtqF4WYT0uK7amUiCmJVk03Oog=</specializations>
+  <specializations>3eTbiMMR3GPY7/xRty3EmJ9bdQU=</specializations>
+  <specializations>3jBuzbuFB0fvpQa1ETvIXevGH2w=</specializations>
+  <specializations>9PQcUNZCJePNJhT5t0prZNV/lHk=</specializations>
 </record>
 <record>
   <name>S8</name>
@@ -2750,6 +2888,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>CvFJnK9Xu7B2Fbh91NqM0+gKVEU=</specializations>
+  <specializations>hwfbdkFRNunC/3V+s6HA5BwWiSQ=</specializations>
+  <specializations>8PQtbs9xGpu1L+b0VOqfLlE6TnY=</specializations>
 </record>
 <function>
   <name>f9</name>
@@ -2980,6 +3121,17 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>JnRKKJOV9sM2/Wi7ytI5OenLTcs=</specializations>
+  <specializations>Lu2i8tgrw9I5p6DXmX9LfM8mVSo=</specializations>
+  <specializations>OsUzyKi8NDCZFI1r1y4+Ki/4H0s=</specializations>
+  <specializations>Xes4IqvFnQoGkxPlP4C4wtbjqxQ=</specializations>
+  <specializations>ZyL4aBHmvCmfq+HyxDSySKwRsdA=</specializations>
+  <specializations>eWg27/kfn86dUmPA26mcOo6kkfs=</specializations>
+  <specializations>g2iVCce1Dp6iPMyevfuMN/UU9F0=</specializations>
+  <specializations>p3PhPnVydwdupHBMAXlcrNQuiFo=</specializations>
+  <specializations>tcws+2wcXL0FEmvv7ZVXvxSkAaI=</specializations>
+  <specializations>zpDyI51RjdguXF8/9KXFrICQwEc=</specializations>
+  <specializations>8snJ9gp5ca88/AsWGEnFe6Ln6RQ=</specializations>
 </record>
 <record>
   <name>S3</name>
@@ -3079,6 +3231,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>J3UZDljdSJ1mGU9Js0JpA3TjVtc=</specializations>
+  <specializations>cV4O7e/J4xug1ZmsOQKwDVjE99M=</specializations>
+  <specializations>yPCRvP9B34hMThomBKlaCzkFM54=</specializations>
 </record>
 <function>
   <name>f4</name>
@@ -3200,6 +3355,25 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>IhITMrVguwgsTFnxWSalhrn5lnw=</specializations>
+  <specializations>I29LgIfKHs2KVKydoPZ2XncISyM=</specializations>
+  <specializations>NnzxSBCBz0/s6OkCTTL/yDO06Go=</specializations>
+  <specializations>RFQpd+7V+unGQTgk13maA1YEoyY=</specializations>
+  <specializations>XLAZYk894KbFFFIzJpR6c2Fi870=</specializations>
+  <specializations>dO93MwJZmA5Fpzul37ZMH6F1ong=</specializations>
+  <specializations>fpqbvQR9NuaJY4fq9LHbiAsZKzw=</specializations>
+  <specializations>hpAmCOpzad0YvzIs/nrK1blINCo=</specializations>
+  <specializations>j53XjxydcG+wI0iK3mM8/acK5rY=</specializations>
+  <specializations>lmGGu3RmJh5DZfXs5nd811FPf14=</specializations>
+  <specializations>s40Z8yfzcJnCZSeYYV5sYlFzOxs=</specializations>
+  <specializations>tZqwapq24sWOnWsHAcGXH/3yX3Y=</specializations>
+  <specializations>uE1JLlP4kj18/7anYGDOOUyNK5M=</specializations>
+  <specializations>umZ8gPZZ+qTWuYY3zYO/hx1XCGI=</specializations>
+  <specializations>wpJv75dxyLgHOdHJsb50f1IIDVc=</specializations>
+  <specializations>1ro4Sv8wGUNxysGIgXgcl9hcP68=</specializations>
+  <specializations>51FuSsXmA0w505ZBRVkx0q/lmUk=</specializations>
+  <specializations>+J66oroZ92MSPf/1vk3672IXQRM=</specializations>
+  <specializations>+YuAVlOefcnfZIU1wckNM7lfNaA=</specializations>
 </record>
 <record>
   <name>S6</name>
@@ -3279,6 +3453,17 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>GJK8oH0tb+kOcrLsJD4KLPgW01k=</specializations>
+  <specializations>J7tgsUhd+qpsq/85qkEgF1l14uk=</specializations>
+  <specializations>NkmHmT5oAR5xJObAVl4zdPrTJPk=</specializations>
+  <specializations>VxqDdgdkcw8E86ZiNolpXLlhyWs=</specializations>
+  <specializations>V/H0waQNmYhkbcgX6kBFOODNK64=</specializations>
+  <specializations>pbmVOgtPeZtTL7BQG/AM7NVsNdo=</specializations>
+  <specializations>r7aMtw1PqhcjWuGFP7pwiW2v0ks=</specializations>
+  <specializations>1YtqF4WYT0uK7amUiCmJVk03Oog=</specializations>
+  <specializations>3eTbiMMR3GPY7/xRty3EmJ9bdQU=</specializations>
+  <specializations>3jBuzbuFB0fvpQa1ETvIXevGH2w=</specializations>
+  <specializations>9PQcUNZCJePNJhT5t0prZNV/lHk=</specializations>
 </record>
 <record>
   <name>S8</name>
@@ -3378,6 +3563,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>CvFJnK9Xu7B2Fbh91NqM0+gKVEU=</specializations>
+  <specializations>hwfbdkFRNunC/3V+s6HA5BwWiSQ=</specializations>
+  <specializations>8PQtbs9xGpu1L+b0VOqfLlE6TnY=</specializations>
 </record>
 <function>
   <name>f9</name>
@@ -4996,6 +5184,47 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>ANhUz0/2S6fRsXsZFhXPTPyPfAE=</specializations>
+  <specializations>AhWlDEmWhkTeQuWWCaZwMGCG5HQ=</specializations>
+  <specializations>A9DWlv0rbuFs3A9eHqZTaJDN7Uk=</specializations>
+  <specializations>ByHV/GlyHOt9h6ZVKpsDi/DkBkM=</specializations>
+  <specializations>FREf1tucqdONQ71W3hB/Sf/Fbw4=</specializations>
+  <specializations>IG7byGfx+stnhACpeGR2toLyv7U=</specializations>
+  <specializations>IKgocAXkFMvNmDD+p5dZpSBSRHI=</specializations>
+  <specializations>IbslzK4eUJj1gUsgbS4h/0Axavg=</specializations>
+  <specializations>IxCiCl8tf7r2/CmQWZiWxFHf7+g=</specializations>
+  <specializations>MUilGFE5YvyMgRjHIcQZ38yyl2c=</specializations>
+  <specializations>MYFk6ANWkex8j7vBuMpAqchgYIY=</specializations>
+  <specializations>MyTy/GXkOXKOTiJVqHAVVvaU4es=</specializations>
+  <specializations>PA+4gdvi0ChhszyGuOL6zlYXHpk=</specializations>
+  <specializations>Rh5ZoB5qF98iwmDPqUPnsyKkTcs=</specializations>
+  <specializations>UUBd87/k0jse5896L03eJ4N0l+c=</specializations>
+  <specializations>UpHebkkBv0Q2s1ECAoKTf79hJ0Q=</specializations>
+  <specializations>Up/SfnuYTQw+Y6klSO3f5z86DOY=</specializations>
+  <specializations>WK6dfZ+3VdrJbp4Egq7SCGyoAF8=</specializations>
+  <specializations>Wu710hbNOx84LbfjQUEgqKkZ2dA=</specializations>
+  <specializations>a69mw641E3cHVf6ovpLtJxTpmps=</specializations>
+  <specializations>c7NNZfjOZ8Ztuw0u26xL/h7UKvA=</specializations>
+  <specializations>eiJusMAs3cvoF4DWqUBlAfXzYcA=</specializations>
+  <specializations>flxREiXFL5ObY0xUAxojj+jvR54=</specializations>
+  <specializations>hwWIBHTi29w+6bJar0PyQvwnZWw=</specializations>
+  <specializations>kn1OyT1FzAvXXJMp4nKleaEX+5c=</specializations>
+  <specializations>nJGs54s6oYf7fHzIpo0tyaCSH9M=</specializations>
+  <specializations>niyoFejCRrpY1Aa9GHwGMnaDfsQ=</specializations>
+  <specializations>nkoZM9sg9xpibNb1eDSyhqn/Ato=</specializations>
+  <specializations>nuqq8wSa/4T9E2xaPl/SzBPbekM=</specializations>
+  <specializations>oXfsqUlMzPbEZZJ7K+iZYQj3wko=</specializations>
+  <specializations>oj8XjM2vuWbeoc2sBpfsIoleCao=</specializations>
+  <specializations>o06yQpJHyCkZyFI44/nN8/tpgT8=</specializations>
+  <specializations>pxo3Lx5X+FdLdaGOmXmAiuNVQME=</specializations>
+  <specializations>tuaR3CreZXFWLNOiRe6vUMcdi/0=</specializations>
+  <specializations>uoCdOuqB1v1s6rvl4wDWcLrD4LA=</specializations>
+  <specializations>vt6SAnqggizkWUqtSC5b9rVm+Qw=</specializations>
+  <specializations>xONzwxGiMBJrTYA5eosi4pOC0n0=</specializations>
+  <specializations>x7MfNbWaSdnUCRBlHt+nSvOlEPw=</specializations>
+  <specializations>zYIKjNzi/kYNKvtrTXu8BhQTFt8=</specializations>
+  <specializations>1gjCMmREpyWTXEFMqDWbHTY9s+Q=</specializations>
+  <specializations>7v/tytUkZe7COeYW1bbrzC9LRio=</specializations>
 </record>
 <record>
   <name>S1</name>
@@ -5075,6 +5304,17 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>JnRKKJOV9sM2/Wi7ytI5OenLTcs=</specializations>
+  <specializations>Lu2i8tgrw9I5p6DXmX9LfM8mVSo=</specializations>
+  <specializations>OsUzyKi8NDCZFI1r1y4+Ki/4H0s=</specializations>
+  <specializations>Xes4IqvFnQoGkxPlP4C4wtbjqxQ=</specializations>
+  <specializations>ZyL4aBHmvCmfq+HyxDSySKwRsdA=</specializations>
+  <specializations>eWg27/kfn86dUmPA26mcOo6kkfs=</specializations>
+  <specializations>g2iVCce1Dp6iPMyevfuMN/UU9F0=</specializations>
+  <specializations>p3PhPnVydwdupHBMAXlcrNQuiFo=</specializations>
+  <specializations>tcws+2wcXL0FEmvv7ZVXvxSkAaI=</specializations>
+  <specializations>zpDyI51RjdguXF8/9KXFrICQwEc=</specializations>
+  <specializations>8snJ9gp5ca88/AsWGEnFe6Ln6RQ=</specializations>
 </record>
 <record>
   <name>S3</name>
@@ -5174,6 +5414,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>J3UZDljdSJ1mGU9Js0JpA3TjVtc=</specializations>
+  <specializations>cV4O7e/J4xug1ZmsOQKwDVjE99M=</specializations>
+  <specializations>yPCRvP9B34hMThomBKlaCzkFM54=</specializations>
 </record>
 <function>
   <name>f4</name>
@@ -5295,6 +5538,25 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>IhITMrVguwgsTFnxWSalhrn5lnw=</specializations>
+  <specializations>I29LgIfKHs2KVKydoPZ2XncISyM=</specializations>
+  <specializations>NnzxSBCBz0/s6OkCTTL/yDO06Go=</specializations>
+  <specializations>RFQpd+7V+unGQTgk13maA1YEoyY=</specializations>
+  <specializations>XLAZYk894KbFFFIzJpR6c2Fi870=</specializations>
+  <specializations>dO93MwJZmA5Fpzul37ZMH6F1ong=</specializations>
+  <specializations>fpqbvQR9NuaJY4fq9LHbiAsZKzw=</specializations>
+  <specializations>hpAmCOpzad0YvzIs/nrK1blINCo=</specializations>
+  <specializations>j53XjxydcG+wI0iK3mM8/acK5rY=</specializations>
+  <specializations>lmGGu3RmJh5DZfXs5nd811FPf14=</specializations>
+  <specializations>s40Z8yfzcJnCZSeYYV5sYlFzOxs=</specializations>
+  <specializations>tZqwapq24sWOnWsHAcGXH/3yX3Y=</specializations>
+  <specializations>uE1JLlP4kj18/7anYGDOOUyNK5M=</specializations>
+  <specializations>umZ8gPZZ+qTWuYY3zYO/hx1XCGI=</specializations>
+  <specializations>wpJv75dxyLgHOdHJsb50f1IIDVc=</specializations>
+  <specializations>1ro4Sv8wGUNxysGIgXgcl9hcP68=</specializations>
+  <specializations>51FuSsXmA0w505ZBRVkx0q/lmUk=</specializations>
+  <specializations>+J66oroZ92MSPf/1vk3672IXQRM=</specializations>
+  <specializations>+YuAVlOefcnfZIU1wckNM7lfNaA=</specializations>
 </record>
 <record>
   <name>S6</name>
@@ -5374,6 +5636,17 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>GJK8oH0tb+kOcrLsJD4KLPgW01k=</specializations>
+  <specializations>J7tgsUhd+qpsq/85qkEgF1l14uk=</specializations>
+  <specializations>NkmHmT5oAR5xJObAVl4zdPrTJPk=</specializations>
+  <specializations>VxqDdgdkcw8E86ZiNolpXLlhyWs=</specializations>
+  <specializations>V/H0waQNmYhkbcgX6kBFOODNK64=</specializations>
+  <specializations>pbmVOgtPeZtTL7BQG/AM7NVsNdo=</specializations>
+  <specializations>r7aMtw1PqhcjWuGFP7pwiW2v0ks=</specializations>
+  <specializations>1YtqF4WYT0uK7amUiCmJVk03Oog=</specializations>
+  <specializations>3eTbiMMR3GPY7/xRty3EmJ9bdQU=</specializations>
+  <specializations>3jBuzbuFB0fvpQa1ETvIXevGH2w=</specializations>
+  <specializations>9PQcUNZCJePNJhT5t0prZNV/lHk=</specializations>
 </record>
 <record>
   <name>S8</name>
@@ -5473,6 +5746,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>CvFJnK9Xu7B2Fbh91NqM0+gKVEU=</specializations>
+  <specializations>hwfbdkFRNunC/3V+s6HA5BwWiSQ=</specializations>
+  <specializations>8PQtbs9xGpu1L+b0VOqfLlE6TnY=</specializations>
 </record>
 <function>
   <name>f9</name>
@@ -5620,6 +5896,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S0</name>
@@ -5654,6 +5931,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -5766,6 +6044,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S3</name>
@@ -6000,6 +6279,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -6112,6 +6392,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S3</name>
@@ -6218,6 +6499,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>f2</name>
@@ -6371,6 +6653,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -6485,6 +6768,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S3</name>
@@ -6603,6 +6887,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S4</name>
@@ -6650,6 +6935,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>f2</name>
@@ -6804,6 +7090,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -6943,6 +7230,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -7049,6 +7337,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>f0</name>
@@ -7106,6 +7395,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -7247,6 +7537,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -7365,6 +7656,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S5</name>
@@ -7412,6 +7704,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>f0</name>
@@ -7470,6 +7763,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -7577,6 +7871,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -7689,6 +7984,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -7796,6 +8092,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -7984,6 +8281,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -8091,6 +8389,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -8214,6 +8513,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S7</name>
@@ -8261,6 +8561,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>f6</name>
@@ -8364,6 +8665,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -8579,6 +8881,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -8686,6 +8989,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -8795,6 +9099,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>f6</name>
@@ -8899,6 +9204,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -9006,6 +9312,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -9117,6 +9424,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S8</name>
@@ -9325,6 +9633,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -9432,6 +9741,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -9544,6 +9854,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S8</name>
@@ -9752,6 +10063,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -9859,6 +10171,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -9973,6 +10286,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S8</name>
@@ -10091,6 +10405,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S9</name>
@@ -10138,6 +10453,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>f7</name>
@@ -10264,6 +10580,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -10373,6 +10690,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>f1</name>
@@ -10504,6 +10822,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -10611,6 +10930,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -10723,6 +11043,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S8</name>
@@ -10829,6 +11150,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>f7</name>
@@ -10955,6 +11277,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -11078,6 +11401,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S2</name>
@@ -11125,6 +11449,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>f1</name>
@@ -11255,6 +11580,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -11366,6 +11692,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S3</name>
@@ -11609,6 +11936,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S0</name>
@@ -11652,6 +11980,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -11772,6 +12101,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S3</name>
@@ -12009,6 +12339,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -12130,6 +12461,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S3</name>
@@ -12367,6 +12699,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -12488,6 +12821,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S3</name>
@@ -12725,6 +13059,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -12867,6 +13202,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -13008,6 +13344,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -13225,6 +13562,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -13367,6 +13705,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -13483,6 +13822,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -13673,6 +14013,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -13789,6 +14130,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -13979,6 +14321,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -14095,6 +14438,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -14285,6 +14629,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -14502,6 +14847,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -14618,6 +14964,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -14809,6 +15156,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -14925,6 +15273,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -15045,6 +15394,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S8</name>
@@ -15280,6 +15630,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -15396,6 +15747,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -15516,6 +15868,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S8</name>
@@ -15727,6 +16080,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -15843,6 +16197,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -15964,6 +16319,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S8</name>
@@ -16174,6 +16530,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -16392,6 +16749,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -16508,6 +16866,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S6</name>
@@ -16629,6 +16988,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S8</name>
@@ -16839,6 +17199,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -17056,6 +17417,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -17176,6 +17538,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S3</name>
@@ -17441,5 +17804,6 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 </mrdocs>

--- a/test-files/golden-tests/symbols/record/class-template-specializations-2.xml
+++ b/test-files/golden-tests/symbols/record/class-template-specializations-2.xml
@@ -44,6 +44,9 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>K6BawvzqAtXZLU2Hm0qPq6aGiS8=</specializations>
+  <specializations>Nkvb8FA0/0YIpaybicEkWLwFOPo=</specializations>
+  <specializations>bcCFiKKGBMnWrAf/IBu1R/sC07s=</specializations>
 </record>
 <record>
   <name>A</name>
@@ -83,6 +86,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>D</name>
@@ -116,6 +120,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>RdjbfZA0y514GFSR1pCAjUyfq24=</specializations>
+  <specializations>flW1A8++hJYAIoinZHMJ/EargvI=</specializations>
 </record>
 <record>
   <name>E</name>
@@ -147,6 +153,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>HzSR9lAhcaSZke6x6ggUIqnawQw=</specializations>
+  <specializations>TpBRSCUm33PjLoWxW50FZsR1GSM=</specializations>
 </record>
 <record>
   <name>E</name>
@@ -191,6 +199,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>F</name>
@@ -253,6 +262,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>G</name>
@@ -284,6 +294,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>zPgrcrIOrcVWP7Qpw8x3Zl2fIpI=</specializations>
 </record>
 <record>
   <name>G</name>
@@ -327,6 +338,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>D</name>
@@ -365,6 +377,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>E</name>
@@ -435,6 +448,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>F</name>
@@ -506,6 +520,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -573,6 +588,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -612,6 +628,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -688,6 +705,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -719,6 +737,10 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>HP4W/UatJ6BMg+LZKC5cQM4kCzw=</specializations>
+  <specializations>WeO5ITJRmNS4Q90O2A5hmw/KZc8=</specializations>
+  <specializations>vuv6bo9spUYsHZ3uwTm6i6UxSNI=</specializations>
+  <specializations>3isZeaf80hT1/O3yko6EPBPmq8s=</specializations>
 </record>
 <record>
   <name>B</name>
@@ -755,6 +777,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -799,6 +822,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>

--- a/test-files/golden-tests/symbols/record/class-template-specializations-3.xml
+++ b/test-files/golden-tests/symbols/record/class-template-specializations-3.xml
@@ -48,6 +48,10 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>C6fFmGgpPJ7jgwKJA98mfx5cxts=</specializations>
+  <specializations>GFV3P/JtfrnQwjOLVfI9VbJpd9U=</specializations>
+  <specializations>eeh34/7lF7rCmE7zXKBrUC7mz3A=</specializations>
+  <specializations>y/8TvVlacBAIG2ds2aYgZE+zGUU=</specializations>
 </record>
 <record>
   <name>B</name>
@@ -82,6 +86,12 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>AmrHzqMyGcAD714oirSEx/XCTwk=</specializations>
+  <specializations>Ax52oDYNHKdb/kayrTPXtP7EnLo=</specializations>
+  <specializations>Pna+OT/o27zekcoRTFxKtb5m+BQ=</specializations>
+  <specializations>X9RyjucPb3aRFUq3aZCNE4g/ZVE=</specializations>
+  <specializations>fSC2izK+T4vA4Kndw3xNjCTDpoQ=</specializations>
+  <specializations>gNJJgsCrBHI+de6/WxRWfc6QUSQ=</specializations>
 </record>
 <record>
   <name>C</name>
@@ -137,6 +147,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>E3rBDckOC8QkP+2YLNtbMxg69mc=</specializations>
+  <specializations>8gtdVs8Zc/2hE1ugmc5SJaowDrk=</specializations>
 </record>
 <record>
   <name>D</name>
@@ -173,6 +185,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -212,6 +225,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -267,6 +281,11 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>FQCRWOnd4VbpVowmyiWSRR2l2cA=</specializations>
+  <specializations>P+rxL5vI4ct+gzn9YkO97Pt7Ras=</specializations>
+  <specializations>rzmzIDLemEwnRqvVCiQsLO9rHE4=</specializations>
+  <specializations>2n2EC+ZzX4R61vVgqMqWD1h4Fqc=</specializations>
+  <specializations>9bJvdwRZpk2+HRV+Az3lOybs1Wc=</specializations>
 </record>
 <record>
   <name>D</name>
@@ -303,6 +322,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>A</name>
@@ -341,6 +361,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -411,6 +432,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -502,6 +524,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>A</name>
@@ -541,6 +564,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -581,6 +605,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>jvnZWmA3eB78JX83nJawhD8NGhw=</specializations>
+  <specializations>3fOXhba/en8Im2gUSThzllitRc0=</specializations>
 </record>
 <record>
   <name>C</name>
@@ -636,6 +662,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>NNxnP63PrqW2AkyLFpJx0uaNuTk=</specializations>
+  <specializations>vu+upAyFdAr9NpomAT9maDrr5VU=</specializations>
 </record>
 <record>
   <name>D</name>
@@ -672,6 +700,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -711,6 +740,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -802,6 +832,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -841,6 +872,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -932,6 +964,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>A</name>
@@ -971,6 +1004,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -1041,6 +1075,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -1132,6 +1167,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -1171,6 +1207,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -1226,6 +1263,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>eYdoT3vlHlbkG+t3+ckhZAqrnlY=</specializations>
 </record>
 <record>
   <name>D</name>
@@ -1262,6 +1300,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>A</name>
@@ -1301,6 +1340,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -1371,6 +1411,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -1462,6 +1503,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -1501,6 +1543,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>C</name>
@@ -1592,6 +1635,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>E</name>

--- a/test-files/golden-tests/symbols/record/specializations-and-guides.adoc
+++ b/test-files/golden-tests/symbols/record/specializations-and-guides.adoc
@@ -1,0 +1,124 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Types
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#A-0e[`A`] 
+| Primary class template&period;
+| link:#B-00[`B`] 
+| Class template with a deduction guide&period;
+|===
+
+
+[#A-0e]
+== A
+
+Primary class template&period;
+
+=== Synopsis
+
+Declared in `&lt;specializations&hyphen;and&hyphen;guides&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;typename T&gt;
+struct A;
+----
+
+=== Member Functions
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#A-0e-f[`f`] 
+| A member function&period;
+|===
+
+
+=== Specializations
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#A-00[`A&lt;int&gt;`] 
+| Explicit specialization of the primary&period;
+|===
+
+
+[#A-0e-f]
+== link:#A-0e[A]::f
+
+A member function&period;
+
+=== Synopsis
+
+Declared in `&lt;specializations&hyphen;and&hyphen;guides&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+f();
+----
+
+[#A-00]
+== link:#A-0e[A]&lt;int&gt;
+
+Explicit specialization of the primary&period;
+
+=== Synopsis
+
+Declared in `&lt;specializations&hyphen;and&hyphen;guides&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;&gt;
+struct link:#A-0e[A]&lt;int&gt;;
+----
+
+[#B-00]
+== B
+
+Class template with a deduction guide&period;
+
+=== Synopsis
+
+Declared in `&lt;specializations&hyphen;and&hyphen;guides&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;int&gt;
+struct B;
+----
+
+=== Deduction Guides
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#B-0c[`B&lt;0&gt;`] 
+| Deduction guide for B&period;
+|===
+
+
+[#B-0c]
+== link:#B-00[B&lt;0&gt;]
+
+Deduction guide for B&period;
+
+=== Synopsis
+
+Declared in `&lt;specializations&hyphen;and&hyphen;guides&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+link:#B-00[B&lt;0&gt;](bool) -> link:#B-00[B&lt;0&gt;];
+----
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/symbols/record/specializations-and-guides.cpp
+++ b/test-files/golden-tests/symbols/record/specializations-and-guides.cpp
@@ -1,0 +1,22 @@
+/// Primary class template.
+template <typename T>
+struct A
+{
+    /// A member function.
+    void f();
+};
+
+/// Explicit specialization of the primary.
+template <>
+struct A<int>
+{
+};
+
+/// Class template with a deduction guide.
+template <int>
+struct B
+{
+};
+
+/// Deduction guide for B.
+B(bool) -> B<0>;

--- a/test-files/golden-tests/symbols/record/specializations-and-guides.yml
+++ b/test-files/golden-tests/symbols/record/specializations-and-guides.yml
@@ -1,0 +1,1 @@
+generator: adoc

--- a/test-files/golden-tests/symbols/record/template-specialization-inheritance.xml
+++ b/test-files/golden-tests/symbols/record/template-specialization-inheritance.xml
@@ -276,6 +276,10 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>c7NNZfjOZ8Ztuw0u26xL/h7UKvA=</specializations>
+  <specializations>flxREiXFL5ObY0xUAxojj+jvR54=</specializations>
+  <specializations>nJGs54s6oYf7fHzIpo0tyaCSH9M=</specializations>
+  <specializations>6Syw3aWFS3pfPUbWU7C8uCE7Jjc=</specializations>
 </record>
 <record>
   <name>S1</name>
@@ -332,6 +336,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -389,6 +394,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S0</name>
@@ -421,6 +427,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S1</name>
@@ -476,5 +483,6 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 </mrdocs>

--- a/test-files/golden-tests/symbols/typedef/decay-to-primary.xml
+++ b/test-files/golden-tests/symbols/typedef/decay-to-primary.xml
@@ -103,6 +103,8 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>BWgkCsMw6w/Tkzj0tkQJ8/AWTUo=</specializations>
+  <specializations>nM49pHyBLj9V6pphxxYAxi4tXXc=</specializations>
 </record>
 <typedef>
   <name>M0</name>
@@ -193,6 +195,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <typedef>
   <name>M0</name>
@@ -283,6 +286,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <typedef>
   <name>M0</name>

--- a/test-files/golden-tests/symbols/typedef/implicit-instantiation-member-ref.xml
+++ b/test-files/golden-tests/symbols/typedef/implicit-instantiation-member-ref.xml
@@ -111,6 +111,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>BWgkCsMw6w/Tkzj0tkQJ8/AWTUo=</specializations>
 </record>
 <record>
   <name>S2</name>
@@ -144,6 +145,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>LQDMND21bNwDyy/hE3qQoQzFLXY=</specializations>
 </record>
 <typedef>
   <name>M2</name>
@@ -234,6 +236,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>S2</name>
@@ -303,6 +306,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <typedef>
   <name>M2</name>

--- a/test-files/golden-tests/symbols/using/using-alias-template-dependent.xml
+++ b/test-files/golden-tests/symbols/using/using-alias-template-dependent.xml
@@ -130,6 +130,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>6f4GHawhlUckr08SJkt7su9cIDY=</specializations>
 </record>
 <typedef>
   <name>type</name>
@@ -197,6 +198,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>is_match</name>

--- a/test-files/golden-tests/templates/c_mct_expl_inline.xml
+++ b/test-files/golden-tests/templates/c_mct_expl_inline.xml
@@ -68,6 +68,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>FxMFFVpoV2/LOOndnkQ2gu3w69U=</specializations>
 </record>
 <function>
   <name>f</name>
@@ -128,6 +129,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>g</name>

--- a/test-files/golden-tests/templates/c_mct_expl_outside.xml
+++ b/test-files/golden-tests/templates/c_mct_expl_outside.xml
@@ -68,6 +68,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>FxMFFVpoV2/LOOndnkQ2gu3w69U=</specializations>
 </record>
 <function>
   <name>f</name>
@@ -128,6 +129,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>g</name>

--- a/test-files/golden-tests/templates/c_mft_expl_inline.xml
+++ b/test-files/golden-tests/templates/c_mft_expl_inline.xml
@@ -89,6 +89,7 @@
   </template>
   <func-class>normal</func-class>
   <is-record-method>1</is-record-method>
+  <specializations>veV2posfyuimiNezTTVnomiz6tY=</specializations>
 </function>
 <function>
   <name>f</name>
@@ -124,5 +125,6 @@
   </template>
   <func-class>normal</func-class>
   <is-record-method>1</is-record-method>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </function>
 </mrdocs>

--- a/test-files/golden-tests/templates/c_mft_expl_outside.xml
+++ b/test-files/golden-tests/templates/c_mft_expl_outside.xml
@@ -89,6 +89,7 @@
   </template>
   <func-class>normal</func-class>
   <is-record-method>1</is-record-method>
+  <specializations>veV2posfyuimiNezTTVnomiz6tY=</specializations>
 </function>
 <function>
   <name>f</name>
@@ -124,5 +125,6 @@
   </template>
   <func-class>normal</func-class>
   <is-record-method>1</is-record-method>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </function>
 </mrdocs>

--- a/test-files/golden-tests/templates/ct_expl.xml
+++ b/test-files/golden-tests/templates/ct_expl.xml
@@ -43,6 +43,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>AKwlChAOi+0ttIAPsD7uitS+gk0=</specializations>
 </record>
 <function>
   <name>f</name>
@@ -103,6 +104,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>g</name>

--- a/test-files/golden-tests/templates/ct_mc_expl_outside.xml
+++ b/test-files/golden-tests/templates/ct_mc_expl_outside.xml
@@ -43,6 +43,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>AKwlChAOi+0ttIAPsD7uitS+gk0=</specializations>
 </record>
 <record>
   <name>B</name>
@@ -128,6 +129,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>

--- a/test-files/golden-tests/templates/ct_mct_expl_inline.xml
+++ b/test-files/golden-tests/templates/ct_mct_expl_inline.xml
@@ -75,6 +75,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>bHsbts/3qH4qdnqFkFXkR6e8OCw=</specializations>
 </record>
 <function>
   <name>f</name>
@@ -135,6 +136,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>g</name>

--- a/test-files/golden-tests/templates/ct_mct_expl_outside.xml
+++ b/test-files/golden-tests/templates/ct_mct_expl_outside.xml
@@ -43,6 +43,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>AKwlChAOi+0ttIAPsD7uitS+gk0=</specializations>
 </record>
 <record>
   <name>B</name>
@@ -75,6 +76,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>IMS2etMN5nj/r7pRC8mVNme6K+o=</specializations>
 </record>
 <function>
   <name>f</name>
@@ -136,6 +138,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <record>
   <name>B</name>
@@ -204,6 +207,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>g</name>

--- a/test-files/golden-tests/templates/ct_mf_expl_outside.xml
+++ b/test-files/golden-tests/templates/ct_mf_expl_outside.xml
@@ -43,6 +43,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>AKwlChAOi+0ttIAPsD7uitS+gk0=</specializations>
 </record>
 <function>
   <name>f</name>
@@ -103,6 +104,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <function>
   <name>f</name>

--- a/test-files/golden-tests/templates/ct_mft_expl_inline.xml
+++ b/test-files/golden-tests/templates/ct_mft_expl_inline.xml
@@ -96,6 +96,7 @@
   </template>
   <func-class>normal</func-class>
   <is-record-method>1</is-record-method>
+  <specializations>TneA5Ayz4v/9oOUbbnRL1ybm8VM=</specializations>
 </function>
 <function>
   <name>f</name>
@@ -131,5 +132,6 @@
   </template>
   <func-class>normal</func-class>
   <is-record-method>1</is-record-method>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </function>
 </mrdocs>

--- a/test-files/golden-tests/templates/ct_mft_expl_outside.xml
+++ b/test-files/golden-tests/templates/ct_mft_expl_outside.xml
@@ -43,6 +43,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <specializations>AKwlChAOi+0ttIAPsD7uitS+gk0=</specializations>
 </record>
 <function>
   <name>f</name>
@@ -73,6 +74,7 @@
   </template>
   <func-class>normal</func-class>
   <is-record-method>1</is-record-method>
+  <specializations>fjcm9F09lrCrLSgw6Swqw9KOBlM=</specializations>
 </function>
 <record>
   <name>A</name>
@@ -110,6 +112,7 @@
     <record-tranche>
     </record-tranche>
   </record-interface>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </record>
 <overloads>
   <name>f</name>
@@ -205,5 +208,6 @@
   </template>
   <func-class>normal</func-class>
   <is-record-method>1</is-record-method>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </function>
 </mrdocs>

--- a/test-files/golden-tests/templates/ft_expl.xml
+++ b/test-files/golden-tests/templates/ft_expl.xml
@@ -63,6 +63,7 @@
     </type-tparam>
   </template>
   <func-class>normal</func-class>
+  <specializations>ytuvwgqk+lakIfCF209MYkKEp4k=</specializations>
 </function>
 <function>
   <name>f</name>
@@ -97,5 +98,6 @@
     <primary>PmhXjCXUJYVnj/a7NhfjjSesyp0=</primary>
   </template>
   <func-class>normal</func-class>
+  <is-listed-on-primary>1</is-listed-on-primary>
 </function>
 </mrdocs>


### PR DESCRIPTION
Class template specializations, function template specializations, and deduction guides used to share the enclosing scope's listing with their primary template. Users have repeatedly reported this as confusing: `A` and `A<int>` appearing side by side in the namespace index reads as if they were independent siblings; and a primary's variants were nowhere on its own page.

Specializations now appear in a dedicated "Specializations" section on the primary's documentation page, and deduction guides in a "Deduction Guides" section on the deduced class's page. The parent scope's listing carries only the primary itself. An orphan specialization (one whose primary has been excluded from extraction) stays in the parent's listing so the index can still reach it.

Closes issue #1154.

[danger skip docs].

-------

## Summary

This moves class template specializations, function template specializations, and deduction guides off the enclosing scope's listing and onto the primary template's own documentation page.

After this PR:

- Each primary's documentation page gains a "Specializations" section listing the specializations of that primary.
- Each deduced class's page gains a "Deduction Guides" section listing the guides that deduce it.
- The parent scope's listing carries only the primary, not its specializations/guides.
- An orphan specialization (one whose primary has been excluded from extraction) stays in the parent's listing, so the index can still reach it.

The primary-to-variant link is corpus-resident: `RecordSymbol` and `FunctionSymbol` gain `Specializations` (and, on records, `DeductionGuides`) lists plus an `IsListedOnPrimary` flag. Populated by a new `SpecializationFinalizer` pass. Every Handlebars template, schema consumer, and downstream tool that reads the corpus sees the new shape automatically through reflection.

## Changes

- **Source**: A new finalizer at src/lib/Metadata/Finalizers/SpecializationFinalizer.{cpp,hpp} populates the back-pointers and sorts them. include/mrdocs/Metadata/Symbol/Function.hpp and include/mrdocs/Metadata/Symbol/Record.hpp declare the new fields and add them to their `MRDOCS_DESCRIBE_STRUCT` lists so reflection picks them up. src/lib/Support/Handlebars.cpp gains a `filter_out` helper (mirroring the existing `filter_by`) used by the parent-tranche template to drop entries listed elsewhere. Templates are updated under share/mrdocs/addons/: common/partials/symbol/tranche.hbs (the per-tranche listing that no longer prints specializations alongside the primary), and the per-format adoc/partials/symbol.adoc.hbs and html/partials/symbol.html.hbs render the new "Specializations" / "Deduction Guides" sections.
- **Tests**: All exercised through golden tests; no separate unit tests added.
- **Golden tests**: HTML and adoc golden-test fixtures are updated across test-files/golden-tests/symbols/, test-files/golden-tests/config/, test-files/golden-tests/templates/, test-files/golden-tests/javadoc/, and test-files/golden-tests/filters/ to reflect the new layout. The XML fixtures also gain new tags (`<specializations>`, `<deduction-guides>`, `<is-listed-on-primary>`) emitted by the reflection-driven XML writer for the new fields.
- **Breaking changes**: None. The XML output and metadata schema gain additive elements (`<specializations>`, `<deduction-guides>`, `<is-listed-on-primary>`); readers that don't know about them are unaffected. The rendered HTML / AsciiDoc output for templates changes: downstream tooling that scrapes the parent scope's listing and expects to find specializations or deduction guides alongside the primary will need to look on the primary's own page instead.

## Testing

- The updated HTML, AsciiDoc, and XML golden fixtures are themselves the verification: each runs the full pipeline against a fixed .cpp input and asserts the resulting output byte-for-byte. The new `SpecializationFinalizer` is exercised through these.
- No CI workflow changes needed.

## Documentation

No user-facing documentation page is added (`[danger skip docs]`). The change is a layout / discoverability improvement for the generated documentation: it does not introduce a new option, flag, or configuration knob a user would need to look up. The new "Specializations" / "Deduction Guides" sections are self-describing in the rendered output.