### PR TITLE
fix: nested types missing from tagfile

### DIFF
--- a/src/lib/Gen/hbs/TagfileWriter.cpp
+++ b/src/lib/Gen/hbs/TagfileWriter.cpp
@@ -182,6 +182,23 @@ writeClassLike(
     tags_.write("filename", generateFilename(I));
     if constexpr (T::isRecord())
     {
+        // Write the nested class-like members of this record
+        corpus_->traverse(I, [this]<typename U>(U const& J)
+        {
+            if (!hbs::shouldGenerate(J, corpus_.getCorpus().config))
+            {
+                return;
+            }
+
+            if (!U::isNamespace() && !U::isFunction())
+            {
+                tags_.write(
+                    "class",
+                    corpus_->qualifiedName(J),
+                    {{"kind", "class"}});
+            }
+        });
+
         // Write the function-like members of this record
         corpus_->traverse(I, [this]<typename U>(U const& J)
         {
@@ -192,6 +209,25 @@ writeClassLike(
         });
     }
     tags_.close("compound");
+
+    if constexpr (T::isRecord())
+    {
+        // Write compound elements for the nested class-like members.
+        // Only recurse into members genuinely nested in this record
+        // (Parent == I.id). Inherited members that are merely referenced
+        // resolve to the base class page and are emitted as part of the
+        // base class compound, so recursing here would duplicate them.
+        corpus_->traverse(I, [this, &I]<typename U>(U const& J)
+        {
+            if constexpr (!U::isNamespace() && !U::isFunction())
+            {
+                if (J.Parent == I.id)
+                {
+                    this->operator()(J);
+                }
+            }
+        });
+    }
 }
 
 void

--- a/test-files/golden-tests/config/tagfile/tagfile.cpp
+++ b/test-files/golden-tests/config/tagfile/tagfile.cpp
@@ -1,0 +1,28 @@
+// NOTE: This golden test enables tagfile generation to verify that types nested
+// inside a class (not just inside a namespace) get their own tagfile entry.
+// See https://github.com/cppalliance/mrdocs/issues/1232.
+
+namespace ns {
+
+/// A class containing a nested type.
+struct outer
+{
+    /// A struct nested in a class: it must get its own tagfile compound.
+    struct config
+    {
+        void apply();
+    };
+
+    /// An enum nested in a class.
+    enum class mode { a, b };
+
+    void method();
+};
+
+/// A type nested in a namespace (control: already worked before the fix).
+struct response_factory
+{
+    int make();
+};
+
+} // namespace ns

--- a/test-files/golden-tests/config/tagfile/tagfile.multipage/html/index.html
+++ b/test-files/golden-tests/config/tagfile/tagfile.multipage/html/index.html
@@ -1,0 +1,45 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1>Global namespace</h1>
+<div class="symbol">
+<div class="header">
+</div><!-- /header -->
+<h2>Namespaces</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="./ns.html"><code>ns</code></a> </td></tr>
+</tbody>
+</table>
+
+<h2 class="symbol"><a href="./ns.html">ns</a> namespace</h2>
+<div class="symbol">
+<div class="header">
+</div><!-- /header -->
+<h3 class="symbol">Types</h3>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="./ns/outer.html"><code>outer</code></a> </td><td>A class containing a nested type.</td></tr>
+<tr><td><a href="./ns/response_factory.html"><code>response_factory</code></a> </td><td>A type nested in a namespace (control: already worked before the fix).</td></tr>
+</tbody>
+</table>
+
+</div><!-- /symbol -->
+</div><!-- /symbol -->
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns.html
+++ b/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns.html
@@ -1,0 +1,30 @@
+<html lang="en">
+<head>
+<title>Reference: ns</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1>ns</h1>
+<div class="symbol">
+<div class="header">
+</div><!-- /header -->
+<h2>Types</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="./ns/outer.html"><code>outer</code></a> </td><td>A class containing a nested type.</td></tr>
+<tr><td><a href="./ns/response_factory.html"><code>response_factory</code></a> </td><td>A type nested in a namespace (control: already worked before the fix).</td></tr>
+</tbody>
+</table>
+
+</div><!-- /symbol -->
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/outer.html
+++ b/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/outer.html
@@ -1,0 +1,56 @@
+<html lang="en">
+<head>
+<title>Reference: outer</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1><a href="../ns.html">ns</a>::outer</h1>
+<div class="symbol">
+<div class="header">
+<div class="brief">
+<p>A class containing a nested type.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h2>Synopsis</h2>
+<p>Declared in <code>&lt;tagfile.cpp&gt;</code></p>
+<pre><code class="source-code cpp">struct outer;</code></pre>
+</div><!-- /synopsis -->
+<h2>Types</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="./outer/config.html"><code>config</code></a> </td><td>A struct nested in a class: it must get its own tagfile compound.</td></tr>
+</tbody>
+</table>
+
+<h2>Enums</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="./outer/mode.html"><code>mode</code></a> </td><td>An enum nested in a class.</td></tr>
+</tbody>
+</table>
+
+<h2>Member Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="./outer/method.html"><code>method</code></a> </td></tr>
+</tbody>
+</table>
+
+</div><!-- /symbol -->
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/outer/config.html
+++ b/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/outer/config.html
@@ -1,0 +1,36 @@
+<html lang="en">
+<head>
+<title>Reference: config</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1><a href="../../ns.html">ns</a>::<a href="../outer.html">outer</a>::config</h1>
+<div class="symbol">
+<div class="header">
+<div class="brief">
+<p>A struct nested in a class: it must get its own tagfile compound.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h2>Synopsis</h2>
+<p>Declared in <code>&lt;tagfile.cpp&gt;</code></p>
+<pre><code class="source-code cpp">struct config;</code></pre>
+</div><!-- /synopsis -->
+<h2>Member Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="./config/apply.html"><code>apply</code></a> </td></tr>
+</tbody>
+</table>
+
+</div><!-- /symbol -->
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/outer/config/apply.html
+++ b/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/outer/config/apply.html
@@ -1,0 +1,25 @@
+<html lang="en">
+<head>
+<title>Reference: apply</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1><a href="../../../ns.html">ns</a>::<a href="../../outer.html">outer</a>::<a href="../config.html">config</a>::apply</h1>
+<div class="symbol">
+<div class="header">
+</div><!-- /header -->
+<div class="synopsis">
+<h2>Synopsis</h2>
+<p>Declared in <code>&lt;tagfile.cpp&gt;</code></p>
+<pre><code class="source-code cpp">void
+apply();</code></pre>
+</div><!-- /synopsis -->
+</div><!-- /symbol -->
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/outer/method.html
+++ b/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/outer/method.html
@@ -1,0 +1,25 @@
+<html lang="en">
+<head>
+<title>Reference: method</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1><a href="../../ns.html">ns</a>::<a href="../outer.html">outer</a>::method</h1>
+<div class="symbol">
+<div class="header">
+</div><!-- /header -->
+<div class="synopsis">
+<h2>Synopsis</h2>
+<p>Declared in <code>&lt;tagfile.cpp&gt;</code></p>
+<pre><code class="source-code cpp">void
+method();</code></pre>
+</div><!-- /synopsis -->
+</div><!-- /symbol -->
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/outer/mode.html
+++ b/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/outer/mode.html
@@ -1,0 +1,37 @@
+<html lang="en">
+<head>
+<title>Reference: mode</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1><a href="../../ns.html">ns</a>::<a href="../outer.html">outer</a>::mode</h1>
+<div class="symbol">
+<div class="header">
+<div class="brief">
+<p>An enum nested in a class.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h2>Synopsis</h2>
+<p>Declared in <code>&lt;tagfile.cpp&gt;</code></p>
+<pre><code class="source-code cpp">enum class mode : int;</code></pre>
+</div><!-- /synopsis -->
+<h2>Members</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th></tr>
+</thead>
+<tbody>
+<tr><td><code>a</code> </td></tr>
+<tr><td><code>b</code> </td></tr>
+</tbody>
+</table>
+
+</div><!-- /symbol -->
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/response_factory.html
+++ b/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/response_factory.html
@@ -1,0 +1,36 @@
+<html lang="en">
+<head>
+<title>Reference: response_factory</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1><a href="../ns.html">ns</a>::response_factory</h1>
+<div class="symbol">
+<div class="header">
+<div class="brief">
+<p>A type nested in a namespace (control: already worked before the fix).</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h2>Synopsis</h2>
+<p>Declared in <code>&lt;tagfile.cpp&gt;</code></p>
+<pre><code class="source-code cpp">struct response_factory;</code></pre>
+</div><!-- /synopsis -->
+<h2>Member Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="./response_factory/make.html"><code>make</code></a> </td></tr>
+</tbody>
+</table>
+
+</div><!-- /symbol -->
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/response_factory/make.html
+++ b/test-files/golden-tests/config/tagfile/tagfile.multipage/html/ns/response_factory/make.html
@@ -1,0 +1,25 @@
+<html lang="en">
+<head>
+<title>Reference: make</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1><a href="../../ns.html">ns</a>::<a href="../response_factory.html">response_factory</a>::make</h1>
+<div class="symbol">
+<div class="header">
+</div><!-- /header -->
+<div class="synopsis">
+<h2>Synopsis</h2>
+<p>Declared in <code>&lt;tagfile.cpp&gt;</code></p>
+<pre><code class="source-code cpp">int
+make();</code></pre>
+</div><!-- /synopsis -->
+</div><!-- /symbol -->
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/config/tagfile/tagfile.multipage/html/reference.tag.xml
+++ b/test-files/golden-tests/config/tagfile/tagfile.multipage/html/reference.tag.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tagfile>
+<compound kind="namespace">
+  <name>ns</name>
+  <filename>ns.html</filename>
+  <class kind="class">ns::outer</class>
+  <class kind="class">ns::response_factory</class>
+</compound>
+<compound kind="class">
+  <name>ns::outer</name>
+  <filename>ns/outer.html</filename>
+  <class kind="class">ns::outer::config</class>
+  <class kind="class">ns::outer::mode</class>
+  <member kind="function">
+    <type>void</type>
+    <name>method</name>
+    <anchorfile>ns/outer/method.html</anchorfile>
+    <anchor/>
+    <arglist>()</arglist>
+  </member>
+</compound>
+<compound kind="class">
+  <name>ns::outer::config</name>
+  <filename>ns/outer/config.html</filename>
+  <member kind="function">
+    <type>void</type>
+    <name>apply</name>
+    <anchorfile>ns/outer/config/apply.html</anchorfile>
+    <anchor/>
+    <arglist>()</arglist>
+  </member>
+</compound>
+<compound kind="class">
+  <name>ns::outer::mode</name>
+  <filename>ns/outer/mode.html</filename>
+</compound>
+<compound kind="class">
+  <name>ns::response_factory</name>
+  <filename>ns/response_factory.html</filename>
+  <member kind="function">
+    <type>int</type>
+    <name>make</name>
+    <anchorfile>ns/response_factory/make.html</anchorfile>
+    <anchor/>
+    <arglist>()</arglist>
+  </member>
+</compound>
+</tagfile>

--- a/test-files/golden-tests/config/tagfile/tagfile.yml
+++ b/test-files/golden-tests/config/tagfile/tagfile.yml
@@ -1,0 +1,3 @@
+multipage: true
+generator: html
+tagfile: reference.tag.xml


### PR DESCRIPTION
A type nested inside a class is documented and gets its own page, but it was omitted from the generated tagfile. A cross-reference to that type then fell back to the class page around it instead of its own. Types nested in a namespace were already included. Only the ones nested in a class were dropped. This PR gives them their own tagfile entry, just like top-level types. 

Fixes #1232.

## Changes

The tagfile now lists the types nested in a class and points each one to its own page.

## Testing

The golden tests for the tagfile config cover the new entries, so the behavior stays checked on every build.

## Documentation

No documentation change is needed.