### PR TITLE
feat: uniform attribute extraction

### DIFF
--- a/docs/modules/ROOT/pages/extensions/dom-reference.adoc
+++ b/docs/modules/ROOT/pages/extensions/dom-reference.adoc
@@ -76,6 +76,64 @@ The `Symbol` object represents a symbol extracted from the source code. The symb
 | `Any`
 | The documentation for the symbol.
 
+| `attributes`
+| `<<attribute-fields,Attribute Object[]>>`
+| The C++ attributes attached to the symbol, for example `[[deprecated]]` or `[[nodiscard]]`.
+
+|===
+
+[#attribute-fields]
+=== Attribute
+
+The `Attribute` object represents a single C++ attribute. Every attribute object has these common fields:
+
+|===
+|Property |Type| Description
+
+| `kind`
+| `string`
+| The recognized standard attribute, identified independently of spelling: one of `deprecated`, `nodiscard`, `maybe-unused`, `no-unique-address`, `noreturn`, `carries-dependency`, `fallthrough`, `likely`, `unlikely`, `assume`, `indeterminate`, or `other` for an unrecognized attribute.
+
+| `name`
+| `string`
+| The attribute name. Recognized attributes use the normalized spelling (e.g., `deprecated`, `no_unique_address`); unrecognized ones keep the written spelling, including any scope (e.g., `gnu::custom`).
+
+| `balancedTokens`
+| `string[]`
+| The arguments as a balanced-token sequence, one per element (e.g., `["printf", "1", "2"]` for `[[gnu::format(printf, 1, 2)]]`). String-literal arguments keep their quotes. Empty for attributes that take no arguments.
+
+|===
+
+Some attribute kinds add a field for an evaluated argument. Templates should branch on `kind` and read these directly (for example, the deprecation notice prints `message`) rather than parsing `balancedTokens`.
+
+When the attribute kind is `deprecated`, the attribute object has the following additional property:
+
+|===
+|Property |Type| Description
+
+| `message`
+| `string`
+| The deprecation message, without quotes (e.g., `use bar instead` for `[[deprecated("use bar instead")]]`). Empty when no message was given.
+|===
+
+When the attribute kind is `nodiscard`, the attribute object has the following additional property:
+
+|===
+|Property |Type| Description
+
+| `reason`
+| `string`
+| The reason the result should not be discarded, without quotes (the C++20 `[[nodiscard("reason")]]` form). Empty otherwise.
+|===
+
+When the attribute kind is `assume`, the attribute object has the following additional property:
+
+|===
+|Property |Type| Description
+
+| `expression`
+| `string`
+| The assumed expression (the C++23 `[[assume(expression)]]` form).
 |===
 
 Handlebars generators extend each symbol with the following fields:
@@ -217,10 +275,6 @@ When the symbol kind is `function`, the symbol object has the following addition
 | `bool`
 | Whether the function is deleted as written.
 
-| `isNoReturn`
-| `bool`
-| Whether the function is noreturn.
-
 | `hasOverrideAttr`
 | `bool`
 | Whether the function has the override attribute.
@@ -240,10 +294,6 @@ When the symbol kind is `function`, the symbol object has the following addition
 | `isFinal`
 | `bool`
 | Whether the function is final.
-
-| `isNodiscard`
-| `bool`
-| Whether the function is nodiscard.
 
 | `isExplicitObjectMemberFunction`
 | `bool`
@@ -292,10 +342,6 @@ When the symbol kind is `function`, the symbol object has the following addition
 | `requires`
 | `string`
 | The `requires` expression of the function.
-
-| `attributes`
-| `string[]`
-| The attributes of the function.
 |===
 
 When the symbol kind is `typedef`, the symbol object has the following additional properties:
@@ -352,10 +398,6 @@ When the symbol kind is `variable`, the symbol object has the following addition
 | `initializer`
 | `string`
 | The initializer of the variable.
-
-| `attributes`
-| `string[]`
-| The attributes of the variable.
 |===
 
 When the symbol kind is `field` (i.e. non-static data members), the symbol object has the following additional properties:
@@ -371,14 +413,6 @@ When the symbol kind is `field` (i.e. non-static data members), the symbol objec
 | `string`
 | The default value of the field.
 
-| `isMaybeUnused`
-| `bool`
-| Whether the field is maybe unused.
-
-| `isDeprecated`
-| `bool`
-| Whether the field is deprecated.
-
 | `isVariant`
 | `bool`
 | Whether the field is a variant.
@@ -391,17 +425,9 @@ When the symbol kind is `field` (i.e. non-static data members), the symbol objec
 | `bool`
 | Whether the field is a bitfield.
 
-| `hasNoUniqueAddress`
-| `string`
-| Whether the field has the `[[no_unique_address]]` attribute.
-
 | `bitfieldWidth`
 | `string`
 | The width of the bitfield.
-
-| `attributes`
-| `string[]`
-| The attributes of the field.
 |===
 
 When the symbol kind is `friend`, the symbol object has the following additional properties:

--- a/include/mrdocs/Metadata/Attribute/AssumeAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/AssumeAttribute.hpp
@@ -1,0 +1,41 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_ASSUMEATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_ASSUMEATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+#include <string>
+
+namespace mrdocs {
+
+/** The `[[assume(expression)]]` attribute (C++23).
+
+    States that the expression always evaluates to true at this point.
+*/
+struct AssumeAttribute final
+    : AttributeCommonBase<AttributeKind::Assume>
+{
+    /** The assumed expression, as written.
+    */
+    std::string Expression;
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    AssumeAttribute,
+    (Attribute),
+    (Expression)
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_ASSUMEATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attribute/AttributeBase.hpp
+++ b/include/mrdocs/Metadata/Attribute/AttributeBase.hpp
@@ -1,0 +1,179 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_ATTRIBUTEBASE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_ATTRIBUTEBASE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/ADT/Polymorphic.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeKind.hpp>
+#include <mrdocs/Support/CompareReflectedType.hpp>
+#include <mrdocs/Support/Describe.hpp>
+#include <string>
+#include <vector>
+
+namespace mrdocs {
+
+class DomCorpus;
+
+/* Forward declarations
+ */
+#define INFO(PascalName) struct PascalName##Attribute;
+#include <mrdocs/Metadata/Attribute/AttributeNodes.inc>
+
+/** A C++ attribute attached to a symbol.
+
+    This base class stores the information common to every
+    attribute: the kind, the spelling name, and the raw
+    balanced-token sequence written between the parentheses.
+    Derived classes add the evaluated arguments for the
+    attributes that take them.
+*/
+struct Attribute {
+    /** The kind of attribute.
+    */
+    AttributeKind Kind;
+
+    /** The attribute name as it appears in the standard form.
+
+        For recognized attributes this is the normalized spelling
+        (e.g. `deprecated`, `no_unique_address`). For unrecognized
+        attributes (the `Other` kind) it is the spelling as written,
+        including any scope (e.g. `gnu::custom`).
+    */
+    std::string Name;
+
+    /** The attribute arguments as a balanced-token sequence.
+
+        Each element is one top-level argument as rendered by Clang,
+        e.g. `{"printf", "1", "2"}` for `[[gnu::format(printf, 1, 2)]]`.
+        Empty for attributes that take no arguments. This is the raw
+        token form; derived classes expose evaluated arguments.
+    */
+    std::vector<std::string> balancedTokens;
+
+    /** View this instance as a const Attribute reference.
+    */
+    constexpr Attribute const& asAttribute() const noexcept
+    {
+        return *this;
+    }
+
+    /** View this instance as a mutable Attribute reference.
+    */
+    constexpr Attribute& asAttribute() noexcept
+    {
+        return *this;
+    }
+
+    #define INFO(PascalName) constexpr bool is##PascalName() const noexcept { \
+        return Kind == AttributeKind::PascalName; \
+    }
+#include <mrdocs/Metadata/Attribute/AttributeNodes.inc>
+
+#define INFO(PascalName) \
+    constexpr PascalName##Attribute const& as##PascalName() const noexcept { \
+        if (Kind == AttributeKind::PascalName) \
+            return reinterpret_cast<PascalName##Attribute const&>(*this); \
+        MRDOCS_UNREACHABLE(); \
+    }
+#include <mrdocs/Metadata/Attribute/AttributeNodes.inc>
+
+#define INFO(PascalName) \
+    constexpr PascalName##Attribute & as##PascalName() noexcept { \
+        if (Kind == AttributeKind::PascalName) \
+            return reinterpret_cast<PascalName##Attribute&>(*this); \
+        MRDOCS_UNREACHABLE(); \
+    }
+#include <mrdocs/Metadata/Attribute/AttributeNodes.inc>
+
+#define INFO(PascalName) \
+    constexpr PascalName##Attribute const* as##PascalName##Ptr() const noexcept { \
+        if (Kind == AttributeKind::PascalName) { return reinterpret_cast<PascalName##Attribute const*>(this); } \
+        return nullptr; \
+    }
+#include <mrdocs/Metadata/Attribute/AttributeNodes.inc>
+
+#define INFO(PascalName) \
+    constexpr PascalName##Attribute * as##PascalName##Ptr() noexcept { \
+        if (Kind == AttributeKind::PascalName) { return reinterpret_cast<PascalName##Attribute *>(this); } \
+        return nullptr; \
+    }
+#include <mrdocs/Metadata/Attribute/AttributeNodes.inc>
+
+protected:
+    /** Virtual destructor for polymorphic base.
+    */
+    constexpr virtual ~Attribute() = default;
+
+    /** Construct with a concrete attribute kind.
+    */
+    constexpr explicit Attribute(AttributeKind kind) noexcept
+        : Kind(kind)
+    {
+    }
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    Attribute,
+    (),
+    (Kind, Name, balancedTokens)
+)
+
+/** Serialize an Attribute into a DOM value.
+*/
+MRDOCS_DECL
+void
+tag_invoke(
+    dom::ValueFromTag,
+    dom::Value& v,
+    Attribute const& I,
+    DomCorpus const* domCorpus);
+
+/** CRTP base that ties a concrete attribute to a fixed AttributeKind.
+*/
+template<AttributeKind K>
+struct AttributeCommonBase : Attribute {
+    /** Static discriminator for the concrete attribute.
+    */
+    static constexpr AttributeKind kind_id = K;
+
+    #define INFO(PascalName) \
+    static constexpr bool is##PascalName() noexcept { return K == AttributeKind::PascalName; }
+#include <mrdocs/Metadata/Attribute/AttributeNodes.inc>
+
+    MRDOCS_DESCRIBE_CLASS(AttributeCommonBase, (Attribute), ())
+
+protected:
+    /** Construct the base with the fixed kind.
+    */
+    constexpr AttributeCommonBase() noexcept
+        : Attribute(K)
+    {
+    }
+};
+
+/** Compare two polymorphic attributes by visitor dispatch.
+*/
+MRDOCS_DECL
+std::strong_ordering
+operator<=>(Polymorphic<Attribute> const&, Polymorphic<Attribute> const&);
+
+/** Equality for two polymorphic attributes.
+*/
+inline bool
+operator==(Polymorphic<Attribute> const& a, Polymorphic<Attribute> const& b)
+{
+    return std::is_eq(a <=> b);
+}
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_ATTRIBUTEBASE_HPP

--- a/include/mrdocs/Metadata/Attribute/AttributeKind.hpp
+++ b/include/mrdocs/Metadata/Attribute/AttributeKind.hpp
@@ -1,0 +1,58 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_ATTRIBUTEKIND_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_ATTRIBUTEKIND_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Dom.hpp>
+
+namespace mrdocs {
+
+/** The kind of a C++ attribute.
+
+    This identifies the standard C++ attributes mrdocs treats
+    specially, regardless of how they were spelled in the source.
+    For example, `[[deprecated]]`, `[[gnu::deprecated]]`, and
+    `__declspec(deprecated)` all share the deprecated kind.
+
+    Attributes mrdocs does not recognize use the `Other` kind.
+
+    @note Like @ref TypeKind, this enum is intentionally NOT registered
+    with `MRDOCS_DESCRIBE_ENUM`: the reflection-driven XML writer would
+    otherwise emit a redundant `<kind>` child into every attribute
+    element. Code that needs a string form calls `toString` below.
+*/
+enum class AttributeKind {
+#define INFO(PascalName) PascalName,
+#include <mrdocs/Metadata/Attribute/AttributeNodes.inc>
+};
+
+/** Convert an AttributeKind to its string representation.
+*/
+MRDOCS_DECL
+dom::String
+toString(AttributeKind kind) noexcept;
+
+/** Map an AttributeKind into a DOM value.
+*/
+inline
+void
+tag_invoke(
+    dom::ValueFromTag,
+    dom::Value& v,
+    AttributeKind kind)
+{
+    v = toString(kind);
+}
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_ATTRIBUTEKIND_HPP

--- a/include/mrdocs/Metadata/Attribute/AttributeNodes.inc
+++ b/include/mrdocs/Metadata/Attribute/AttributeNodes.inc
@@ -1,0 +1,40 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef INFO
+#define INFO(PascalName)
+#endif
+
+/// An attribute mrdocs does not treat specially.
+INFO(Other)
+/// `[[noreturn]]` (C++11)
+INFO(Noreturn)
+/// `[[carries_dependency]]` (C++11)
+INFO(CarriesDependency)
+/// `[[deprecated]]` / `[[deprecated("reason")]]` (C++14)
+INFO(Deprecated)
+/// `[[fallthrough]]` (C++17)
+INFO(Fallthrough)
+/// `[[maybe_unused]]` (C++17)
+INFO(MaybeUnused)
+/// `[[nodiscard]]` / `[[nodiscard("reason")]]` (C++17)
+INFO(Nodiscard)
+/// `[[likely]]` (C++20)
+INFO(Likely)
+/// `[[unlikely]]` (C++20)
+INFO(Unlikely)
+/// `[[no_unique_address]]` (C++20)
+INFO(NoUniqueAddress)
+/// `[[assume(expression)]]` (C++23)
+INFO(Assume)
+/// `[[indeterminate]]` (C++26)
+INFO(Indeterminate)
+
+#undef INFO

--- a/include/mrdocs/Metadata/Attribute/CarriesDependencyAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/CarriesDependencyAttribute.hpp
@@ -1,0 +1,35 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_CARRIESDEPENDENCYATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_CARRIESDEPENDENCYATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+
+namespace mrdocs {
+
+/** The `[[carries_dependency]]` attribute (C++11): release-consume dependency propagation.
+*/
+struct CarriesDependencyAttribute final
+    : AttributeCommonBase<AttributeKind::CarriesDependency>
+{
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    CarriesDependencyAttribute,
+    (Attribute),
+    ()
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_CARRIESDEPENDENCYATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attribute/DeprecatedAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/DeprecatedAttribute.hpp
@@ -1,0 +1,45 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_DEPRECATEDATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_DEPRECATEDATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+#include <string>
+
+namespace mrdocs {
+
+/** The `[[deprecated]]` attribute (C++14).
+
+    Indicates that the use of the entity is allowed but discouraged.
+*/
+struct DeprecatedAttribute final
+    : AttributeCommonBase<AttributeKind::Deprecated>
+{
+    /** The deprecation message, if any.
+
+        This is the evaluated string argument, without quotes, e.g.
+        `use bar instead` for `[[deprecated("use bar instead")]]`.
+        Empty when no message was given.
+    */
+    std::string Message;
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    DeprecatedAttribute,
+    (Attribute),
+    (Message)
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_DEPRECATEDATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attribute/FallthroughAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/FallthroughAttribute.hpp
@@ -1,0 +1,35 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_FALLTHROUGHATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_FALLTHROUGHATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+
+namespace mrdocs {
+
+/** The `[[fallthrough]]` attribute (C++17): an intentional switch fall-through.
+*/
+struct FallthroughAttribute final
+    : AttributeCommonBase<AttributeKind::Fallthrough>
+{
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    FallthroughAttribute,
+    (Attribute),
+    ()
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_FALLTHROUGHATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attribute/IndeterminateAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/IndeterminateAttribute.hpp
@@ -1,0 +1,35 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_INDETERMINATEATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_INDETERMINATEATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+
+namespace mrdocs {
+
+/** The `[[indeterminate]]` attribute (C++26): the object has an indeterminate value if uninitialized.
+*/
+struct IndeterminateAttribute final
+    : AttributeCommonBase<AttributeKind::Indeterminate>
+{
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    IndeterminateAttribute,
+    (Attribute),
+    ()
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_INDETERMINATEATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attribute/LikelyAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/LikelyAttribute.hpp
@@ -1,0 +1,35 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_LIKELYATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_LIKELYATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+
+namespace mrdocs {
+
+/** The `[[likely]]` attribute (C++20): this path is more likely.
+*/
+struct LikelyAttribute final
+    : AttributeCommonBase<AttributeKind::Likely>
+{
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    LikelyAttribute,
+    (Attribute),
+    ()
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_LIKELYATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attribute/MaybeUnusedAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/MaybeUnusedAttribute.hpp
@@ -1,0 +1,35 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_MAYBEUNUSEDATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_MAYBEUNUSEDATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+
+namespace mrdocs {
+
+/** The `[[maybe_unused]]` attribute (C++17): suppresses unused-entity warnings.
+*/
+struct MaybeUnusedAttribute final
+    : AttributeCommonBase<AttributeKind::MaybeUnused>
+{
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    MaybeUnusedAttribute,
+    (Attribute),
+    ()
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_MAYBEUNUSEDATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attribute/NoUniqueAddressAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/NoUniqueAddressAttribute.hpp
@@ -1,0 +1,35 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_NOUNIQUEADDRESSATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_NOUNIQUEADDRESSATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+
+namespace mrdocs {
+
+/** The `[[no_unique_address]]` attribute (C++20): the member need not have a unique address.
+*/
+struct NoUniqueAddressAttribute final
+    : AttributeCommonBase<AttributeKind::NoUniqueAddress>
+{
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    NoUniqueAddressAttribute,
+    (Attribute),
+    ()
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_NOUNIQUEADDRESSATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attribute/NodiscardAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/NodiscardAttribute.hpp
@@ -1,0 +1,44 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_NODISCARDATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_NODISCARDATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+#include <string>
+
+namespace mrdocs {
+
+/** The `[[nodiscard]]` attribute (C++17, reason added in C++20).
+
+    Encourages the compiler to warn if the return value is discarded.
+*/
+struct NodiscardAttribute final
+    : AttributeCommonBase<AttributeKind::Nodiscard>
+{
+    /** The reason, if any.
+
+        This is the evaluated string argument, without quotes, given
+        by the C++20 form `[[nodiscard("reason")]]`. Empty otherwise.
+    */
+    std::string Reason;
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    NodiscardAttribute,
+    (Attribute),
+    (Reason)
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_NODISCARDATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attribute/NoreturnAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/NoreturnAttribute.hpp
@@ -1,0 +1,35 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_NORETURNATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_NORETURNATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+
+namespace mrdocs {
+
+/** The `[[noreturn]]` attribute (C++11): the function does not return.
+*/
+struct NoreturnAttribute final
+    : AttributeCommonBase<AttributeKind::Noreturn>
+{
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    NoreturnAttribute,
+    (Attribute),
+    ()
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_NORETURNATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attribute/OtherAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/OtherAttribute.hpp
@@ -1,0 +1,38 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_OTHERATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_OTHERATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+
+namespace mrdocs {
+
+/** An attribute mrdocs does not treat specially.
+
+    The spelling is preserved in @ref Attribute::Name and the
+    arguments in @ref Attribute::balancedTokens.
+*/
+struct OtherAttribute final
+    : AttributeCommonBase<AttributeKind::Other>
+{
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    OtherAttribute,
+    (Attribute),
+    ()
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_OTHERATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attribute/UnlikelyAttribute.hpp
+++ b/include/mrdocs/Metadata/Attribute/UnlikelyAttribute.hpp
@@ -1,0 +1,35 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTE_UNLIKELYATTRIBUTE_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTE_UNLIKELYATTRIBUTE_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Support/Describe.hpp>
+
+namespace mrdocs {
+
+/** The `[[unlikely]]` attribute (C++20): this path is less likely.
+*/
+struct UnlikelyAttribute final
+    : AttributeCommonBase<AttributeKind::Unlikely>
+{
+};
+
+MRDOCS_DESCRIBE_STRUCT(
+    UnlikelyAttribute,
+    (Attribute),
+    ()
+)
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTE_UNLIKELYATTRIBUTE_HPP

--- a/include/mrdocs/Metadata/Attributes.hpp
+++ b/include/mrdocs/Metadata/Attributes.hpp
@@ -1,0 +1,80 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_API_METADATA_ATTRIBUTES_HPP
+#define MRDOCS_API_METADATA_ATTRIBUTES_HPP
+
+#include <mrdocs/Platform.hpp>
+#include <mrdocs/ADT/Polymorphic.hpp>
+#include <mrdocs/Metadata/Attribute/AssumeAttribute.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeBase.hpp>
+#include <mrdocs/Metadata/Attribute/AttributeKind.hpp>
+#include <mrdocs/Metadata/Attribute/CarriesDependencyAttribute.hpp>
+#include <mrdocs/Metadata/Attribute/DeprecatedAttribute.hpp>
+#include <mrdocs/Metadata/Attribute/FallthroughAttribute.hpp>
+#include <mrdocs/Metadata/Attribute/IndeterminateAttribute.hpp>
+#include <mrdocs/Metadata/Attribute/LikelyAttribute.hpp>
+#include <mrdocs/Metadata/Attribute/MaybeUnusedAttribute.hpp>
+#include <mrdocs/Metadata/Attribute/NoUniqueAddressAttribute.hpp>
+#include <mrdocs/Metadata/Attribute/NodiscardAttribute.hpp>
+#include <mrdocs/Metadata/Attribute/NoreturnAttribute.hpp>
+#include <mrdocs/Metadata/Attribute/OtherAttribute.hpp>
+#include <mrdocs/Metadata/Attribute/UnlikelyAttribute.hpp>
+#include <mrdocs/Support/Visitor.hpp>
+
+namespace mrdocs {
+
+/** Visit an @ref Attribute with the provided callable.
+
+    @param info The attribute instance to visit.
+    @param fn The callable to dispatch to the concrete attribute.
+    @param args Additional arguments forwarded to the callable.
+    @return Whatever the callable returns.
+*/
+template<
+    std::derived_from<Attribute> AttributeTy,
+    class F,
+    class... Args>
+decltype(auto)
+visit(
+    AttributeTy& info,
+    F&& fn,
+    Args&&... args)
+{
+    auto visitor = makeVisitor<Attribute>(
+        info, std::forward<F>(fn),
+        std::forward<Args>(args)...);
+    switch(info.Kind)
+    {
+    #define INFO(PascalName) case AttributeKind::PascalName: \
+        return visitor.template visit<PascalName##Attribute>();
+#include <mrdocs/Metadata/Attribute/AttributeNodes.inc>
+    default:
+        MRDOCS_UNREACHABLE();
+    }
+}
+
+/** Serialize a polymorphic attribute into a DOM value.
+*/
+inline
+void
+tag_invoke(
+    dom::ValueFromTag,
+    dom::Value& v,
+    Polymorphic<Attribute> const& I,
+    DomCorpus const* domCorpus)
+{
+    MRDOCS_ASSERT(!I.valueless_after_move());
+    tag_invoke(dom::ValueFromTag{}, v, *I, domCorpus);
+}
+
+} // mrdocs
+
+#endif // MRDOCS_API_METADATA_ATTRIBUTES_HPP

--- a/include/mrdocs/Metadata/Symbol/Function.hpp
+++ b/include/mrdocs/Metadata/Symbol/Function.hpp
@@ -73,18 +73,12 @@ struct FunctionSymbol final
     /** True when deleted as written (vs deduced).
     */
     bool IsDeletedAsWritten = false;
-    /** True when marked [[noreturn]] or equivalent.
-    */
-    bool IsNoReturn = false;
     /** True when annotated with override.
     */
     bool HasOverrideAttr = false;
     /** True when using a trailing return type.
     */
     bool HasTrailingReturn = false;
-    /** True when declared [[nodiscard]].
-    */
-    bool IsNodiscard = false;
     /** True when explicit object parameter syntax is used.
     */
     bool IsExplicitObjectMemberFunction = false;
@@ -97,9 +91,6 @@ struct FunctionSymbol final
     /** Storage class specifier.
     */
     StorageClassKind StorageClass = StorageClassKind::None;
-    /** Collected attributes attached to the declaration.
-    */
-    std::vector<std::string> Attributes;
 
     // CXXMethodDecl
     /** True when this is a non-static member function.
@@ -188,11 +179,11 @@ MRDOCS_DESCRIBE_STRUCT(
     (SymbolCommonBase<SymbolKind::Function>),
     (ReturnType, Params, Template, FuncClass, Noexcept, Requires,
      IsVariadic, IsDefaulted, IsExplicitlyDefaulted, IsDeleted,
-     IsDeletedAsWritten, IsNoReturn, HasOverrideAttr, HasTrailingReturn,
-     IsNodiscard, IsExplicitObjectMemberFunction, Constexpr,
+     IsDeletedAsWritten, HasOverrideAttr, HasTrailingReturn,
+     IsExplicitObjectMemberFunction, Constexpr,
      OverloadedOperator, StorageClass, IsRecordMethod, IsVirtual,
      IsVirtualAsWritten, IsPure, IsConst, IsVolatile, IsFinal,
-     RefQualifier, Explicit, Attributes, FunctionObjectImpl,
+     RefQualifier, Explicit, FunctionObjectImpl,
      IsListedOnPrimary, Specializations)
 )
 

--- a/include/mrdocs/Metadata/Symbol/SymbolBase.hpp
+++ b/include/mrdocs/Metadata/Symbol/SymbolBase.hpp
@@ -13,6 +13,8 @@
 #define MRDOCS_API_METADATA_SYMBOL_SYMBOLBASE_HPP
 
 #include <mrdocs/Platform.hpp>
+#include <mrdocs/ADT/Polymorphic.hpp>
+#include <mrdocs/Metadata/Attributes.hpp>
 #include <mrdocs/Metadata/DocComment.hpp>
 #include <mrdocs/Metadata/Specifiers/AccessKind.hpp>
 #include <mrdocs/Metadata/Symbol/ExtractionMode.hpp>
@@ -89,6 +91,15 @@ struct MRDOCS_VISIBLE Symbol {
     /** The extracted documentation for this declaration.
     */
     Optional<DocComment> doc;
+
+    /** The C++ attributes attached to this declaration.
+
+        These are the attributes as written in the source,
+        e.g. `[[deprecated]]` or `[[nodiscard]]`, captured for
+        every symbol kind. See @ref Attribute for the per-attribute
+        name and arguments.
+    */
+    std::vector<Polymorphic<Attribute>> Attributes;
 
     //--------------------------------------------
 
@@ -177,7 +188,7 @@ MRDOCS_DESCRIBE_STRUCT(
     Symbol,
     (),
     (Name, Loc, Kind, id, Access,
-     Extraction, IsCopyFromInherited, Parent, doc)
+     Extraction, IsCopyFromInherited, Parent, doc, Attributes)
 )
 
 /** Map a Symbol to a dom::Object with computed extraction properties.

--- a/include/mrdocs/Metadata/Symbol/Variable.hpp
+++ b/include/mrdocs/Metadata/Symbol/Variable.hpp
@@ -64,22 +64,6 @@ struct VariableSymbol final
     */
     bool IsThreadLocal = false;
 
-    /** Raw attribute spellings attached to the variable.
-    */
-    std::vector<std::string> Attributes;
-
-    /** Whether the variable carries `[[maybe_unused]]`.
-    */
-    bool IsMaybeUnused = false;
-
-    /** Whether the variable is marked deprecated.
-    */
-    bool IsDeprecated = false;
-
-    /** Whether the variable uses [[no_unique_address]].
-    */
-    bool HasNoUniqueAddress = false;
-
     //--------------------------------------------
     // Record fields
     /** True if this variable is a data member of a record.
@@ -121,9 +105,8 @@ MRDOCS_DESCRIBE_STRUCT(
     VariableSymbol,
     (SymbolCommonBase<SymbolKind::Variable>),
     (Type, Template, Initializer, StorageClass, IsInline,
-     IsConstexpr, IsConstinit, IsThreadLocal, Attributes, IsMaybeUnused,
-     IsDeprecated, HasNoUniqueAddress, IsRecordField, IsMutable, IsVariant,
-     IsBitfield, BitfieldWidth)
+     IsConstexpr, IsConstinit, IsThreadLocal, IsRecordField, IsMutable,
+     IsVariant, IsBitfield, BitfieldWidth)
 )
 
 } // mrdocs

--- a/mrdocs.rnc
+++ b/mrdocs.rnc
@@ -142,8 +142,56 @@ grammar
         element extraction { ExtractionMode }?,
         element is-copy-from-inherited { Bool }?,
         element parent { SymbolID }?,
-        DocComment?
+        DocComment?,
+        AnyAttribute*
     )
+
+    #---------------------------------------------
+    # Attributes (polymorphic)
+    #---------------------------------------------
+
+    AttributeBase =
+    (
+        element name { text }?,
+        element balanced-tokens { text }*
+    )
+
+    AnyAttribute =
+        OtherAttribute | NoreturnAttribute | CarriesDependencyAttribute |
+        DeprecatedAttribute | FallthroughAttribute | MaybeUnusedAttribute |
+        NodiscardAttribute | LikelyAttribute | UnlikelyAttribute |
+        NoUniqueAddressAttribute | AssumeAttribute | IndeterminateAttribute
+
+    OtherAttribute            = element other-attribute             { AttributeBase }
+    NoreturnAttribute         = element noreturn-attribute          { AttributeBase }
+    CarriesDependencyAttribute = element carries-dependency-attribute { AttributeBase }
+    FallthroughAttribute      = element fallthrough-attribute       { AttributeBase }
+    MaybeUnusedAttribute      = element maybe-unused-attribute      { AttributeBase }
+    LikelyAttribute           = element likely-attribute            { AttributeBase }
+    UnlikelyAttribute         = element unlikely-attribute          { AttributeBase }
+    NoUniqueAddressAttribute  = element no-unique-address-attribute { AttributeBase }
+    IndeterminateAttribute    = element indeterminate-attribute     { AttributeBase }
+
+    DeprecatedAttribute =
+        element deprecated-attribute
+        {
+            AttributeBase,
+            element message { text }?
+        }
+
+    NodiscardAttribute =
+        element nodiscard-attribute
+        {
+            AttributeBase,
+            element reason { text }?
+        }
+
+    AssumeAttribute =
+        element assume-attribute
+        {
+            AttributeBase,
+            element expression { text }?
+        }
 
     #---------------------------------------------
     # Types (polymorphic)
@@ -430,10 +478,8 @@ grammar
             element is-explicitly-defaulted { Bool }?,
             element is-deleted { Bool }?,
             element is-deleted-as-written { Bool }?,
-            element is-no-return { Bool }?,
             element has-override-attr { Bool }?,
             element has-trailing-return { Bool }?,
-            element is-nodiscard { Bool }?,
             element is-explicit-object-member-function { Bool }?,
             element constexpr { text }?,
             element overloaded-operator { text }?,
@@ -447,7 +493,6 @@ grammar
             element is-final { Bool }?,
             element ref-qualifier { text }?,
             element explicit { text }?,
-            element attributes { text }*,
             element function-object-impl { SymbolID }?,
             element is-listed-on-primary { Bool }?,
             element specializations { SymbolID }*
@@ -508,10 +553,6 @@ grammar
             element is-constexpr { Bool }?,
             element is-constinit { Bool }?,
             element is-thread-local { Bool }?,
-            element attributes { text }*,
-            element is-maybe-unused { Bool }?,
-            element is-deprecated { Bool }?,
-            element has-no-unique-address { Bool }?,
             element is-record-field { Bool }?,
             element is-mutable { Bool }?,
             element is-variant { Bool }?,

--- a/share/mrdocs/addons/generator/adoc/partials/markup/a.adoc.hbs
+++ b/share/mrdocs/addons/generator/adoc/partials/markup/a.adoc.hbs
@@ -12,5 +12,5 @@
 {{~else if (starts_with href ".")~}}
     xref:{{{href}}}[{{> @partial-block }}]
 {{~else~}}
-    {{{href}}}[{{> @partial-block }}]
+    {{{href}}}[{{> @partial-block }}{{#if blank}}^{{/if}}]
 {{~/if~}}

--- a/share/mrdocs/addons/generator/common/partials/symbol.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol.hbs
@@ -15,6 +15,7 @@
 {{#> markup/section name="symbol"}}
 {{> symbol/section/header}}
 {{> symbol/section/synopsis}}
+{{> symbol/section/attribute-admonitions ~}}
 {{> symbol/section/function-object-admonition}}
 {{> symbol/section/description}}
 {{> symbol/section/base-classes}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/section/attribute-admonitions.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/section/attribute-admonitions.hbs
@@ -1,0 +1,22 @@
+{{! An admonition for each recognized standard attribute the symbol carries, linking to cppreference in passing. }}
+{{~#each symbol.attributes~}}
+{{~#if (eq kind "deprecated")~}}
+{{#> markup/admonition kind="warning"}}{{#> markup/a href="https://en.cppreference.com/cpp/language/attributes/deprecated" blank=true}}Deprecated{{/markup/a}}{{#if message}}: {{message}}{{/if}}. Use of this entity is allowed but discouraged.{{/markup/admonition}}
+{{~else if (eq kind "maybe-unused")~}}
+{{#> markup/admonition kind="note"}}This entity {{#> markup/a href="https://en.cppreference.com/cpp/language/attributes/maybe_unused" blank=true}}may be unused{{/markup/a}}, and the compiler will not warn about it.{{/markup/admonition}}
+{{~else if (eq kind "no-unique-address")~}}
+{{#> markup/admonition kind="note"}}This member {{#> markup/a href="https://en.cppreference.com/cpp/language/attributes/no_unique_address" blank=true}}need not have an address distinct from all other non-static data members{{/markup/a}} of its class.{{/markup/admonition}}
+{{~else if (eq kind "carries-dependency")~}}
+{{#> markup/admonition kind="note"}}This {{#> markup/a href="https://en.cppreference.com/cpp/language/attributes/carries_dependency" blank=true}}carries a dependency{{/markup/a}} for release-consume ordering.{{/markup/admonition}}
+{{~else if (eq kind "fallthrough")~}}
+{{#> markup/admonition kind="note"}}The {{#> markup/a href="https://en.cppreference.com/cpp/language/attributes/fallthrough" blank=true}}fall-through{{/markup/a}} from the previous case label is intentional.{{/markup/admonition}}
+{{~else if (eq kind "likely")~}}
+{{#> markup/admonition kind="note"}}This path is {{#> markup/a href="https://en.cppreference.com/cpp/language/attributes/likely" blank=true}}more likely{{/markup/a}} to execute than the alternatives.{{/markup/admonition}}
+{{~else if (eq kind "unlikely")~}}
+{{#> markup/admonition kind="note"}}This path is {{#> markup/a href="https://en.cppreference.com/cpp/language/attributes/likely" blank=true}}less likely{{/markup/a}} to execute than the alternatives.{{/markup/admonition}}
+{{~else if (eq kind "assume")~}}
+{{#> markup/admonition kind="note"}}The expression{{#if expression}} `{{expression}}`{{/if}} is {{#> markup/a href="https://en.cppreference.com/cpp/language/attributes/assume" blank=true}}assumed{{/markup/a}} to always hold at this point.{{/markup/admonition}}
+{{~else if (eq kind "indeterminate")~}}
+{{#> markup/admonition kind="note"}}If it is not initialized, this object has an {{#> markup/a href="https://en.cppreference.com/cpp/language/attributes/indeterminate" blank=true}}indeterminate value{{/markup/a}}.{{/markup/admonition}}
+{{~/if~}}
+{{~/each~}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/section/attribute-return-admonitions.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/section/attribute-return-admonitions.hbs
@@ -1,0 +1,8 @@
+{{! Admonitions for attributes that describe a function's return behavior, rendered in the Return Value section. }}
+{{~#each symbol.attributes~}}
+{{~#if (eq kind "nodiscard")~}}
+{{#> markup/admonition kind="note"}}The return value {{#> markup/a href="https://en.cppreference.com/cpp/language/attributes/nodiscard" blank=true}}should not be discarded{{/markup/a}}{{#if reason}}: {{reason}}{{/if}}.{{/markup/admonition}}
+{{~else if (eq kind "noreturn")~}}
+{{#> markup/admonition kind="note"}}This function {{#> markup/a href="https://en.cppreference.com/cpp/language/attributes/noreturn" blank=true}}does not return{{/markup/a}}.{{/markup/admonition}}
+{{~/if~}}
+{{~/each~}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/section/return-value.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/section/return-value.hbs
@@ -1,7 +1,8 @@
-{{! Return value(s) (@returns). Single returns render inline; multiples render as a list. }}
-{{#if symbol.doc.returns}}
+{{! Return value(s) (@returns) plus return-related attribute admonitions (nodiscard, noreturn). Single returns render inline; multiples render as a list. }}
+{{#if (or (size symbol.doc.returns) (contains_any (pluck symbol.attributes "kind") (arr "nodiscard" "noreturn")))}}
 {{#> markup/section name="return-value"}}
 {{#> markup/dynamic-level-h }}Return Value{{/markup/dynamic-level-h~}}
+{{#if symbol.doc.returns}}
 {{#if (eq (size symbol.doc.returns) 1)}}
 {{#> markup/p}}{{> doc/block/returns symbol.doc.returns.[0]}}{{/markup/p}}
 {{else}}
@@ -11,5 +12,7 @@
 {{/each}}
 {{/markup/ul}}
 {{/if}}
+{{/if}}
+{{> symbol/section/attribute-return-admonitions ~}}
 {{/markup/section}}
 {{/if}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/signature/attributes.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/signature/attributes.hbs
@@ -1,0 +1,1 @@
+{{!-- Renders the symbol's C++ attributes as a `[[...]]` clause. Expects the symbol context (uses `attributes`). --}}{{~ str "[[" ~}}{{~#each attributes~}}{{~#unless @first}}, {{/unless~}}{{~ name ~}}{{~#if balancedTokens}}({{join ", " balancedTokens}}){{/if~}}{{~/each~}}{{~ str "]]" ~}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/signature/enum-constant.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/signature/enum-constant.hbs
@@ -1,1 +1,1 @@
-{{ name }}{{#if initializer}} = {{initializer}}{{~/if}}
+{{ name }}{{#if attributes}} {{>symbol/signature/attributes}}{{/if}}{{#if initializer}} = {{initializer}}{{~/if}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/signature/enum.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/signature/enum.hbs
@@ -1,2 +1,2 @@
-enum {{#if scoped}}class {{/if}}{{>symbol/name-text .~}}
+enum {{#if scoped}}class {{/if}}{{#if attributes}}{{>symbol/signature/attributes}} {{/if}}{{>symbol/name-text .~}}
 {{#if underlyingType}} : {{>type/declarator underlyingType}}{{/if}};

--- a/share/mrdocs/addons/generator/common/partials/symbol/signature/function.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/signature/function.hbs
@@ -2,7 +2,7 @@
 {{/if~}}
 {{#if isFriend}}friend
 {{/if~}}
-{{#if attributes}}{{#unless isFriend}}{{ str "[[" }}{{join ", " attributes}}{{ str "]]" }}
+{{#if attributes}}{{#unless isFriend}}{{>symbol/signature/attributes}}
 {{/unless}}{{/if~}}
 {{#if constexpr}}{{constexpr}}
 {{/if~}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/signature/record.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/signature/record.hbs
@@ -1,7 +1,7 @@
 {{#if template}}{{>template/head template}}
 {{/if~}}
 {{#if isFriend}}friend {{/if~}}
-{{~keyKind}} {{#if (contains (arr "explicit" "partial") template.kind)~}}
+{{~keyKind}} {{#if attributes}}{{>symbol/signature/attributes}} {{/if}}{{#if (contains (arr "explicit" "partial") template.kind)~}}
     {{!~ If the last part is a template specialization, we include links to primary template and the arguments. ~}}
     {{!~ If the primary template wasn't correctly extracted for some reason, we just print the name as usual. ~}}
     {{#if template.primary }}{{~>symbol/name template.primary ~}}{{else}}{{ name }}{{/if}}{{>template/args args=template.args ~}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/signature/typedef.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/signature/typedef.hbs
@@ -1,7 +1,7 @@
 {{#if isUsing~}}
     {{#if template}}{{>template/head template}}
     {{/if~}}
-    using {{name}} = {{>type/declarator type}}
+    using {{name}} {{#if attributes}}{{>symbol/signature/attributes}} {{/if}}= {{>type/declarator type}}
 {{~else~}}
     typedef {{>type/declarator type decl-name=name}}
 {{~/if}};

--- a/share/mrdocs/addons/generator/common/partials/symbol/signature/variable.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/signature/variable.hbs
@@ -1,4 +1,4 @@
-{{#if attributes}}{{ str "[[" }}{{join ", " attributes}}{{ str "]]" }}
+{{#if attributes}}{{>symbol/signature/attributes}}
 {{/if}}
 {{#if template}}{{>template/head template}}
 {{/if~}}

--- a/share/mrdocs/addons/generator/common/partials/symbol/special-function-suffix.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/special-function-suffix.hbs
@@ -30,4 +30,12 @@
     {{~#if isVariant~}}
         {{#>markup/span class="small"}}[variant member]{{/markup/span}}
     {{~/if~}}
-{{~/if}}
+{{~/if~}}
+{{!-- Terse attribute tags. These apply to every symbol kind that carries the attribute. --}}
+{{~#each attributes~}}
+{{~#if (eq kind "deprecated")~}}
+    {{str ' '}}{{#>markup/span class="small"}}[deprecated]{{/markup/span}}
+{{~else if (eq kind "noreturn")~}}
+    {{str ' '}}{{#>markup/span class="small"}}[noreturn]{{/markup/span}}
+{{~/if~}}
+{{~/each~}}

--- a/share/mrdocs/addons/generator/html/partials/markup/a.html.hbs
+++ b/share/mrdocs/addons/generator/html/partials/markup/a.html.hbs
@@ -1,5 +1,5 @@
 {{#if (eq href @root.symbol.url)~}}
     {{{> @partial-block }}}
 {{~else~}}
-    <a href="{{{relativize href}}}">{{> @partial-block }}</a>
+    <a href="{{{relativize href}}}"{{#if blank}} target="_blank" rel="noopener"{{/if}}>{{> @partial-block }}</a>
 {{~/if~}}

--- a/src/lib/AST/ASTVisitor.cpp
+++ b/src/lib/AST/ASTVisitor.cpp
@@ -552,6 +552,11 @@ populate(Symbol& I, bool const isNew, DeclTy const* D)
     populate(I.doc, D);
     populate(I.Loc, D);
 
+    // Attributes are extracted for every symbol kind and may be spread
+    // across redeclarations, so collect them even when the symbol is
+    // not new (the helper deduplicates).
+    populateAttributes(I, D);
+
     // All other information is redundant if the symbol is not new
     MRDOCS_CHECK_OR(isNew);
 
@@ -893,7 +898,6 @@ populate(
     I.IsExplicitlyDefaulted |= D->isExplicitlyDefaulted();
     I.IsDeleted |= D->isDeleted();
     I.IsDeletedAsWritten |= D->isDeletedAsWritten();
-    I.IsNoReturn |= D->isNoReturn();
     I.HasOverrideAttr |= D->hasAttr<clang::OverrideAttr>();
 
     if (clang::ConstexprSpecKind const CSK = D->getConstexprKind();
@@ -907,7 +911,6 @@ populate(
         I.StorageClass = toStorageClassKind(SC);
     }
 
-    I.IsNodiscard |= D->hasAttr<clang::WarnUnusedResultAttr>();
     I.IsExplicitObjectMemberFunction |= D->hasCXXExplicitFunctionObjectParameter();
 
     llvm::ArrayRef<clang::ParmVarDecl*> const params = D->parameters();
@@ -996,8 +999,6 @@ populate(
             }
         }
     }
-
-    populateAttributes(I, D);
 }
 
 void
@@ -1171,7 +1172,6 @@ populate(
         QT.removeLocalConst();
     }
     I.Type = toType(QT);
-    populateAttributes(I, D);
 }
 
 void
@@ -1216,10 +1216,6 @@ populate(
         I.IsBitfield = true;
         populate(I.BitfieldWidth, D->getBitWidth());
     }
-    I.HasNoUniqueAddress = D->hasAttr<clang::NoUniqueAddressAttr>();
-    I.IsDeprecated = D->hasAttr<clang::DeprecatedAttr>();
-    I.IsMaybeUnused = D->hasAttr<clang::UnusedAttr>();
-    populateAttributes(I, D);
 }
 
 void
@@ -1738,26 +1734,280 @@ populate(
         }));
 }
 
-template <std::derived_from<Symbol> InfoTy>
+namespace {
+// Split the text inside an attribute's parentheses into its individual
+// arguments, breaking on top-level commas while respecting nested
+// brackets and string/character literals.
+std::vector<std::string>
+splitAttributeArgs(std::string_view s)
+{
+    std::vector<std::string> args;
+    std::string cur;
+    int depth = 0;
+    bool inString = false;
+    bool inChar = false;
+    for (std::size_t i = 0; i < s.size(); ++i)
+    {
+        char const c = s[i];
+        if (inString || inChar)
+        {
+            cur += c;
+            if (c == '\\' && i + 1 < s.size())
+            {
+                cur += s[++i];
+            }
+            else if (inString && c == '"')
+            {
+                inString = false;
+            }
+            else if (inChar && c == '\'')
+            {
+                inChar = false;
+            }
+            continue;
+        }
+        switch (c)
+        {
+        case '"': inString = true; break;
+        case '\'': inChar = true; break;
+        case '(': case '[': case '{': ++depth; break;
+        case ')': case ']': case '}': --depth; break;
+        default: break;
+        }
+        if (c == ',' && depth == 0)
+        {
+            args.emplace_back(trim(cur));
+            cur.clear();
+            continue;
+        }
+        cur += c;
+    }
+    if (std::string_view const last = trim(cur); !last.empty())
+    {
+        args.emplace_back(last);
+    }
+    return args;
+}
+
+// Extract the argument tokens from an attribute's pretty-printed form.
+// Anchored on the attribute name, so the surrounding `[[ ]]` or
+// `__attribute__(( ))` wrapper does not matter.
+std::vector<std::string>
+attributeArgs(std::string_view pretty, std::string_view name)
+{
+    std::size_t const namePos = pretty.find(name);
+    if (namePos == std::string_view::npos)
+    {
+        return {};
+    }
+    std::size_t const open = pretty.find('(', namePos + name.size());
+    if (open == std::string_view::npos)
+    {
+        return {};
+    }
+    int depth = 0;
+    bool inString = false;
+    bool inChar = false;
+    std::size_t i = open;
+    for (; i < pretty.size(); ++i)
+    {
+        char const c = pretty[i];
+        if (inString || inChar)
+        {
+            if (c == '\\') { ++i; continue; }
+            if (inString && c == '"') { inString = false; }
+            else if (inChar && c == '\'') { inChar = false; }
+            continue;
+        }
+        if (c == '"') { inString = true; }
+        else if (c == '\'') { inChar = true; }
+        else if (c == '(') { ++depth; }
+        else if (c == ')') { if (--depth == 0) { break; } }
+    }
+    if (i >= pretty.size())
+    {
+        return {};
+    }
+    return splitAttributeArgs(pretty.substr(open + 1, i - open - 1));
+}
+
+// Map a Clang attribute kind to the mrdocs attribute kind for the
+// standard C++ attributes, identifying by kind rather than spelling.
+AttributeKind
+toAttributeKind(clang::attr::Kind const kind)
+{
+    switch (kind)
+    {
+    case clang::attr::CXX11NoReturn:
+    case clang::attr::C11NoReturn:       return AttributeKind::Noreturn;
+    case clang::attr::CarriesDependency: return AttributeKind::CarriesDependency;
+    case clang::attr::Deprecated:        return AttributeKind::Deprecated;
+    case clang::attr::FallThrough:       return AttributeKind::Fallthrough;
+    case clang::attr::Unused:            return AttributeKind::MaybeUnused;
+    case clang::attr::WarnUnusedResult:  return AttributeKind::Nodiscard;
+    case clang::attr::Likely:            return AttributeKind::Likely;
+    case clang::attr::Unlikely:          return AttributeKind::Unlikely;
+    case clang::attr::NoUniqueAddress:   return AttributeKind::NoUniqueAddress;
+    case clang::attr::CXXAssume:         return AttributeKind::Assume;
+    default:                             return AttributeKind::Other;
+    }
+}
+
+// The normalized standard spelling for a recognized attribute kind,
+// or empty for AttributeKind::Other.
+std::string_view
+standardAttributeName(AttributeKind const kind)
+{
+    switch (kind)
+    {
+    case AttributeKind::Noreturn:          return "noreturn";
+    case AttributeKind::CarriesDependency: return "carries_dependency";
+    case AttributeKind::Deprecated:        return "deprecated";
+    case AttributeKind::Fallthrough:       return "fallthrough";
+    case AttributeKind::MaybeUnused:       return "maybe_unused";
+    case AttributeKind::Nodiscard:         return "nodiscard";
+    case AttributeKind::Likely:            return "likely";
+    case AttributeKind::Unlikely:          return "unlikely";
+    case AttributeKind::NoUniqueAddress:   return "no_unique_address";
+    case AttributeKind::Assume:            return "assume";
+    case AttributeKind::Indeterminate:     return "indeterminate";
+    default:                               return {};
+    }
+}
+
+// Construct the concrete attribute object for a kind.
+Polymorphic<Attribute>
+makeAttribute(AttributeKind const kind)
+{
+    switch (kind)
+    {
+#define INFO(PascalName) case AttributeKind::PascalName: \
+        return Polymorphic<Attribute>(PascalName##Attribute{});
+#include <mrdocs/Metadata/Attribute/AttributeNodes.inc>
+    default:
+        MRDOCS_UNREACHABLE();
+    }
+}
+} // (anon)
+
 void
 ASTVisitor::
-populateAttributes(InfoTy& I, clang::Decl const* D)
+populateAttributes(Symbol& I, clang::Decl const* D)
 {
-    if constexpr (requires { I.Attributes; })
+    auto collect = [&](clang::Decl const* Decl)
     {
-        MRDOCS_CHECK_OR(D->hasAttrs());
-        for (clang::Attr const* attr: D->getAttrs())
+        if (!Decl || !Decl->hasAttrs())
         {
-            clang::IdentifierInfo const* II = attr->getAttrName();
-            if (!II)
+            return;
+        }
+        for (clang::Attr const* attr: Decl->getAttrs())
+        {
+            // Skip attributes the compiler injected rather than the user wrote.
+            if (attr->isImplicit())
             {
                 continue;
             }
-            if (!contains(I.Attributes, II->getName()))
+
+            // Only surface attributes written with a real attribute syntax.
+            // This excludes context-sensitive keywords such as `override`
+            // and `final`, which Clang models as attributes but which are
+            // documented through their own dedicated fields.
+            if (!attr->isStandardAttributeSyntax() &&
+                !attr->isGNUAttribute() &&
+                !attr->isDeclspecAttribute())
             {
-                I.Attributes.emplace_back(II->getName());
+                continue;
+            }
+
+            AttributeKind const kind = toAttributeKind(attr->getKind());
+            Polymorphic<Attribute> attribute = makeAttribute(kind);
+
+            // The written name, with scope (e.g. `gnu::custom`). Recognized
+            // attributes are normalized to their standard spelling; others
+            // keep the written spelling.
+            std::string written;
+            if (clang::IdentifierInfo const* scope = attr->getScopeName())
+            {
+                written = scope->getName().str();
+                written += "::";
+            }
+            std::string spelledName;
+            if (clang::IdentifierInfo const* II = attr->getAttrName())
+            {
+                spelledName = II->getName().str();
+            }
+            else
+            {
+                spelledName = attr->getSpelling();
+            }
+            written += spelledName;
+
+            if (std::string_view const normalized = standardAttributeName(kind);
+                !normalized.empty())
+            {
+                attribute->Name = normalized;
+            }
+            else
+            {
+                attribute->Name = std::move(written);
+            }
+
+            // Render the attribute canonically and read its argument tokens.
+            // printPretty avoids the fragility of the source spelling (macros,
+            // raw strings, comments) and normalizes string literals.
+            std::string pretty;
+            {
+                llvm::raw_string_ostream os(pretty);
+                attr->printPretty(os, context_.getPrintingPolicy());
+            }
+            attribute->balancedTokens = attributeArgs(pretty, spelledName);
+            // printPretty renders an argument-less `[[deprecated]]` or
+            // `[[nodiscard]]` as `name("")`; treat a lone empty string
+            // literal as no arguments.
+            if (attribute->balancedTokens.size() == 1 &&
+                attribute->balancedTokens.front() == "\"\"")
+            {
+                attribute->balancedTokens.clear();
+            }
+
+            // Evaluated, typed arguments for the attributes that carry them.
+            if (auto const* DA = dyn_cast<clang::DeprecatedAttr>(attr))
+            {
+                attribute->asDeprecated().Message = DA->getMessage().str();
+            }
+            else if (auto const* NA = dyn_cast<clang::WarnUnusedResultAttr>(attr))
+            {
+                attribute->asNodiscard().Reason = NA->getMessage().str();
+            }
+            else if (kind == AttributeKind::Assume &&
+                     !attribute->balancedTokens.empty())
+            {
+                attribute->asAssume().Expression = attribute->balancedTokens.front();
+            }
+
+            // Suppress exact duplicates only (same kind, name, and tokens):
+            // the same attribute may appear on more than one redeclaration or
+            // on both a template and its templated declaration. A repeated
+            // attribute with different arguments is kept.
+            if (std::ranges::none_of(
+                    I.Attributes,
+                    [&](Polymorphic<Attribute> const& other)
+                    {
+                        return other == attribute;
+                    }))
+            {
+                I.Attributes.push_back(std::move(attribute));
             }
         }
+    };
+
+    collect(D);
+
+    // Attributes such as [[nodiscard]] or [[deprecated]] on a template
+    // are attached to the templated declaration, not the template itself.
+    if (auto const* TD = dyn_cast<clang::TemplateDecl>(D))
+    {
+        collect(TD->getTemplatedDecl());
     }
 }
 

--- a/src/lib/AST/ASTVisitor.hpp
+++ b/src/lib/AST/ASTVisitor.hpp
@@ -729,10 +729,8 @@ private:
         std::vector<Polymorphic<TArg>>& result,
         clang::ASTTemplateArgumentListInfo const* args);
 
-    template <std::derived_from<Symbol> InfoTy>
-    static
     void
-    populateAttributes(InfoTy& I, clang::Decl const* D);
+    populateAttributes(Symbol& I, clang::Decl const* D);
 
     // =================================================
     // Populate function helpers

--- a/src/lib/Gen/xml/XMLWriter.cpp
+++ b/src/lib/Gen/xml/XMLWriter.cpp
@@ -13,10 +13,11 @@
 //
 
 #include "XMLWriter.hpp"
-#include <mrdocs/Metadata/Expression.hpp>
-#include <mrdocs/Metadata/Type.hpp>
-#include <mrdocs/Metadata/Template.hpp>
+#include <mrdocs/Metadata/Attributes.hpp>
 #include <mrdocs/Metadata/DocComment.hpp>
+#include <mrdocs/Metadata/Expression.hpp>
+#include <mrdocs/Metadata/Template.hpp>
+#include <mrdocs/Metadata/Type.hpp>
 #include <mrdocs/Support/EnumToString.hpp>
 #include <mrdocs/Support/MapReflectedType.hpp>
 #include <string>
@@ -270,7 +271,20 @@ XMLWriter::writePolymorphic(T const& value)
             writeMembers(static_cast<Name##Type const&>(value)); \
             tags_.close(toKebabCase(#Name)); \
             break;
-        #include <mrdocs/Metadata/Type/TypeNodes.inc>
+#include <mrdocs/Metadata/Type/TypeNodes.inc>
+        default: MRDOCS_UNREACHABLE();
+        }
+    }
+    else if constexpr (std::is_base_of_v<::mrdocs::Attribute, T>)
+    {
+        switch (value.Kind)
+        {
+        #define INFO(Name) case ::mrdocs::AttributeKind::Name: \
+            tags_.open(toKebabCase(#Name) + "-attribute"); \
+            writeMembers(value.as##Name()); \
+            tags_.close(toKebabCase(#Name) + "-attribute"); \
+            break;
+#include <mrdocs/Metadata/Attribute/AttributeNodes.inc>
         default: MRDOCS_UNREACHABLE();
         }
     }
@@ -283,7 +297,7 @@ XMLWriter::writePolymorphic(T const& value)
             writeMembers(static_cast<Name##TParam const&>(value)); \
             tags_.close(toKebabCase(#Name) + "-tparam"); \
             break;
-        #include <mrdocs/Metadata/TParam/TParamInfoNodes.inc>
+#include <mrdocs/Metadata/TParam/TParamInfoNodes.inc>
         default: MRDOCS_UNREACHABLE();
         }
     }
@@ -296,7 +310,7 @@ XMLWriter::writePolymorphic(T const& value)
             writeMembers(static_cast<Name##TArg const&>(value)); \
             tags_.close(toKebabCase(#Name) + "-targ"); \
             break;
-        #include <mrdocs/Metadata/TArg/TArgInfoNodes.inc>
+#include <mrdocs/Metadata/TArg/TArgInfoNodes.inc>
         default: MRDOCS_UNREACHABLE();
         }
     }
@@ -309,7 +323,7 @@ XMLWriter::writePolymorphic(T const& value)
             writeMembers(value.as##Name()); \
             tags_.close(toKebabCase(#Name)); \
             break;
-        #include <mrdocs/Metadata/DocComment/Block/BlockNodes.inc>
+#include <mrdocs/Metadata/DocComment/Block/BlockNodes.inc>
         default: MRDOCS_UNREACHABLE();
         }
     }
@@ -322,7 +336,7 @@ XMLWriter::writePolymorphic(T const& value)
             writeMembers(value.as##Name()); \
             tags_.close(toKebabCase(#Name)); \
             break;
-        #include <mrdocs/Metadata/DocComment/Inline/InlineNodes.inc>
+#include <mrdocs/Metadata/DocComment/Inline/InlineNodes.inc>
         default: MRDOCS_UNREACHABLE();
         }
     }

--- a/src/lib/Metadata/Attributes.cpp
+++ b/src/lib/Metadata/Attributes.cpp
@@ -1,0 +1,78 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#include <mrdocs/Dom/LazyObject.hpp>
+#include <mrdocs/Metadata/Attributes.hpp>
+#include <mrdocs/Support/CompareReflectedType.hpp>
+#include <mrdocs/Support/MapReflectedType.hpp>
+
+namespace mrdocs {
+
+dom::String
+toString(AttributeKind kind) noexcept
+{
+    switch(kind)
+    {
+    case AttributeKind::Other:
+        return "other";
+    case AttributeKind::Noreturn:
+        return "noreturn";
+    case AttributeKind::CarriesDependency:
+        return "carries-dependency";
+    case AttributeKind::Deprecated:
+        return "deprecated";
+    case AttributeKind::Fallthrough:
+        return "fallthrough";
+    case AttributeKind::MaybeUnused:
+        return "maybe-unused";
+    case AttributeKind::Nodiscard:
+        return "nodiscard";
+    case AttributeKind::Likely:
+        return "likely";
+    case AttributeKind::Unlikely:
+        return "unlikely";
+    case AttributeKind::NoUniqueAddress:
+        return "no-unique-address";
+    case AttributeKind::Assume:
+        return "assume";
+    case AttributeKind::Indeterminate:
+        return "indeterminate";
+    default:
+        MRDOCS_UNREACHABLE();
+    }
+}
+
+void
+tag_invoke(
+    dom::ValueFromTag,
+    dom::Value& v,
+    Attribute const& I,
+    DomCorpus const* domCorpus)
+{
+    visit(I, [&]<typename T>(T const& t) {
+        v = dom::LazyObject(t, domCorpus);
+    });
+}
+
+std::strong_ordering
+operator<=>(Polymorphic<Attribute> const& lhs, Polymorphic<Attribute> const& rhs)
+{
+    MRDOCS_ASSERT(!lhs.valueless_after_move());
+    MRDOCS_ASSERT(!rhs.valueless_after_move());
+    auto& lhsRef = *lhs;
+    auto& rhsRef = *rhs;
+    if (lhsRef.Kind == rhsRef.Kind)
+    {
+        return visit(lhsRef, detail::VisitCompareFn<Attribute>(rhsRef));
+    }
+    return lhsRef.Kind <=> rhsRef.Kind;
+}
+
+} // mrdocs

--- a/src/test/lib/Metadata/Merge.cpp
+++ b/src/test/lib/Metadata/Merge.cpp
@@ -8,13 +8,13 @@
 // Official repository: https://github.com/cppalliance/mrdocs
 //
 
+#include <mrdocs/Metadata/Name/IdentifierName.hpp>
 #include <mrdocs/Metadata/Symbol/Enum.hpp>
 #include <mrdocs/Metadata/Symbol/Friend.hpp>
 #include <mrdocs/Metadata/Symbol/Function.hpp>
 #include <mrdocs/Metadata/Symbol/Namespace.hpp>
 #include <mrdocs/Metadata/Symbol/Param.hpp>
 #include <mrdocs/Metadata/Symbol/Record.hpp>
-#include <mrdocs/Metadata/Name/IdentifierName.hpp>
 #include <mrdocs/Metadata/Type/NamedType.hpp>
 #include <mrdocs/Support/MergeReflectedType.hpp>
 #include <test_suite/test_suite.hpp>
@@ -327,11 +327,19 @@ struct MergeTest
 
     void test_func_attributes_dedup()
     {
+        auto makeNodiscard = []{
+            NodiscardAttribute a;
+            a.Name = "nodiscard";
+            return Polymorphic<Attribute>(a);
+        };
         auto dst = makeFunc();
-        dst.Attributes.push_back("nodiscard");
+        dst.Attributes.push_back(makeNodiscard());
         auto src = makeFunc();
-        src.Attributes.push_back("nodiscard");
-        src.Attributes.push_back("deprecated");
+        src.Attributes.push_back(makeNodiscard());
+        DeprecatedAttribute dep;
+        dep.Name = "deprecated";
+        dep.Message = "use bar";
+        src.Attributes.push_back(Polymorphic<Attribute>(dep));
 
         merge(dst, std::move(src));
         BOOST_TEST(dst.Attributes.size() == 2u);

--- a/test-files/golden-tests/generator/hbs/attributes/attributes.adoc
+++ b/test-files/golden-tests/generator/hbs/attributes/attributes.adoc
@@ -1,0 +1,357 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Types
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#Aligned[`Aligned`] 
+| An over&hyphen;aligned type (a single, non&hyphen;string attribute argument)&period;
+| link:#Gadget[`Gadget`] 
+| A class whose members carry attributes, to exercise member&hyphen;table tags&period;
+| link:#Gnu[`Gnu`]  [.small]#[deprecated]#
+| A class deprecated via the GNU spelling, normalized to the standard form&period;
+| link:#Widget[`Widget`]  [.small]#[deprecated]#
+| A deprecated class&period;
+|===
+
+
+=== Type Aliases
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#extension_type[`extension&lowbar;type`]  [.small]#[deprecated]#
+| A deprecated type alias (the motivating case from issue &num;1233)&period;
+|===
+
+
+=== Enums
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#Color[`Color`]  [.small]#[deprecated]#
+| A deprecated scoped enum with a deprecated enumerator&period;
+|===
+
+
+=== Functions
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#annotated[`annotated`] 
+| A function carrying the same attribute twice with different arguments&period;
+| link:#checked[`checked`] 
+| A nodiscard function (an attribute with no arguments)&period;
+| link:#compute[`compute`]  [.small]#[deprecated]#
+| A deprecated function with a message&period;
+| link:#log_message[`log&lowbar;message`] 
+| A printf&hyphen;like function (an attribute with multiple arguments)&period;
+|===
+
+
+=== Variables
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#value[`value`]  [.small]#[deprecated]#
+| A deprecated variable&period;
+|===
+
+
+[#extension_type]
+== extension&lowbar;type
+
+A deprecated type alias (the motivating case from issue &num;1233)&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+using extension&lowbar;type &lsqb;&lsqb;deprecated(&quot;use extent&lowbar;type&quot;)&rsqb;&rsqb; = int;
+----
+
+[WARNING]
+====
+https://en.cppreference.com/cpp/language/attributes/deprecated[Deprecated^]: use extent&lowbar;type. Use of this entity is allowed but discouraged.
+====
+[#Aligned]
+== Aligned
+
+An over&hyphen;aligned type (a single, non&hyphen;string attribute argument)&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct &lsqb;&lsqb;gnu&colon;&colon;aligned(16)&rsqb;&rsqb; Aligned;
+----
+
+[#Gadget]
+== Gadget
+
+A class whose members carry attributes, to exercise member&hyphen;table tags&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct Gadget;
+----
+
+=== Member Functions
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#Gadget-fail[`fail`]  [.small]#[noreturn]#
+| A member function that never returns&period;
+| link:#Gadget-run[`run`]  [.small]#[deprecated]#
+| A deprecated member function&period;
+|===
+
+
+=== Data Members
+
+[cols="1,4"]
+|===
+| Name| Description
+| link:#Gadget-field[`field`]  [.small]#[deprecated]#
+| A deprecated data member&period;
+|===
+
+
+[#Gadget-fail]
+== link:#Gadget[Gadget]::fail
+
+A member function that never returns&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&lsqb;&lsqb;noreturn&rsqb;&rsqb;
+void
+fail();
+----
+
+=== Return Value
+
+[NOTE]
+====
+This function https://en.cppreference.com/cpp/language/attributes/noreturn[does not return^].
+====
+[#Gadget-run]
+== link:#Gadget[Gadget]::run
+
+A deprecated member function&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&lsqb;&lsqb;deprecated(&quot;use run2&quot;)&rsqb;&rsqb;
+void
+run();
+----
+
+[WARNING]
+====
+https://en.cppreference.com/cpp/language/attributes/deprecated[Deprecated^]: use run2. Use of this entity is allowed but discouraged.
+====
+[#Gadget-field]
+== link:#Gadget[Gadget]::field
+
+A deprecated data member&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&lsqb;&lsqb;deprecated&rsqb;&rsqb;
+int field;
+----
+
+[WARNING]
+====
+https://en.cppreference.com/cpp/language/attributes/deprecated[Deprecated^]. Use of this entity is allowed but discouraged.
+====
+[#Gnu]
+== Gnu
+
+A class deprecated via the GNU spelling, normalized to the standard form&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct &lsqb;&lsqb;deprecated(&quot;use Gnu2&quot;)&rsqb;&rsqb; Gnu;
+----
+
+[WARNING]
+====
+https://en.cppreference.com/cpp/language/attributes/deprecated[Deprecated^]: use Gnu2. Use of this entity is allowed but discouraged.
+====
+[#Widget]
+== Widget
+
+A deprecated class&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct &lsqb;&lsqb;deprecated(&quot;use Widget2&quot;)&rsqb;&rsqb; Widget;
+----
+
+[WARNING]
+====
+https://en.cppreference.com/cpp/language/attributes/deprecated[Deprecated^]: use Widget2. Use of this entity is allowed but discouraged.
+====
+[#Color]
+== Color
+
+A deprecated scoped enum with a deprecated enumerator&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+enum class &lsqb;&lsqb;deprecated(&quot;use Color2&quot;)&rsqb;&rsqb; Color : int;
+----
+
+[WARNING]
+====
+https://en.cppreference.com/cpp/language/attributes/deprecated[Deprecated^]: use Color2. Use of this entity is allowed but discouraged.
+====
+=== Members
+
+[cols="1"]
+|===
+| Name
+| `Red` 
+| `Green`  [.small]#[deprecated]#
+| `Blue` 
+|===
+
+
+[#annotated]
+== annotated
+
+A function carrying the same attribute twice with different arguments&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&lsqb;&lsqb;clang&colon;&colon;annotate(&quot;a&quot;), clang&colon;&colon;annotate(&quot;b&quot;)&rsqb;&rsqb;
+void
+annotated();
+----
+
+[#checked]
+== checked
+
+A nodiscard function (an attribute with no arguments)&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&lsqb;&lsqb;nodiscard&rsqb;&rsqb;
+int
+checked();
+----
+
+=== Return Value
+
+[NOTE]
+====
+The return value https://en.cppreference.com/cpp/language/attributes/nodiscard[should not be discarded^].
+====
+[#compute]
+== compute
+
+A deprecated function with a message&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&lsqb;&lsqb;deprecated(&quot;use compute2&quot;)&rsqb;&rsqb;
+int
+compute();
+----
+
+[WARNING]
+====
+https://en.cppreference.com/cpp/language/attributes/deprecated[Deprecated^]: use compute2. Use of this entity is allowed but discouraged.
+====
+[#log_message]
+== log&lowbar;message
+
+A printf&hyphen;like function (an attribute with multiple arguments)&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&lsqb;&lsqb;gnu&colon;&colon;format(printf, 1, 2)&rsqb;&rsqb;
+void
+log&lowbar;message(char const* fmt, &period;&period;&period;);
+----
+
+[#value]
+== value
+
+A deprecated variable&period;
+
+=== Synopsis
+
+Declared in `&lt;attributes&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&lsqb;&lsqb;deprecated(&quot;use value2&quot;)&rsqb;&rsqb;
+inline int value = 0;
+----
+
+[WARNING]
+====
+https://en.cppreference.com/cpp/language/attributes/deprecated[Deprecated^]: use value2. Use of this entity is allowed but discouraged.
+====
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/generator/hbs/attributes/attributes.cpp
+++ b/test-files/golden-tests/generator/hbs/attributes/attributes.cpp
@@ -1,0 +1,57 @@
+// A generator rendering example: how C++ attributes appear in the
+// Handlebars-generated pages (adoc and HTML).
+//
+// Unlike the XML corpus tests under symbols/, this exercises the
+// templates: the `[[...]]` clause in each kind's signature, the
+// attribute admonitions, and the `[deprecated]`/`[noreturn]` tags in
+// member tables.
+// It is deliberately small because the HTML/adoc generators are
+// expensive; it just needs to cover the renderable cases once.
+
+/// A deprecated class.
+struct [[deprecated("use Widget2")]] Widget {};
+
+/// A class deprecated via the GNU spelling, normalized to the standard form.
+struct [[gnu::deprecated("use Gnu2")]] Gnu {};
+
+/// An over-aligned type (a single, non-string attribute argument).
+struct [[gnu::aligned(16)]] Aligned {};
+
+/// A deprecated scoped enum with a deprecated enumerator.
+enum class [[deprecated("use Color2")]] Color
+{
+    Red,
+    Green [[deprecated("use Blue")]],
+    Blue
+};
+
+/// A deprecated type alias (the motivating case from issue #1233).
+using extension_type [[deprecated("use extent_type")]] = int;
+
+/// A nodiscard function (an attribute with no arguments).
+[[nodiscard]] int checked();
+
+/// A deprecated function with a message.
+[[deprecated("use compute2")]] int compute();
+
+/// A printf-like function (an attribute with multiple arguments).
+[[gnu::format(printf, 1, 2)]] void log_message(char const* fmt, ...);
+
+/// A function carrying the same attribute twice with different arguments.
+[[clang::annotate("a"), clang::annotate("b")]] void annotated();
+
+/// A deprecated variable.
+[[deprecated("use value2")]] inline int value = 0;
+
+/// A class whose members carry attributes, to exercise member-table tags.
+struct Gadget
+{
+    /// A deprecated member function.
+    [[deprecated("use run2")]] void run();
+
+    /// A member function that never returns.
+    [[noreturn]] void fail();
+
+    /// A deprecated data member.
+    [[deprecated]] int field;
+};

--- a/test-files/golden-tests/generator/hbs/attributes/attributes.html
+++ b/test-files/golden-tests/generator/hbs/attributes/attributes.html
@@ -1,0 +1,347 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+<meta charset="utf-8">
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div class="symbol">
+<div class="header">
+<h2 id="index">Global namespace</h2>
+</div><!-- /header -->
+<h3>Types</h3>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="#Aligned"><code>Aligned</code></a> </td><td>An over-aligned type (a single, non-string attribute argument).</td></tr>
+<tr><td><a href="#Gadget"><code>Gadget</code></a> </td><td>A class whose members carry attributes, to exercise member-table tags.</td></tr>
+<tr><td><a href="#Gnu"><code>Gnu</code></a>  <span class="small">[deprecated]</span></td><td>A class deprecated via the GNU spelling, normalized to the standard form.</td></tr>
+<tr><td><a href="#Widget"><code>Widget</code></a>  <span class="small">[deprecated]</span></td><td>A deprecated class.</td></tr>
+</tbody>
+</table>
+
+<h3>Type Aliases</h3>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="#extension_type"><code>extension_type</code></a>  <span class="small">[deprecated]</span></td><td>A deprecated type alias (the motivating case from issue #1233).</td></tr>
+</tbody>
+</table>
+
+<h3>Enums</h3>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="#Color"><code>Color</code></a>  <span class="small">[deprecated]</span></td><td>A deprecated scoped enum with a deprecated enumerator.</td></tr>
+</tbody>
+</table>
+
+<h3>Functions</h3>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="#annotated"><code>annotated</code></a> </td><td>A function carrying the same attribute twice with different arguments.</td></tr>
+<tr><td><a href="#checked"><code>checked</code></a> </td><td>A nodiscard function (an attribute with no arguments).</td></tr>
+<tr><td><a href="#compute"><code>compute</code></a>  <span class="small">[deprecated]</span></td><td>A deprecated function with a message.</td></tr>
+<tr><td><a href="#log_message"><code>log_message</code></a> </td><td>A printf-like function (an attribute with multiple arguments).</td></tr>
+</tbody>
+</table>
+
+<h3>Variables</h3>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="#value"><code>value</code></a>  <span class="small">[deprecated]</span></td><td>A deprecated variable.</td></tr>
+</tbody>
+</table>
+
+</div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="extension_type">extension_type</h2>
+<div class="brief">
+<p>A deprecated type alias (the motivating case from issue #1233).</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">using extension_type [[deprecated(&quot;use extent_type&quot;)]] = int;</code></pre>
+</div><!-- /synopsis -->
+<div class="admonition">
+<h4>WARNING</h4>
+<div>
+<p><a href="https://en.cppreference.com/cpp/language/attributes/deprecated" target="_blank" rel="noopener">Deprecated</a>: use extent_type. Use of this entity is allowed but discouraged.</p>
+</div>
+</div></div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="Aligned">Aligned</h2>
+<div class="brief">
+<p>An over-aligned type (a single, non-string attribute argument).</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">struct [[gnu::aligned(16)]] Aligned;</code></pre>
+</div><!-- /synopsis -->
+</div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="Gadget">Gadget</h2>
+<div class="brief">
+<p>A class whose members carry attributes, to exercise member-table tags.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">struct Gadget;</code></pre>
+</div><!-- /synopsis -->
+<h3>Member Functions</h3>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="#Gadget-fail"><code>fail</code></a>  <span class="small">[noreturn]</span></td><td>A member function that never returns.</td></tr>
+<tr><td><a href="#Gadget-run"><code>run</code></a>  <span class="small">[deprecated]</span></td><td>A deprecated member function.</td></tr>
+</tbody>
+</table>
+
+<h3>Data Members</h3>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><a href="#Gadget-field"><code>field</code></a>  <span class="small">[deprecated]</span></td><td>A deprecated data member.</td></tr>
+</tbody>
+</table>
+
+</div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="Gadget-fail"><a href="#Gadget">Gadget</a>::fail</h2>
+<div class="brief">
+<p>A member function that never returns.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">[[noreturn]]
+void
+fail();</code></pre>
+</div><!-- /synopsis -->
+<div class="return-value">
+<h3>Return Value</h3>
+<div class="admonition">
+<h4>NOTE</h4>
+<div>
+<p>This function <a href="https://en.cppreference.com/cpp/language/attributes/noreturn" target="_blank" rel="noopener">does not return</a>.</p>
+</div>
+</div></div><!-- /return-value -->
+</div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="Gadget-run"><a href="#Gadget">Gadget</a>::run</h2>
+<div class="brief">
+<p>A deprecated member function.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">[[deprecated(&quot;use run2&quot;)]]
+void
+run();</code></pre>
+</div><!-- /synopsis -->
+<div class="admonition">
+<h4>WARNING</h4>
+<div>
+<p><a href="https://en.cppreference.com/cpp/language/attributes/deprecated" target="_blank" rel="noopener">Deprecated</a>: use run2. Use of this entity is allowed but discouraged.</p>
+</div>
+</div></div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="Gadget-field"><a href="#Gadget">Gadget</a>::field</h2>
+<div class="brief">
+<p>A deprecated data member.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">[[deprecated]]
+int field;</code></pre>
+</div><!-- /synopsis -->
+<div class="admonition">
+<h4>WARNING</h4>
+<div>
+<p><a href="https://en.cppreference.com/cpp/language/attributes/deprecated" target="_blank" rel="noopener">Deprecated</a>. Use of this entity is allowed but discouraged.</p>
+</div>
+</div></div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="Gnu">Gnu</h2>
+<div class="brief">
+<p>A class deprecated via the GNU spelling, normalized to the standard form.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">struct [[deprecated(&quot;use Gnu2&quot;)]] Gnu;</code></pre>
+</div><!-- /synopsis -->
+<div class="admonition">
+<h4>WARNING</h4>
+<div>
+<p><a href="https://en.cppreference.com/cpp/language/attributes/deprecated" target="_blank" rel="noopener">Deprecated</a>: use Gnu2. Use of this entity is allowed but discouraged.</p>
+</div>
+</div></div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="Widget">Widget</h2>
+<div class="brief">
+<p>A deprecated class.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">struct [[deprecated(&quot;use Widget2&quot;)]] Widget;</code></pre>
+</div><!-- /synopsis -->
+<div class="admonition">
+<h4>WARNING</h4>
+<div>
+<p><a href="https://en.cppreference.com/cpp/language/attributes/deprecated" target="_blank" rel="noopener">Deprecated</a>: use Widget2. Use of this entity is allowed but discouraged.</p>
+</div>
+</div></div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="Color">Color</h2>
+<div class="brief">
+<p>A deprecated scoped enum with a deprecated enumerator.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">enum class [[deprecated(&quot;use Color2&quot;)]] Color : int;</code></pre>
+</div><!-- /synopsis -->
+<div class="admonition">
+<h4>WARNING</h4>
+<div>
+<p><a href="https://en.cppreference.com/cpp/language/attributes/deprecated" target="_blank" rel="noopener">Deprecated</a>: use Color2. Use of this entity is allowed but discouraged.</p>
+</div>
+</div><h3>Members</h3>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr><th>Name</th></tr>
+</thead>
+<tbody>
+<tr><td><code>Red</code> </td></tr>
+<tr><td><code>Green</code>  <span class="small">[deprecated]</span></td></tr>
+<tr><td><code>Blue</code> </td></tr>
+</tbody>
+</table>
+
+</div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="annotated">annotated</h2>
+<div class="brief">
+<p>A function carrying the same attribute twice with different arguments.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">[[clang::annotate(&quot;a&quot;), clang::annotate(&quot;b&quot;)]]
+void
+annotated();</code></pre>
+</div><!-- /synopsis -->
+</div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="checked">checked</h2>
+<div class="brief">
+<p>A nodiscard function (an attribute with no arguments).</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">[[nodiscard]]
+int
+checked();</code></pre>
+</div><!-- /synopsis -->
+<div class="return-value">
+<h3>Return Value</h3>
+<div class="admonition">
+<h4>NOTE</h4>
+<div>
+<p>The return value <a href="https://en.cppreference.com/cpp/language/attributes/nodiscard" target="_blank" rel="noopener">should not be discarded</a>.</p>
+</div>
+</div></div><!-- /return-value -->
+</div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="compute">compute</h2>
+<div class="brief">
+<p>A deprecated function with a message.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">[[deprecated(&quot;use compute2&quot;)]]
+int
+compute();</code></pre>
+</div><!-- /synopsis -->
+<div class="admonition">
+<h4>WARNING</h4>
+<div>
+<p><a href="https://en.cppreference.com/cpp/language/attributes/deprecated" target="_blank" rel="noopener">Deprecated</a>: use compute2. Use of this entity is allowed but discouraged.</p>
+</div>
+</div></div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="log_message">log_message</h2>
+<div class="brief">
+<p>A printf-like function (an attribute with multiple arguments).</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">[[gnu::format(printf, 1, 2)]]
+void
+log_message(char const* fmt, ...);</code></pre>
+</div><!-- /synopsis -->
+</div><!-- /symbol -->
+<div class="symbol">
+<div class="header">
+<h2 id="value">value</h2>
+<div class="brief">
+<p>A deprecated variable.</p></div><!-- /brief -->
+</div><!-- /header -->
+<div class="synopsis">
+<h3>Synopsis</h3>
+<p>Declared in <code>&lt;attributes.cpp&gt;</code></p>
+<pre><code class="source-code cpp">[[deprecated(&quot;use value2&quot;)]]
+inline int value = 0;</code></pre>
+</div><!-- /synopsis -->
+<div class="admonition">
+<h4>WARNING</h4>
+<div>
+<p><a href="https://en.cppreference.com/cpp/language/attributes/deprecated" target="_blank" rel="noopener">Deprecated</a>: use value2. Use of this entity is allowed but discouraged.</p>
+</div>
+</div></div><!-- /symbol -->
+
+</div>
+<footer class="mrdocs-footer">
+<span>Created with <a href="https://www.mrdocs.com">MrDocs</a></span>
+</footer>
+</body>
+</html>

--- a/test-files/golden-tests/generator/hbs/attributes/mrdocs.yml
+++ b/test-files/golden-tests/generator/hbs/attributes/mrdocs.yml
@@ -1,0 +1,5 @@
+generator: [adoc, html]
+multipage: false
+no-default-styles: true
+warn-if-undocumented: false
+source-root: .

--- a/test-files/golden-tests/snippets/landing/sqrt.adoc
+++ b/test-files/golden-tests/snippets/landing/sqrt.adoc
@@ -43,6 +43,10 @@ Returns zero for zero input&period;
 
 The integer square root of `value`&period;
 
+[NOTE]
+====
+The return value https://en.cppreference.com/cpp/language/attributes/nodiscard[should not be discarded^].
+====
 === Template Parameters
 
 [cols="1,4"]

--- a/test-files/golden-tests/snippets/landing/sqrt.html
+++ b/test-files/golden-tests/snippets/landing/sqrt.html
@@ -42,7 +42,12 @@ requires std::is_integral_v&lt;T&gt;;</code></pre>
 <div class="return-value">
 <h3>Return Value</h3>
 <p>The integer square root of <code>value</code>.</p>
-</div><!-- /return-value -->
+<div class="admonition">
+<h4>NOTE</h4>
+<div>
+<p>The return value <a href="https://en.cppreference.com/cpp/language/attributes/nodiscard" target="_blank" rel="noopener">should not be discarded</a>.</p>
+</div>
+</div></div><!-- /return-value -->
 <div class="template-parameters">
 <h3>Template Parameters</h3>
 <table style="table-layout: fixed; width: 100%;">

--- a/test-files/golden-tests/snippets/terminate.adoc
+++ b/test-files/golden-tests/snippets/terminate.adoc
@@ -27,5 +27,11 @@ This function does not return&period;
 
 ====
 
+=== Return Value
+
+[NOTE]
+====
+This function https://en.cppreference.com/cpp/language/attributes/noreturn[does not return^].
+====
 
 [.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/symbols/enum/attributes.cpp
+++ b/test-files/golden-tests/symbols/enum/attributes.cpp
@@ -1,0 +1,6 @@
+// Attributes are captured on enums and their enumerators.
+enum class [[deprecated("use Color2")]] Color {
+    Red,
+    Green [[deprecated("use Blue")]],
+    Blue
+};

--- a/test-files/golden-tests/symbols/enum/attributes.xml
+++ b/test-files/golden-tests/symbols/enum/attributes.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace>
+  <source>
+  </source>
+  <kind>namespace</kind>
+  <id>//////////////////////////8=</id>
+  <extraction>regular</extraction>
+  <namespace-tranche>
+    <enums>8ys5YHCZzogRGq/E/f61InZlmOE=</enums>
+  </namespace-tranche>
+</namespace>
+<enum>
+  <name>Color</name>
+  <source>
+    <location>
+      <short-path>attributes.cpp</short-path>
+      <source-path>attributes.cpp</source-path>
+      <line-number>2</line-number>
+      <column-number>1</column-number>
+    </location>
+  </source>
+  <kind>enum</kind>
+  <id>8ys5YHCZzogRGq/E/f61InZlmOE=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <deprecated-attribute>
+    <name>deprecated</name>
+    <balanced-tokens>&quot;use Color2&quot;</balanced-tokens>
+    <message>use Color2</message>
+  </deprecated-attribute>
+  <scoped>1</scoped>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>int</identifier>
+    </name>
+  </named>
+  <constants>BBOAF6yhnTvCHkG9Jr5y9fvtD58=</constants>
+  <constants>Lx0D7a81JkdDRHL9+a9QPTM4Np0=</constants>
+  <constants>kd2nnOQJJwznL3PIvdJxDbGUmr4=</constants>
+</enum>
+<enum-constant>
+  <name>Red</name>
+  <source>
+    <location>
+      <short-path>attributes.cpp</short-path>
+      <source-path>attributes.cpp</source-path>
+      <line-number>3</line-number>
+      <column-number>5</column-number>
+    </location>
+  </source>
+  <kind>enum-constant</kind>
+  <id>BBOAF6yhnTvCHkG9Jr5y9fvtD58=</id>
+  <extraction>regular</extraction>
+  <parent>8ys5YHCZzogRGq/E/f61InZlmOE=</parent>
+</enum-constant>
+<enum-constant>
+  <name>Green</name>
+  <source>
+    <location>
+      <short-path>attributes.cpp</short-path>
+      <source-path>attributes.cpp</source-path>
+      <line-number>4</line-number>
+      <column-number>5</column-number>
+    </location>
+  </source>
+  <kind>enum-constant</kind>
+  <id>Lx0D7a81JkdDRHL9+a9QPTM4Np0=</id>
+  <extraction>regular</extraction>
+  <parent>8ys5YHCZzogRGq/E/f61InZlmOE=</parent>
+  <deprecated-attribute>
+    <name>deprecated</name>
+    <balanced-tokens>&quot;use Blue&quot;</balanced-tokens>
+    <message>use Blue</message>
+  </deprecated-attribute>
+</enum-constant>
+<enum-constant>
+  <name>Blue</name>
+  <source>
+    <location>
+      <short-path>attributes.cpp</short-path>
+      <source-path>attributes.cpp</source-path>
+      <line-number>5</line-number>
+      <column-number>5</column-number>
+    </location>
+  </source>
+  <kind>enum-constant</kind>
+  <id>kd2nnOQJJwznL3PIvdJxDbGUmr4=</id>
+  <extraction>regular</extraction>
+  <parent>8ys5YHCZzogRGq/E/f61InZlmOE=</parent>
+</enum-constant>
+</mrdocs>

--- a/test-files/golden-tests/symbols/function/attributes-2.xml
+++ b/test-files/golden-tests/symbols/function/attributes-2.xml
@@ -25,6 +25,9 @@
   <id>e/hP0+mSSe5Ju83w/5pueMcFgLQ=</id>
   <extraction>regular</extraction>
   <parent>//////////////////////////8=</parent>
+  <nodiscard-attribute>
+    <name>nodiscard</name>
+  </nodiscard-attribute>
   <named>
     <name>
       <kind>identifier</kind>
@@ -39,7 +42,5 @@
     </type-tparam>
   </template>
   <func-class>normal</func-class>
-  <is-nodiscard>1</is-nodiscard>
-  <attributes>nodiscard</attributes>
 </function>
 </mrdocs>

--- a/test-files/golden-tests/symbols/function/attributes-3.cpp
+++ b/test-files/golden-tests/symbols/function/attributes-3.cpp
@@ -1,0 +1,11 @@
+// A deprecated function with a message, and an attribute with multiple arguments.
+[[deprecated("use compute2")]] int compute();
+
+[[gnu::format(printf, 1, 2)]] void log_message(char const* fmt, ...);
+
+// The same attribute repeated with different arguments is kept, not deduplicated.
+[[clang::annotate("a"), clang::annotate("b")]] void annotated();
+
+// A raw string literal with an inner comma stays a single argument
+// (printPretty renders it as a normal string literal).
+[[deprecated(R"(use a, b)")]] void raw_message();

--- a/test-files/golden-tests/symbols/function/attributes-3.xml
+++ b/test-files/golden-tests/symbols/function/attributes-3.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace>
+  <source>
+  </source>
+  <kind>namespace</kind>
+  <id>//////////////////////////8=</id>
+  <extraction>regular</extraction>
+  <namespace-tranche>
+    <functions>6BYUopzX+DBqDbRJLP2dm/2e0PI=</functions>
+    <functions>1EwAic4Ry+EDiChtdDEPDw/vEtQ=</functions>
+    <functions>K/UYck54RmD14h3yIN/RSUyOvEg=</functions>
+    <functions>TC/uKMv0qxSXX9JNVZ+KVi1ZvMU=</functions>
+  </namespace-tranche>
+</namespace>
+<function>
+  <name>annotated</name>
+  <source>
+    <location>
+      <short-path>attributes-3.cpp</short-path>
+      <source-path>attributes-3.cpp</source-path>
+      <line-number>7</line-number>
+      <column-number>48</column-number>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>6BYUopzX+DBqDbRJLP2dm/2e0PI=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <other-attribute>
+    <name>clang::annotate</name>
+    <balanced-tokens>&quot;a&quot;</balanced-tokens>
+  </other-attribute>
+  <other-attribute>
+    <name>clang::annotate</name>
+    <balanced-tokens>&quot;b&quot;</balanced-tokens>
+  </other-attribute>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+<function>
+  <name>compute</name>
+  <source>
+    <location>
+      <short-path>attributes-3.cpp</short-path>
+      <source-path>attributes-3.cpp</source-path>
+      <line-number>2</line-number>
+      <column-number>32</column-number>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>1EwAic4Ry+EDiChtdDEPDw/vEtQ=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <deprecated-attribute>
+    <name>deprecated</name>
+    <balanced-tokens>&quot;use compute2&quot;</balanced-tokens>
+    <message>use compute2</message>
+  </deprecated-attribute>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>int</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+<function>
+  <name>log_message</name>
+  <source>
+    <location>
+      <short-path>attributes-3.cpp</short-path>
+      <source-path>attributes-3.cpp</source-path>
+      <line-number>4</line-number>
+      <column-number>31</column-number>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>K/UYck54RmD14h3yIN/RSUyOvEg=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <other-attribute>
+    <name>gnu::format</name>
+    <balanced-tokens>printf</balanced-tokens>
+    <balanced-tokens>1</balanced-tokens>
+    <balanced-tokens>2</balanced-tokens>
+  </other-attribute>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <param>
+    <pointer>
+      <named>
+        <is-const>1</is-const>
+        <name>
+          <kind>identifier</kind>
+          <identifier>char</identifier>
+        </name>
+      </named>
+    </pointer>
+    <name>fmt</name>
+  </param>
+  <func-class>normal</func-class>
+  <is-variadic>1</is-variadic>
+</function>
+<function>
+  <name>raw_message</name>
+  <source>
+    <location>
+      <short-path>attributes-3.cpp</short-path>
+      <source-path>attributes-3.cpp</source-path>
+      <line-number>11</line-number>
+      <column-number>31</column-number>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>TC/uKMv0qxSXX9JNVZ+KVi1ZvMU=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <deprecated-attribute>
+    <name>deprecated</name>
+    <balanced-tokens>&quot;use a, b&quot;</balanced-tokens>
+    <message>use a, b</message>
+  </deprecated-attribute>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+</mrdocs>

--- a/test-files/golden-tests/symbols/function/attributes_1.xml
+++ b/test-files/golden-tests/symbols/function/attributes_1.xml
@@ -25,6 +25,9 @@
   <id>s6nsa+zVhpzzrN+yUVPP5rvdXqs=</id>
   <extraction>regular</extraction>
   <parent>//////////////////////////8=</parent>
+  <nodiscard-attribute>
+    <name>nodiscard</name>
+  </nodiscard-attribute>
   <named>
     <name>
       <kind>identifier</kind>
@@ -32,7 +35,5 @@
     </name>
   </named>
   <func-class>normal</func-class>
-  <is-nodiscard>1</is-nodiscard>
-  <attributes>nodiscard</attributes>
 </function>
 </mrdocs>

--- a/test-files/golden-tests/symbols/function/noreturn.xml
+++ b/test-files/golden-tests/symbols/function/noreturn.xml
@@ -55,6 +55,9 @@
   <id>TkBjWwqMDycyUbq+TJZ9qfUhSn0=</id>
   <extraction>regular</extraction>
   <parent>CgGNdHpW5mG/i5741WPYQDw28OQ=</parent>
+  <noreturn-attribute>
+    <name>noreturn</name>
+  </noreturn-attribute>
   <named>
     <name>
       <kind>identifier</kind>
@@ -62,9 +65,7 @@
     </name>
   </named>
   <func-class>normal</func-class>
-  <is-no-return>1</is-no-return>
   <is-record-method>1</is-record-method>
-  <attributes>noreturn</attributes>
 </function>
 <function>
   <name>f2</name>
@@ -80,6 +81,9 @@
   <id>QjsWLydQujVa097RP8f2Lq3nLQ4=</id>
   <extraction>regular</extraction>
   <parent>CgGNdHpW5mG/i5741WPYQDw28OQ=</parent>
+  <noreturn-attribute>
+    <name>noreturn</name>
+  </noreturn-attribute>
   <named>
     <name>
       <kind>identifier</kind>
@@ -87,9 +91,7 @@
     </name>
   </named>
   <func-class>normal</func-class>
-  <is-no-return>1</is-no-return>
   <is-record-method>1</is-record-method>
-  <attributes>noreturn</attributes>
 </function>
 <function>
   <name>f1</name>
@@ -105,6 +107,9 @@
   <id>CnO51rIKTzfiVKHkR3TdPa0eo+8=</id>
   <extraction>regular</extraction>
   <parent>//////////////////////////8=</parent>
+  <noreturn-attribute>
+    <name>noreturn</name>
+  </noreturn-attribute>
   <named>
     <name>
       <kind>identifier</kind>
@@ -112,7 +117,5 @@
     </name>
   </named>
   <func-class>normal</func-class>
-  <is-no-return>1</is-no-return>
-  <attributes>noreturn</attributes>
 </function>
 </mrdocs>

--- a/test-files/golden-tests/symbols/namespace/attributes.cpp
+++ b/test-files/golden-tests/symbols/namespace/attributes.cpp
@@ -1,0 +1,4 @@
+// Attributes are captured on namespaces.
+namespace [[deprecated("use modern")]] legacy_ns {
+    int helper();
+}

--- a/test-files/golden-tests/symbols/namespace/attributes.xml
+++ b/test-files/golden-tests/symbols/namespace/attributes.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace>
+  <source>
+  </source>
+  <kind>namespace</kind>
+  <id>//////////////////////////8=</id>
+  <extraction>regular</extraction>
+  <namespace-tranche>
+    <namespaces>vpR4zjT6foxXlZ9V8mKO1WZYP60=</namespaces>
+  </namespace-tranche>
+</namespace>
+<namespace>
+  <name>legacy_ns</name>
+  <source>
+    <location>
+      <short-path>attributes.cpp</short-path>
+      <source-path>attributes.cpp</source-path>
+      <line-number>2</line-number>
+      <column-number>1</column-number>
+    </location>
+  </source>
+  <kind>namespace</kind>
+  <id>vpR4zjT6foxXlZ9V8mKO1WZYP60=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <deprecated-attribute>
+    <name>deprecated</name>
+    <balanced-tokens>&quot;use modern&quot;</balanced-tokens>
+    <message>use modern</message>
+  </deprecated-attribute>
+  <namespace-tranche>
+    <functions>MGjnNpl1DGvioJk9Sr4NgYgDIAo=</functions>
+  </namespace-tranche>
+</namespace>
+<function>
+  <name>helper</name>
+  <source>
+    <location>
+      <short-path>attributes.cpp</short-path>
+      <source-path>attributes.cpp</source-path>
+      <line-number>3</line-number>
+      <column-number>5</column-number>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>MGjnNpl1DGvioJk9Sr4NgYgDIAo=</id>
+  <extraction>regular</extraction>
+  <parent>vpR4zjT6foxXlZ9V8mKO1WZYP60=</parent>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>int</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+</mrdocs>

--- a/test-files/golden-tests/symbols/record/attributes.cpp
+++ b/test-files/golden-tests/symbols/record/attributes.cpp
@@ -1,0 +1,5 @@
+// Attributes are captured on record symbols.
+struct [[deprecated("use Widget2")]] Widget {};
+
+// A scoped attribute with a single argument.
+struct [[gnu::aligned(16)]] Aligned {};

--- a/test-files/golden-tests/symbols/record/attributes.xml
+++ b/test-files/golden-tests/symbols/record/attributes.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace>
+  <source>
+  </source>
+  <kind>namespace</kind>
+  <id>//////////////////////////8=</id>
+  <extraction>regular</extraction>
+  <namespace-tranche>
+    <records>PQ4j8n/T0THRVULn+iM+q2WWHP4=</records>
+    <records>9thLmlNjyEVo7oVvsZ1FMMqUUjg=</records>
+  </namespace-tranche>
+</namespace>
+<record>
+  <name>Aligned</name>
+  <source>
+    <location>
+      <short-path>attributes.cpp</short-path>
+      <source-path>attributes.cpp</source-path>
+      <line-number>5</line-number>
+      <column-number>1</column-number>
+    </location>
+  </source>
+  <kind>record</kind>
+  <id>PQ4j8n/T0THRVULn+iM+q2WWHP4=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <other-attribute>
+    <name>gnu::aligned</name>
+    <balanced-tokens>16</balanced-tokens>
+  </other-attribute>
+  <key-kind>struct</key-kind>
+  <record-interface>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+  </record-interface>
+</record>
+<record>
+  <name>Widget</name>
+  <source>
+    <location>
+      <short-path>attributes.cpp</short-path>
+      <source-path>attributes.cpp</source-path>
+      <line-number>2</line-number>
+      <column-number>1</column-number>
+    </location>
+  </source>
+  <kind>record</kind>
+  <id>9thLmlNjyEVo7oVvsZ1FMMqUUjg=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <deprecated-attribute>
+    <name>deprecated</name>
+    <balanced-tokens>&quot;use Widget2&quot;</balanced-tokens>
+    <message>use Widget2</message>
+  </deprecated-attribute>
+  <key-kind>struct</key-kind>
+  <record-interface>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+    <record-tranche>
+    </record-tranche>
+  </record-interface>
+</record>
+</mrdocs>

--- a/test-files/golden-tests/symbols/typedef/attributes.cpp
+++ b/test-files/golden-tests/symbols/typedef/attributes.cpp
@@ -1,0 +1,2 @@
+// A deprecated type alias (the motivating case from issue #1233).
+using extension_type [[deprecated("use extent_type")]] = int;

--- a/test-files/golden-tests/symbols/typedef/attributes.xml
+++ b/test-files/golden-tests/symbols/typedef/attributes.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace>
+  <source>
+  </source>
+  <kind>namespace</kind>
+  <id>//////////////////////////8=</id>
+  <extraction>regular</extraction>
+  <namespace-tranche>
+    <typedefs>Nz16WgwQioPGG3IEr5zgZyHBaR4=</typedefs>
+  </namespace-tranche>
+</namespace>
+<typedef>
+  <name>extension_type</name>
+  <source>
+    <location>
+      <short-path>attributes.cpp</short-path>
+      <source-path>attributes.cpp</source-path>
+      <line-number>2</line-number>
+      <column-number>1</column-number>
+    </location>
+  </source>
+  <kind>typedef</kind>
+  <id>Nz16WgwQioPGG3IEr5zgZyHBaR4=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <deprecated-attribute>
+    <name>deprecated</name>
+    <balanced-tokens>&quot;use extent_type&quot;</balanced-tokens>
+    <message>use extent_type</message>
+  </deprecated-attribute>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>int</identifier>
+    </name>
+  </named>
+  <is-using>1</is-using>
+</typedef>
+</mrdocs>

--- a/test-files/golden-tests/symbols/variable/no_unique_address.xml
+++ b/test-files/golden-tests/symbols/variable/no_unique_address.xml
@@ -76,6 +76,12 @@
   <id>h2j8f921HD+Fyaokcs4ndGM/yNk=</id>
   <extraction>regular</extraction>
   <parent>CgGNdHpW5mG/i5741WPYQDw28OQ=</parent>
+  <deprecated-attribute>
+    <name>deprecated</name>
+  </deprecated-attribute>
+  <maybe-unused-attribute>
+    <name>maybe_unused</name>
+  </maybe-unused-attribute>
   <named>
     <name>
       <kind>identifier</kind>
@@ -84,10 +90,6 @@
     </name>
   </named>
   <initializer>Empty{}</initializer>
-  <attributes>deprecated</attributes>
-  <attributes>maybe_unused</attributes>
-  <is-maybe-unused>1</is-maybe-unused>
-  <is-deprecated>1</is-deprecated>
   <is-record-field>1</is-record-field>
 </variable>
 <variable>


### PR DESCRIPTION
Reads attributes for every kind of symbol and shows them in the generated pages. Before, it only read attributes on functions and variables, and a deprecated symbol gave no sign that it was deprecated. For other symbols, it showed nothing. Now every symbol carries its attributes, deprecated symbols get a notice with the message in an admonition, and attributes appear in signatures and member tables. 

Fixes #1233.

## Changes

In the source code, attributes now live on the common symbol base class. Each attribute now contains its name and all its arguments. The templates render them in each signature, add a deprecation notice, and tag deprecated entries in member tables the same way constructors are tagged. The output schema and the golden tests were updated to match.

## Testing

New metadata fixtures cover attribute extraction for each symbol type. A new generator example renders the attributes to AsciiDoc and HTML.

## Documentation

The data model reference section now describes the new attribute fields.


