### PR TITLE
feat: pass extra compiler arguments from the config file

### DIFF
--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -153,6 +153,15 @@
       "title": "Symbol patterns to exclude",
       "type": "array"
     },
+    "extra-compiler-args": {
+      "default": [],
+      "description": "Extra arguments appended to each translation unit's compile command, regardless of the strategy used to generate the compilation database. Use these for compiler options MrDocs does not model directly. The arguments are passed to the compiler verbatim.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Additional command-line arguments passed to the compiler",
+      "type": "array"
+    },
     "extract-all": {
       "default": true,
       "description": "When set to `true`, MrDocs extracts all symbols from the source code, even if no documentation is provided. MrDocs can only identify whether a symbol is ultimated documented after extracting information from all translation units. For this reason, when this option is set to `false`, it's still recommendable to provide file and symbol filters so that only the desired symbols are traversed and stored by MrDocs.",

--- a/src/lib/ConfigOptions.json
+++ b/src/lib/ConfigOptions.json
@@ -74,6 +74,13 @@
         "default": []
       },
       {
+        "name": "extra-compiler-args",
+        "brief": "Additional command-line arguments passed to the compiler",
+        "details": "Extra arguments appended to each translation unit's compile command, regardless of the strategy used to generate the compilation database. Use these for compiler options MrDocs does not model directly. The arguments are passed to the compiler verbatim.",
+        "type": "list<string>",
+        "default": []
+      },
+      {
         "name": "use-system-stdlib",
         "brief": "Use the system C++ standard library",
         "details": "To achieve reproducible results, MrDocs bundles the LibC++ headers. To use the C++ standard library available in the system instead, set this option to true.",

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -373,6 +373,12 @@ adjustCommandLine(
     }
     new_cmdline.emplace_back("-D__MRDOCS__");
 
+    // Additional compiler arguments from the config file
+    for (auto const& arg : (*config)->extraCompilerArgs)
+    {
+        new_cmdline.emplace_back(arg);
+    }
+
     if ((*config)->useSystemStdlib || (*config)->useSystemLibc)
     {
         // ------------------------------------------------------

--- a/test-files/golden-tests/config/extra-compiler-args/extra-compiler-args.cpp
+++ b/test-files/golden-tests/config/extra-compiler-args/extra-compiler-args.cpp
@@ -1,0 +1,7 @@
+#ifdef MRDOCS_EXTRA_ARG
+/// Visible only when MRDOCS_EXTRA_ARG is defined.
+void gated();
+#endif
+
+/// Always visible, regardless of extra compiler arguments.
+void always();

--- a/test-files/golden-tests/config/extra-compiler-args/extra-compiler-args.xml
+++ b/test-files/golden-tests/config/extra-compiler-args/extra-compiler-args.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace>
+  <source>
+  </source>
+  <kind>namespace</kind>
+  <id>//////////////////////////8=</id>
+  <extraction>regular</extraction>
+  <namespace-tranche>
+    <functions>FCl6kQqcum1BJjGHToB834KPI/M=</functions>
+    <functions>Hf4ZEmoq/XgUVgRDrMJKtlEwmtQ=</functions>
+  </namespace-tranche>
+</namespace>
+<function>
+  <name>always</name>
+  <source>
+    <location>
+      <short-path>extra-compiler-args.cpp</short-path>
+      <source-path>extra-compiler-args.cpp</source-path>
+      <line-number>7</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>FCl6kQqcum1BJjGHToB834KPI/M=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>Always visible, regardless of extra compiler arguments.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+<function>
+  <name>gated</name>
+  <source>
+    <location>
+      <short-path>extra-compiler-args.cpp</short-path>
+      <source-path>extra-compiler-args.cpp</source-path>
+      <line-number>3</line-number>
+      <column-number>1</column-number>
+      <documented>1</documented>
+    </location>
+  </source>
+  <kind>function</kind>
+  <id>Hf4ZEmoq/XgUVgRDrMJKtlEwmtQ=</id>
+  <extraction>regular</extraction>
+  <parent>//////////////////////////8=</parent>
+  <doc-comment>
+    <brief>
+      <kind>brief</kind>
+      <text>
+        <kind>text</kind>
+        <literal>Visible only when MRDOCS_EXTRA_ARG is defined.</literal>
+      </text>
+    </brief>
+  </doc-comment>
+  <named>
+    <name>
+      <kind>identifier</kind>
+      <identifier>void</identifier>
+    </name>
+  </named>
+  <func-class>normal</func-class>
+</function>
+</mrdocs>

--- a/test-files/golden-tests/config/extra-compiler-args/extra-compiler-args.yml
+++ b/test-files/golden-tests/config/extra-compiler-args/extra-compiler-args.yml
@@ -1,0 +1,2 @@
+extra-compiler-args:
+  - -DMRDOCS_EXTRA_ARG


### PR DESCRIPTION
This adds support for an `extra-compiler-args` option (a list of strings whose values are appended verbatim to each translation unit's compile command). It is an escape hatch for compiler flags MrDocs does not model directly.

## Changes

- **Source**: `adjustCommandLine()` is extended to append any such arguments as specified in the config file.
- **Golden tests**: A new golden test fixture ensures `-D<macro_name>` reaches the compiler.

## Testing

A new golden test includes a config file that adds the command-line argument `-DMRDOCS_EXTRA_ARG`; the corresponding .cpp file uses that macro to guard a function declaration, and the test checks that the function is included in the XML output.

## Documentation

ConfigOptions.json provides the documentation for the new option.

Closes #9.