### PR TITLE
fix: clang resource directory missing from release packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,12 +412,15 @@ endif()
 
 # Replicate the clang resource directory structure within our own build,
 # so that libclang will find it when executing directly from the build directory.
-# The installed binary will use runtime path resolution to locate the resource directory
-# relative to the executable, so both LLVM and MrDocs must be installed to the same prefix.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "bin")
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib/clang")
 set(RESOURCE_DIR "lib/clang/${Clang_VERSION_MAJOR}")
 file(CREATE_LINK "${LLVM_BINARY_DIR}/${RESOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_DIR}" SYMBOLIC)
+if (NOT EXISTS "${LLVM_BINARY_DIR}/${RESOURCE_DIR}/include")
+    message(FATAL_ERROR
+            "Clang resource headers (${LLVM_BINARY_DIR}/${RESOURCE_DIR}/include) do not exist.\n"
+            "Please provide an LLVM install that contains the clang resource directory.\n")
+endif()
 
 #-------------------------------------------------
 #
@@ -827,6 +830,9 @@ if (MRDOCS_INSTALL)
             FILES_MATCHING PATTERN "*")
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/share/mrdocs/headers/libc-stubs/
             DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/mrdocs/headers/libc-stubs
+            FILES_MATCHING PATTERN "*")
+    install(DIRECTORY ${LLVM_BINARY_DIR}/${RESOURCE_DIR}/include
+            DESTINATION ${RESOURCE_DIR}
             FILES_MATCHING PATTERN "*")
 
     foreach (share_mrdocs_dir addons)

--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -110,6 +110,16 @@
       "title": "Output an embeddable document",
       "type": "boolean"
     },
+    "error-on-empty-corpus": {
+      "default": true,
+      "description": "When set to `true`, MrDocs treats an empty corpus as a hard error and exits with a failure status instead of emitting a warning and succeeding. An empty corpus usually means no symbols were extracted, which is rarely intended in CI, so this turns that silent success into a detectable failure. This escalation applies regardless of the `warn-as-error` option.",
+      "enum": [
+        true,
+        false
+      ],
+      "title": "Treat an empty corpus as an error",
+      "type": "boolean"
+    },
     "exclude": {
       "default": [],
       "description": "Symbols defined in files in these directories are not extracted even if they are in the list of include directories. When relative, the paths are relative to the directory of the mrdocs configuration file. For instance, \"include/experimental\" will exclude all files in the directory `<config-dir>/include/experimental`.",

--- a/src/lib/ConfigOptions.json
+++ b/src/lib/ConfigOptions.json
@@ -655,6 +655,13 @@
         "default": false
       },
       {
+        "name": "error-on-empty-corpus",
+        "brief": "Treat an empty corpus as an error",
+        "details": "When set to `true`, MrDocs treats an empty corpus as a hard error and exits with a failure status instead of emitting a warning and succeeding. An empty corpus usually means no symbols were extracted, which is rarely intended in CI, so this turns that silent success into a detectable failure. This escalation applies regardless of the `warn-as-error` option.",
+        "type": "bool",
+        "default": true
+      },
+      {
         "name": "concurrency",
         "brief": "Number of threads to use",
         "details": "The desired level of concurrency: 0 for hardware-suggested.",

--- a/src/tool/GenerateAction.cpp
+++ b/src/tool/GenerateAction.cpp
@@ -98,6 +98,11 @@ DoGenerateAction(
         CorpusImpl::build(config, compilationDatabase));
     if (corpus->empty())
     {
+        if (settings.errorOnEmptyCorpus)
+        {
+            report::error("Corpus is empty, not generating docs");
+            return Unexpected(Error("Corpus is empty, not generating docs"));
+        }
         report::warn("Corpus is empty, not generating docs");
         return {};
     }

--- a/test-files/golden-tests/core/libcxx.cpp
+++ b/test-files/golden-tests/core/libcxx.cpp
@@ -150,3 +150,17 @@ template <typename T>
 std::enable_if_t<std::is_integral_v<T>, T>
 sqrt(T value);
 
+// Regression guard for the bundled clang resource directory.
+//
+// `::max_align_t` is supplied only by clang's builtin <stddef.h>, which lives
+// in the clang resource directory. The bundled libc-stubs deliberately leaves
+// it to the compiler in C++ mode (see headers/libc-stubs/stddef.h: it defines
+// `__no_need_max_align_t` for C++11+ on non-Apple, non-MSVC targets), and
+// libc++ pulls it in via `using ::max_align_t` while parsing <memory_resource>.
+// If the resource directory is missing from an install, this no longer
+// compiles, which is the failure that broke downstream builds. Keep an explicit
+// use so the dependency stays exercised even if libc++ stops touching
+// max_align_t while parsing its own headers. This is placed after sqrt so the
+// documented declarations keep their line numbers in the golden fixtures.
+static_assert(alignof(std::max_align_t) >= alignof(char));
+


### PR DESCRIPTION
Release packages stopped shipping clang's resource directory, which holds the compiler's own builtin headers (`stddef.h`, `stdarg.h`, `__stddef_max_align_t.h`, the intrinsics). [PR #1077](https://github.com/cppalliance/mrdocs/pull/1077) ([6cee4af28](https://github.com/cppalliance/mrdocs/commit/6cee4af28afe30cf6ae13b395190b201d9ccb70d)) dropped the bundling and made libclang resolve the resource directory relative to the executable, which only works when LLVM and MrDocs share an install prefix 😐. A downloaded MrDocs package has no LLVM next to it, so those headers are gone. 

The breakage stays hidden until libc++ needs them. `<memory_resource>` evaluates `alignof(max_align_t)` while parsing, and `::max_align_t` comes only from clang's builtin `<stddef.h>`. The bundled libc-stubs deliberately leaves `max_align_t` to the compiler in C++ mode on non-Apple, non-MSVC targets, so on Linux there is nothing to fall back to and the build fails. That is what broke Boost.Capy after it updated MrDocs ([failing CI run](https://github.com/cppalliance/capy/actions/runs/27235081850/job/80424872908)).

This installs the resource directory into the package at the path the binary already resolves, `<prefix>/lib/clang/<version>/include`, so the package is self-contained and no longer needs a co-installed clang.

## Changes

- **Build**: Install the clang resource directory's `include` to `<prefix>/lib/clang/<version>`, the path libclang resolves relative to the executable. Added a configure-time check that fails the build when the resource headers are absent, so a broken package can't ship silently.
- **Golden tests**: `core/libcxx.cpp` now references `max_align_t` directly so the dependency stays covered even if libc++ stops touching it during header parsing. No fixture output changed: the probe adds no documented symbol and sits after the existing declaration.

## Testing

The `core/libcxx` golden test parses the full standard library against the bundled headers and now asserts on `max_align_t`, so a host with a working resource directory stays covered. That probe can't catch the packaging regression by itself, because golden tests run the freshly built binary, which always finds a resource directory (the build-tree symlink on Linux, the system clang on macOS). An extracted release package is never run end to end, and that is the gap that let this ship. The smoke step in `ci-releases.yml` unpacks the package but only calls `mrdocs --version`. Running the installed package over a small libc++ input that needs `max_align_t` would have caught it, so it belongs in that smoke step. I can add it to this PR if you want it in scope.

## Documentation

No documentation change. The bundled headers are an implementation detail of the package, and the user-facing options (`use-system-stdlib`, `use-system-libc`) are unchanged.
