### PR TITLE
fix: macro member order

### DIFF
--- a/src/mrdocs/Metadata/Finalizers/SortMembersFinalizer.cpp
+++ b/src/mrdocs/Metadata/Finalizers/SortMembersFinalizer.cpp
@@ -276,33 +276,21 @@ void
 SortMembersFinalizer::
 sortMembers(NamespaceTranche& T)
 {
-    sortMembers(T.Namespaces);
-    sortMembers(T.NamespaceAliases);
-    sortMembers(T.Typedefs);
-    sortMembers(T.Records);
-    sortMembers(T.Enums);
-    sortMembers(T.Functions);
-    sortMembers(T.Variables);
-    sortMembers(T.Concepts);
-    sortMembers(T.Guides);
-    sortMembers(T.Usings);
+    // Sort every member bucket. The lists are discovered by reflection,
+    // so adding a member to NamespaceTranche (e.g. Macros) is sorted
+    // automatically, with no hand-maintained list to keep in sync.
+    describe::for_each_member<NamespaceTranche>([&](auto const d) {
+        sortMembers(T.*d.pointer);
+    });
 }
 
 void
 SortMembersFinalizer::
 sortMembers(RecordTranche& T)
 {
-    sortMembers(T.NamespaceAliases);
-    sortMembers(T.Typedefs);
-    sortMembers(T.Records);
-    sortMembers(T.Enums);
-    sortMembers(T.Functions);
-    sortMembers(T.StaticFunctions);
-    sortMembers(T.Variables);
-    sortMembers(T.StaticVariables);
-    sortMembers(T.Concepts);
-    sortMembers(T.Guides);
-    sortMembers(T.Usings);
+    describe::for_each_member<RecordTranche>([&](auto const d) {
+        sortMembers(T.*d.pointer);
+    });
 }
 
 void

--- a/tests/golden/fixtures/config/exclude-macros/macros-excluded.xml
+++ b/tests/golden/fixtures/config/exclude-macros/macros-excluded.xml
@@ -6,36 +6,9 @@
   <id>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</id>
   <extraction>regular</extraction>
   <members>
-    <macros>25TXh1YkaJx4KSKRnd6vM4Cz56V8 3swZTuggskjgutsth2qaMNHouYwY</macros>
+    <macros>3swZTuggskjgutsth2qaMNHouYwY 25TXh1YkaJx4KSKRnd6vM4Cz56V8</macros>
   </members>
 </namespace>
-<macro>
-  <name>MYLIB_VERSION</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros-excluded.cpp</shortPath>
-      <sourcePath>macros-excluded.cpp</sourcePath>
-      <lineNumber>4</lineNumber>
-      <columnNumber>9</columnNumber>
-      <documented/>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>25TXh1YkaJx4KSKRnd6vM4Cz56V8</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>Public macro, kept.</literal>
-        </text>
-      </children>
-    </brief>
-  </doc>
-</macro>
 <macro>
   <name>MYLIB_ASSERT</name>
   <loc>
@@ -66,5 +39,32 @@
   <parameters>
     <string>x</string>
   </parameters>
+</macro>
+<macro>
+  <name>MYLIB_VERSION</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros-excluded.cpp</shortPath>
+      <sourcePath>macros-excluded.cpp</sourcePath>
+      <lineNumber>4</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>25TXh1YkaJx4KSKRnd6vM4Cz56V8</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>Public macro, kept.</literal>
+        </text>
+      </children>
+    </brief>
+  </doc>
 </macro>
 </mrdocs>

--- a/tests/golden/fixtures/config/exclude-symbols/macros-excluded.xml
+++ b/tests/golden/fixtures/config/exclude-symbols/macros-excluded.xml
@@ -6,36 +6,9 @@
   <id>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</id>
   <extraction>regular</extraction>
   <members>
-    <macros>25TXh1YkaJx4KSKRnd6vM4Cz56V8 3swZTuggskjgutsth2qaMNHouYwY</macros>
+    <macros>3swZTuggskjgutsth2qaMNHouYwY 25TXh1YkaJx4KSKRnd6vM4Cz56V8</macros>
   </members>
 </namespace>
-<macro>
-  <name>MYLIB_VERSION</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros-excluded.cpp</shortPath>
-      <sourcePath>macros-excluded.cpp</sourcePath>
-      <lineNumber>4</lineNumber>
-      <columnNumber>9</columnNumber>
-      <documented/>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>25TXh1YkaJx4KSKRnd6vM4Cz56V8</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>Public macro, kept.</literal>
-        </text>
-      </children>
-    </brief>
-  </doc>
-</macro>
 <macro>
   <name>MYLIB_ASSERT</name>
   <loc>
@@ -66,5 +39,32 @@
   <parameters>
     <string>x</string>
   </parameters>
+</macro>
+<macro>
+  <name>MYLIB_VERSION</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros-excluded.cpp</shortPath>
+      <sourcePath>macros-excluded.cpp</sourcePath>
+      <lineNumber>4</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>25TXh1YkaJx4KSKRnd6vM4Cz56V8</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>Public macro, kept.</literal>
+        </text>
+      </children>
+    </brief>
+  </doc>
 </macro>
 </mrdocs>

--- a/tests/golden/fixtures/config/extract-all-macros/extract-all-macros.xml
+++ b/tests/golden/fixtures/config/extract-all-macros/extract-all-macros.xml
@@ -6,23 +6,39 @@
   <id>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</id>
   <extraction>regular</extraction>
   <members>
-    <macros>tQFuKKgXKZ1UPrAexsi9ALYdgMN 4N9PhViqArL8roP1btrbEg6udQs7 i8TH7jf7ovtrtBTF3HpHBvRTvAg 28RUXy6f87xcyyVYtJrwNuMNbb75</macros>
+    <macros>28RUXy6f87xcyyVYtJrwNuMNbb75 4N9PhViqArL8roP1btrbEg6udQs7 i8TH7jf7ovtrtBTF3HpHBvRTvAg tQFuKKgXKZ1UPrAexsi9ALYdgMN</macros>
   </members>
 </namespace>
 <macro>
-  <name>UNDOC_OBJECT</name>
+  <name>DOC_FUNC</name>
   <loc>
     <defLoc>
       <shortPath>extract-all-macros.cpp</shortPath>
       <sourcePath>extract-all-macros.cpp</sourcePath>
-      <lineNumber>4</lineNumber>
+      <lineNumber>12</lineNumber>
       <columnNumber>9</columnNumber>
+      <documented/>
     </defLoc>
   </loc>
   <kind>macro</kind>
-  <id>tQFuKKgXKZ1UPrAexsi9ALYdgMN</id>
+  <id>28RUXy6f87xcyyVYtJrwNuMNbb75</id>
   <extraction>regular</extraction>
   <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>Documented function-like macro.</literal>
+        </text>
+      </children>
+    </brief>
+  </doc>
+  <isFunctionLike/>
+  <parameters>
+    <string>x</string>
+  </parameters>
 </macro>
 <macro>
   <name>DOC_OBJECT</name>
@@ -71,34 +87,18 @@
   </parameters>
 </macro>
 <macro>
-  <name>DOC_FUNC</name>
+  <name>UNDOC_OBJECT</name>
   <loc>
     <defLoc>
       <shortPath>extract-all-macros.cpp</shortPath>
       <sourcePath>extract-all-macros.cpp</sourcePath>
-      <lineNumber>12</lineNumber>
+      <lineNumber>4</lineNumber>
       <columnNumber>9</columnNumber>
-      <documented/>
     </defLoc>
   </loc>
   <kind>macro</kind>
-  <id>28RUXy6f87xcyyVYtJrwNuMNbb75</id>
+  <id>tQFuKKgXKZ1UPrAexsi9ALYdgMN</id>
   <extraction>regular</extraction>
   <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>Documented function-like macro.</literal>
-        </text>
-      </children>
-    </brief>
-  </doc>
-  <isFunctionLike/>
-  <parameters>
-    <string>x</string>
-  </parameters>
 </macro>
 </mrdocs>

--- a/tests/golden/fixtures/config/extract-all/no-extract-all-macros.xml
+++ b/tests/golden/fixtures/config/extract-all/no-extract-all-macros.xml
@@ -6,36 +6,9 @@
   <id>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</id>
   <extraction>regular</extraction>
   <members>
-    <macros>ifZRvs46MXdbXRNPkmDXUFZWNfX 2MJA7aC2EtYDDyqqWvAzp1EbS7FY</macros>
+    <macros>2MJA7aC2EtYDDyqqWvAzp1EbS7FY ifZRvs46MXdbXRNPkmDXUFZWNfX</macros>
   </members>
 </namespace>
-<macro>
-  <name>DOC_OBJECT</name>
-  <loc>
-    <defLoc>
-      <shortPath>no-extract-all-macros.cpp</shortPath>
-      <sourcePath>no-extract-all-macros.cpp</sourcePath>
-      <lineNumber>6</lineNumber>
-      <columnNumber>9</columnNumber>
-      <documented/>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>ifZRvs46MXdbXRNPkmDXUFZWNfX</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>Documented object-like macro.</literal>
-        </text>
-      </children>
-    </brief>
-  </doc>
-</macro>
 <macro>
   <name>DOC_FUNC</name>
   <loc>
@@ -78,5 +51,32 @@
   <parameters>
     <string>x</string>
   </parameters>
+</macro>
+<macro>
+  <name>DOC_OBJECT</name>
+  <loc>
+    <defLoc>
+      <shortPath>no-extract-all-macros.cpp</shortPath>
+      <sourcePath>no-extract-all-macros.cpp</sourcePath>
+      <lineNumber>6</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>ifZRvs46MXdbXRNPkmDXUFZWNfX</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>Documented object-like macro.</literal>
+        </text>
+      </children>
+    </brief>
+  </doc>
 </macro>
 </mrdocs>

--- a/tests/golden/fixtures/config/include-macros/macros-allowlist.xml
+++ b/tests/golden/fixtures/config/include-macros/macros-allowlist.xml
@@ -6,36 +6,9 @@
   <id>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</id>
   <extraction>regular</extraction>
   <members>
-    <macros>6oML46RphGNbT5N6xF9kXpXn57i n5QAufKQ7hqBwDXk7Ecp6GzZHLE 2MoUpS3Z8krDThUcEryJorBPvsJp</macros>
+    <macros>n5QAufKQ7hqBwDXk7Ecp6GzZHLE 2MoUpS3Z8krDThUcEryJorBPvsJp 6oML46RphGNbT5N6xF9kXpXn57i</macros>
   </members>
 </namespace>
-<macro>
-  <name>MYLIB_VERSION</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros-allowlist.cpp</shortPath>
-      <sourcePath>macros-allowlist.cpp</sourcePath>
-      <lineNumber>6</lineNumber>
-      <columnNumber>9</columnNumber>
-      <documented/>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>6oML46RphGNbT5N6xF9kXpXn57i</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>Public API version.</literal>
-        </text>
-      </children>
-    </brief>
-  </doc>
-</macro>
 <macro>
   <name>MYLIB_ASSERT</name>
   <loc>
@@ -89,6 +62,33 @@
         <text>
           <kind>text</kind>
           <literal>Implementation detail, still under MYLIB_, so still allowed.</literal>
+        </text>
+      </children>
+    </brief>
+  </doc>
+</macro>
+<macro>
+  <name>MYLIB_VERSION</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros-allowlist.cpp</shortPath>
+      <sourcePath>macros-allowlist.cpp</sourcePath>
+      <lineNumber>6</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>6oML46RphGNbT5N6xF9kXpXn57i</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>Public API version.</literal>
         </text>
       </children>
     </brief>

--- a/tests/golden/fixtures/config/multipage/multipage-macros.multipage/adoc/index.adoc
+++ b/tests/golden/fixtures/config/multipage/multipage-macros.multipage/adoc/index.adoc
@@ -16,10 +16,10 @@
 [cols="1,4"]
 |===
 | Name| Description
-| xref:MY_VERSION.adoc[`MY&lowbar;VERSION`] 
-| Object&hyphen;like macro&period;
 | xref:MY_INC.adoc[`MY&lowbar;INC`] 
 | Function&hyphen;like macro&period;
+| xref:MY_VERSION.adoc[`MY&lowbar;VERSION`] 
+| Object&hyphen;like macro&period;
 |===
 
 

--- a/tests/golden/fixtures/config/multipage/multipage-macros.multipage/html/index.html
+++ b/tests/golden/fixtures/config/multipage/multipage-macros.multipage/html/index.html
@@ -25,8 +25,8 @@
 <tr><th>Name</th><th>Description</th></tr>
 </thead>
 <tbody>
-<tr><td><a href="./MY_VERSION.html"><code>MY_VERSION</code></a> </td><td>Object-like macro.</td></tr>
 <tr><td><a href="./MY_INC.html"><code>MY_INC</code></a> </td><td>Function-like macro.</td></tr>
+<tr><td><a href="./MY_VERSION.html"><code>MY_VERSION</code></a> </td><td>Object-like macro.</td></tr>
 </tbody>
 </table>
 

--- a/tests/golden/fixtures/symbols/macro/macros-edge-cases.xml
+++ b/tests/golden/fixtures/symbols/macro/macros-edge-cases.xml
@@ -6,9 +6,49 @@
   <id>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</id>
   <extraction>regular</extraction>
   <members>
-    <macros>taiRsNxDnEPbGDX6TUAdTGe8FsT 2gZEKEXddibTYTDBviFnMfz3ri1H 2RxkLvemUQ3X8C4baVnh1hcpUDq1 2CjEHzyvJeernxCXkT7QGgKDP22D 3hM8jc31JWkocdaQKVddcEVJSd7F</macros>
+    <macros>2CjEHzyvJeernxCXkT7QGgKDP22D taiRsNxDnEPbGDX6TUAdTGe8FsT 2gZEKEXddibTYTDBviFnMfz3ri1H 2RxkLvemUQ3X8C4baVnh1hcpUDq1 3hM8jc31JWkocdaQKVddcEVJSd7F</macros>
   </members>
 </namespace>
+<macro>
+  <name>DOC_THEN_BLANK</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros-edge-cases.cpp</shortPath>
+      <sourcePath>macros-edge-cases.cpp</sourcePath>
+      <lineNumber>26</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>2CjEHzyvJeernxCXkT7QGgKDP22D</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>Documentation for </literal>
+        </text>
+        <code>
+          <kind>code</kind>
+          <children>
+            <text>
+              <kind>text</kind>
+              <literal>DOC_THEN_BLANK</literal>
+            </text>
+          </children>
+        </code>
+        <text>
+          <kind>text</kind>
+          <literal>; one blank line separates this comment from the macro definition.</literal>
+        </text>
+      </children>
+    </brief>
+  </doc>
+</macro>
 <macro>
   <name>FIRST_THING_IN_FILE</name>
   <loc>
@@ -53,46 +93,6 @@
   <id>2RxkLvemUQ3X8C4baVnh1hcpUDq1</id>
   <extraction>regular</extraction>
   <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-</macro>
-<macro>
-  <name>DOC_THEN_BLANK</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros-edge-cases.cpp</shortPath>
-      <sourcePath>macros-edge-cases.cpp</sourcePath>
-      <lineNumber>26</lineNumber>
-      <columnNumber>9</columnNumber>
-      <documented/>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>2CjEHzyvJeernxCXkT7QGgKDP22D</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>Documentation for </literal>
-        </text>
-        <code>
-          <kind>code</kind>
-          <children>
-            <text>
-              <kind>text</kind>
-              <literal>DOC_THEN_BLANK</literal>
-            </text>
-          </children>
-        </code>
-        <text>
-          <kind>text</kind>
-          <literal>; one blank line separates this comment from the macro definition.</literal>
-        </text>
-      </children>
-    </brief>
-  </doc>
 </macro>
 <macro>
   <name>SAME_LINE</name>

--- a/tests/golden/fixtures/symbols/macro/macros-embedded.xml
+++ b/tests/golden/fixtures/symbols/macro/macros-embedded.xml
@@ -6,36 +6,9 @@
   <id>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</id>
   <extraction>regular</extraction>
   <members>
-    <macros>vdpMVAYZuWBsRhcnASK83Yx5S4F 2dFYE4LwLyAkA3uA7Kd4gfZhuyLt</macros>
+    <macros>2dFYE4LwLyAkA3uA7Kd4gfZhuyLt vdpMVAYZuWBsRhcnASK83Yx5S4F</macros>
   </members>
 </namespace>
-<macro>
-  <name>EMBED_OBJECT</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros-embedded.cpp</shortPath>
-      <sourcePath>macros-embedded.cpp</sourcePath>
-      <lineNumber>8</lineNumber>
-      <columnNumber>9</columnNumber>
-      <documented/>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>vdpMVAYZuWBsRhcnASK83Yx5S4F</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>A simple object-like macro.</literal>
-        </text>
-      </children>
-    </brief>
-  </doc>
-</macro>
 <macro>
   <name>EMBED_FUNC</name>
   <loc>
@@ -78,5 +51,32 @@
   <parameters>
     <string>x</string>
   </parameters>
+</macro>
+<macro>
+  <name>EMBED_OBJECT</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros-embedded.cpp</shortPath>
+      <sourcePath>macros-embedded.cpp</sourcePath>
+      <lineNumber>8</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>vdpMVAYZuWBsRhcnASK83Yx5S4F</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>A simple object-like macro.</literal>
+        </text>
+      </children>
+    </brief>
+  </doc>
 </macro>
 </mrdocs>

--- a/tests/golden/fixtures/symbols/macro/macros-multi-file.xml
+++ b/tests/golden/fixtures/symbols/macro/macros-multi-file.xml
@@ -6,24 +6,9 @@
   <id>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</id>
   <extraction>regular</extraction>
   <members>
-    <macros>QG5iRzeDE2tatU6QHB3vtFnqFhG 2vqFfC4Y3Y3Ru4FxrrfLh9FYKv8S</macros>
+    <macros>2vqFfC4Y3Y3Ru4FxrrfLh9FYKv8S QG5iRzeDE2tatU6QHB3vtFnqFhG</macros>
   </members>
 </namespace>
-<macro>
-  <name>SHARED_MACRO</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros-multi-file.hpp</shortPath>
-      <sourcePath>macros-multi-file.hpp</sourcePath>
-      <lineNumber>5</lineNumber>
-      <columnNumber>9</columnNumber>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>QG5iRzeDE2tatU6QHB3vtFnqFhG</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-</macro>
 <macro>
   <name>SHARED_MACRO</name>
   <loc>
@@ -36,6 +21,21 @@
   </loc>
   <kind>macro</kind>
   <id>2vqFfC4Y3Y3Ru4FxrrfLh9FYKv8S</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+</macro>
+<macro>
+  <name>SHARED_MACRO</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros-multi-file.hpp</shortPath>
+      <sourcePath>macros-multi-file.hpp</sourcePath>
+      <lineNumber>5</lineNumber>
+      <columnNumber>9</columnNumber>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>QG5iRzeDE2tatU6QHB3vtFnqFhG</id>
   <extraction>regular</extraction>
   <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
 </macro>

--- a/tests/golden/fixtures/symbols/macro/macros.xml
+++ b/tests/golden/fixtures/symbols/macro/macros.xml
@@ -6,81 +6,9 @@
   <id>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</id>
   <extraction>regular</extraction>
   <members>
-    <macros>3KokfPfZXiD4EAfFZytrfCT6Qjxr idKKNbHYquVJgZX7GPChW7WYqSh 3XnVYwGqrtnkzT5sMaWVCDsKLdD2 bNPfz3TBGnpgJaxGa5wc1r85hq7 gbEzDQ11PFhDs5EXfjVsHNukAc5 4Q7TTx3mZusx1BmztiXtcv41BEPz 4F6vnNtWjsCJvAspRPpFz3FtrdA3 4Fbi3tQEeTohxw38nyq4Ju4oFmzj 2mse2tzUeyDpF8QrLzMBXzyzhUUm 3g9xse138ygnrEV7iXMcAhvEwHzP 3uc94queU1WFsN6HZDjAQbRedRwv 2EefAggSG8L7H4vHJtCnn85PFMfw 3Syex11XobpE3ALhGXqz1zpq97TH 2YmbqbEZhyx5i19pKEaBDjHm4yKS 3ec1weFMC8QuRH2sXH5b8jFFozUR 3kxr1ifc8LVeq2pHKi7RFJoMJBEC 4YvEmEyzaDiEZ22KKjKi8pPZFqN5 2DeCzuXQbMbRRHU6BnKV9exULsuV 2Q78jvu4FSWoSEUrSMNs6wmhxSvK nsoUTEXNh8agVJaaYL2Hb2SnmiW</macros>
+    <macros>gbEzDQ11PFhDs5EXfjVsHNukAc5 2mse2tzUeyDpF8QrLzMBXzyzhUUm 4YvEmEyzaDiEZ22KKjKi8pPZFqN5 bNPfz3TBGnpgJaxGa5wc1r85hq7 3KokfPfZXiD4EAfFZytrfCT6Qjxr 3XnVYwGqrtnkzT5sMaWVCDsKLdD2 4Q7TTx3mZusx1BmztiXtcv41BEPz 4F6vnNtWjsCJvAspRPpFz3FtrdA3 3kxr1ifc8LVeq2pHKi7RFJoMJBEC 3g9xse138ygnrEV7iXMcAhvEwHzP 2EefAggSG8L7H4vHJtCnn85PFMfw 2Q78jvu4FSWoSEUrSMNs6wmhxSvK nsoUTEXNh8agVJaaYL2Hb2SnmiW idKKNbHYquVJgZX7GPChW7WYqSh 2YmbqbEZhyx5i19pKEaBDjHm4yKS 3uc94queU1WFsN6HZDjAQbRedRwv 3Syex11XobpE3ALhGXqz1zpq97TH 4Fbi3tQEeTohxw38nyq4Ju4oFmzj 3ec1weFMC8QuRH2sXH5b8jFFozUR 2DeCzuXQbMbRRHU6BnKV9exULsuV</macros>
   </members>
 </namespace>
-<macro>
-  <name>FOO</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>3</lineNumber>
-      <columnNumber>9</columnNumber>
-      <documented/>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>3KokfPfZXiD4EAfFZytrfCT6Qjxr</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>A documentation comment.</literal>
-        </text>
-      </children>
-    </brief>
-  </doc>
-</macro>
-<macro>
-  <name>PI</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>4</lineNumber>
-      <columnNumber>9</columnNumber>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>idKKNbHYquVJgZX7GPChW7WYqSh</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-</macro>
-<macro>
-  <name>GREETING</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>5</lineNumber>
-      <columnNumber>9</columnNumber>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>3XnVYwGqrtnkzT5sMaWVCDsKLdD2</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-</macro>
-<macro>
-  <name>EMPTY</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>8</lineNumber>
-      <columnNumber>9</columnNumber>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>bNPfz3TBGnpgJaxGa5wc1r85hq7</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-</macro>
 <macro>
   <name>ADD</name>
   <loc>
@@ -134,6 +62,131 @@
     <string>a</string>
     <string>b</string>
   </parameters>
+</macro>
+<macro>
+  <name>ANSWER</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>30</lineNumber>
+      <columnNumber>9</columnNumber>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>2mse2tzUeyDpF8QrLzMBXzyzhUUm</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+</macro>
+<macro>
+  <name>DUP</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>96</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>4YvEmEyzaDiEZ22KKjKi8pPZFqN5</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>Duplicate parameter documentation.</literal>
+        </text>
+      </children>
+    </brief>
+    <params>
+      <param>
+        <kind>param</kind>
+        <children>
+          <text>
+            <kind>text</kind>
+            <literal>One thing.</literal>
+          </text>
+        </children>
+        <name>x</name>
+      </param>
+      <param>
+        <kind>param</kind>
+        <children>
+          <text>
+            <kind>text</kind>
+            <literal>Same thing again.</literal>
+          </text>
+        </children>
+        <name>x</name>
+      </param>
+    </params>
+  </doc>
+  <isFunctionLike/>
+  <parameters>
+    <string>x</string>
+  </parameters>
+</macro>
+<macro>
+  <name>EMPTY</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>8</lineNumber>
+      <columnNumber>9</columnNumber>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>bNPfz3TBGnpgJaxGa5wc1r85hq7</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+</macro>
+<macro>
+  <name>FOO</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>3</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>3KokfPfZXiD4EAfFZytrfCT6Qjxr</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>A documentation comment.</literal>
+        </text>
+      </children>
+    </brief>
+  </doc>
+</macro>
+<macro>
+  <name>GREETING</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>5</lineNumber>
+      <columnNumber>9</columnNumber>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>3XnVYwGqrtnkzT5sMaWVCDsKLdD2</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
 </macro>
 <macro>
   <name>LOG</name>
@@ -225,289 +278,6 @@
   <isVariadic/>
 </macro>
 <macro>
-  <name>VLOG</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>27</lineNumber>
-      <columnNumber>9</columnNumber>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>4Fbi3tQEeTohxw38nyq4Ju4oFmzj</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <isFunctionLike/>
-  <isVariadic/>
-</macro>
-<macro>
-  <name>ANSWER</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>30</lineNumber>
-      <columnNumber>9</columnNumber>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>2mse2tzUeyDpF8QrLzMBXzyzhUUm</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-</macro>
-<macro>
-  <name>MIN</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>36</lineNumber>
-      <columnNumber>9</columnNumber>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>3g9xse138ygnrEV7iXMcAhvEwHzP</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <isFunctionLike/>
-  <parameters>
-    <string>a</string>
-    <string>b</string>
-  </parameters>
-</macro>
-<macro>
-  <name>SQUARE</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>44</lineNumber>
-      <columnNumber>12</columnNumber>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>3uc94queU1WFsN6HZDjAQbRedRwv</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <isFunctionLike/>
-  <parameters>
-    <string>x</string>
-  </parameters>
-</macro>
-<macro>
-  <name>MISALIGNED</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>52</lineNumber>
-      <columnNumber>12</columnNumber>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>2EefAggSG8L7H4vHJtCnn85PFMfw</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <isFunctionLike/>
-  <parameters>
-    <string>x</string>
-  </parameters>
-</macro>
-<macro>
-  <name>SUM</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>59</lineNumber>
-      <columnNumber>9</columnNumber>
-      <documented/>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>3Syex11XobpE3ALhGXqz1zpq97TH</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>Sum a variadic list of values.</literal>
-        </text>
-      </children>
-    </brief>
-    <params>
-      <param>
-        <kind>param</kind>
-        <children>
-          <text>
-            <kind>text</kind>
-            <literal>The values to sum.</literal>
-          </text>
-        </children>
-        <name>...</name>
-      </param>
-    </params>
-  </doc>
-  <isFunctionLike/>
-  <isVariadic/>
-</macro>
-<macro>
-  <name>PRINTF</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>67</lineNumber>
-      <columnNumber>9</columnNumber>
-      <documented/>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>2YmbqbEZhyx5i19pKEaBDjHm4yKS</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>Variadic </literal>
-        </text>
-        <code>
-          <kind>code</kind>
-          <children>
-            <text>
-              <kind>text</kind>
-              <literal>printf</literal>
-            </text>
-          </children>
-        </code>
-        <text>
-          <kind>text</kind>
-          <literal> wrapper, documenting the variadic argument list with the conventional </literal>
-        </text>
-        <code>
-          <kind>code</kind>
-          <children>
-            <text>
-              <kind>text</kind>
-              <literal>...</literal>
-            </text>
-          </children>
-        </code>
-        <text>
-          <kind>text</kind>
-          <literal> form.</literal>
-        </text>
-      </children>
-    </brief>
-    <params>
-      <param>
-        <kind>param</kind>
-        <children>
-          <text>
-            <kind>text</kind>
-            <literal>The format string.</literal>
-          </text>
-        </children>
-        <name>fmt</name>
-      </param>
-      <param>
-        <kind>param</kind>
-        <children>
-          <text>
-            <kind>text</kind>
-            <literal>Format arguments.</literal>
-          </text>
-        </children>
-        <name>...</name>
-      </param>
-    </params>
-  </doc>
-  <isFunctionLike/>
-  <parameters>
-    <string>fmt</string>
-  </parameters>
-  <isVariadic/>
-</macro>
-<macro>
-  <name>VPRINTF</name>
-  <loc>
-    <defLoc>
-      <shortPath>macros.cpp</shortPath>
-      <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>75</lineNumber>
-      <columnNumber>9</columnNumber>
-      <documented/>
-    </defLoc>
-  </loc>
-  <kind>macro</kind>
-  <id>3ec1weFMC8QuRH2sXH5b8jFFozUR</id>
-  <extraction>regular</extraction>
-  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>Variadic printf wrapper, documented with the explicit </literal>
-        </text>
-        <code>
-          <kind>code</kind>
-          <children>
-            <strong>
-              <kind>strong</kind>
-              <children>
-                <text>
-                  <kind>text</kind>
-                  <literal>VA_ARGS</literal>
-                </text>
-              </children>
-            </strong>
-          </children>
-        </code>
-        <text>
-          <kind>text</kind>
-          <literal> name.</literal>
-        </text>
-      </children>
-    </brief>
-    <params>
-      <param>
-        <kind>param</kind>
-        <children>
-          <text>
-            <kind>text</kind>
-            <literal>The format string.</literal>
-          </text>
-        </children>
-        <name>fmt</name>
-      </param>
-      <param>
-        <kind>param</kind>
-        <children>
-          <text>
-            <kind>text</kind>
-            <literal>Format arguments.</literal>
-          </text>
-        </children>
-        <name>__VA_ARGS__</name>
-      </param>
-    </params>
-  </doc>
-  <isFunctionLike/>
-  <parameters>
-    <string>fmt</string>
-  </parameters>
-  <isVariadic/>
-</macro>
-<macro>
   <name>MEDIAN3</name>
   <loc>
     <defLoc>
@@ -553,96 +323,39 @@
   </parameters>
 </macro>
 <macro>
-  <name>DUP</name>
+  <name>MIN</name>
   <loc>
     <defLoc>
       <shortPath>macros.cpp</shortPath>
       <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>96</lineNumber>
+      <lineNumber>36</lineNumber>
       <columnNumber>9</columnNumber>
-      <documented/>
     </defLoc>
   </loc>
   <kind>macro</kind>
-  <id>4YvEmEyzaDiEZ22KKjKi8pPZFqN5</id>
+  <id>3g9xse138ygnrEV7iXMcAhvEwHzP</id>
   <extraction>regular</extraction>
   <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>Duplicate parameter documentation.</literal>
-        </text>
-      </children>
-    </brief>
-    <params>
-      <param>
-        <kind>param</kind>
-        <children>
-          <text>
-            <kind>text</kind>
-            <literal>One thing.</literal>
-          </text>
-        </children>
-        <name>x</name>
-      </param>
-      <param>
-        <kind>param</kind>
-        <children>
-          <text>
-            <kind>text</kind>
-            <literal>Same thing again.</literal>
-          </text>
-        </children>
-        <name>x</name>
-      </param>
-    </params>
-  </doc>
   <isFunctionLike/>
   <parameters>
-    <string>x</string>
+    <string>a</string>
+    <string>b</string>
   </parameters>
 </macro>
 <macro>
-  <name>WRONG_PARAM</name>
+  <name>MISALIGNED</name>
   <loc>
     <defLoc>
       <shortPath>macros.cpp</shortPath>
       <sourcePath>macros.cpp</sourcePath>
-      <lineNumber>103</lineNumber>
-      <columnNumber>9</columnNumber>
-      <documented/>
+      <lineNumber>52</lineNumber>
+      <columnNumber>12</columnNumber>
     </defLoc>
   </loc>
   <kind>macro</kind>
-  <id>2DeCzuXQbMbRRHU6BnKV9exULsuV</id>
+  <id>2EefAggSG8L7H4vHJtCnn85PFMfw</id>
   <extraction>regular</extraction>
   <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
-  <doc>
-    <brief>
-      <kind>brief</kind>
-      <children>
-        <text>
-          <kind>text</kind>
-          <literal>Documentation that names a parameter the macro does not actually have.</literal>
-        </text>
-      </children>
-    </brief>
-    <params>
-      <param>
-        <kind>param</kind>
-        <children>
-          <text>
-            <kind>text</kind>
-            <literal>Not actually a parameter of WRONG_PARAM.</literal>
-          </text>
-        </children>
-        <name>y</name>
-      </param>
-    </params>
-  </doc>
   <isFunctionLike/>
   <parameters>
     <string>x</string>
@@ -739,5 +452,292 @@
       </param>
     </params>
   </doc>
+</macro>
+<macro>
+  <name>PI</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>4</lineNumber>
+      <columnNumber>9</columnNumber>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>idKKNbHYquVJgZX7GPChW7WYqSh</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+</macro>
+<macro>
+  <name>PRINTF</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>67</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>2YmbqbEZhyx5i19pKEaBDjHm4yKS</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>Variadic </literal>
+        </text>
+        <code>
+          <kind>code</kind>
+          <children>
+            <text>
+              <kind>text</kind>
+              <literal>printf</literal>
+            </text>
+          </children>
+        </code>
+        <text>
+          <kind>text</kind>
+          <literal> wrapper, documenting the variadic argument list with the conventional </literal>
+        </text>
+        <code>
+          <kind>code</kind>
+          <children>
+            <text>
+              <kind>text</kind>
+              <literal>...</literal>
+            </text>
+          </children>
+        </code>
+        <text>
+          <kind>text</kind>
+          <literal> form.</literal>
+        </text>
+      </children>
+    </brief>
+    <params>
+      <param>
+        <kind>param</kind>
+        <children>
+          <text>
+            <kind>text</kind>
+            <literal>The format string.</literal>
+          </text>
+        </children>
+        <name>fmt</name>
+      </param>
+      <param>
+        <kind>param</kind>
+        <children>
+          <text>
+            <kind>text</kind>
+            <literal>Format arguments.</literal>
+          </text>
+        </children>
+        <name>...</name>
+      </param>
+    </params>
+  </doc>
+  <isFunctionLike/>
+  <parameters>
+    <string>fmt</string>
+  </parameters>
+  <isVariadic/>
+</macro>
+<macro>
+  <name>SQUARE</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>44</lineNumber>
+      <columnNumber>12</columnNumber>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>3uc94queU1WFsN6HZDjAQbRedRwv</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <isFunctionLike/>
+  <parameters>
+    <string>x</string>
+  </parameters>
+</macro>
+<macro>
+  <name>SUM</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>59</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>3Syex11XobpE3ALhGXqz1zpq97TH</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>Sum a variadic list of values.</literal>
+        </text>
+      </children>
+    </brief>
+    <params>
+      <param>
+        <kind>param</kind>
+        <children>
+          <text>
+            <kind>text</kind>
+            <literal>The values to sum.</literal>
+          </text>
+        </children>
+        <name>...</name>
+      </param>
+    </params>
+  </doc>
+  <isFunctionLike/>
+  <isVariadic/>
+</macro>
+<macro>
+  <name>VLOG</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>27</lineNumber>
+      <columnNumber>9</columnNumber>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>4Fbi3tQEeTohxw38nyq4Ju4oFmzj</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <isFunctionLike/>
+  <isVariadic/>
+</macro>
+<macro>
+  <name>VPRINTF</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>75</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>3ec1weFMC8QuRH2sXH5b8jFFozUR</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>Variadic printf wrapper, documented with the explicit </literal>
+        </text>
+        <code>
+          <kind>code</kind>
+          <children>
+            <strong>
+              <kind>strong</kind>
+              <children>
+                <text>
+                  <kind>text</kind>
+                  <literal>VA_ARGS</literal>
+                </text>
+              </children>
+            </strong>
+          </children>
+        </code>
+        <text>
+          <kind>text</kind>
+          <literal> name.</literal>
+        </text>
+      </children>
+    </brief>
+    <params>
+      <param>
+        <kind>param</kind>
+        <children>
+          <text>
+            <kind>text</kind>
+            <literal>The format string.</literal>
+          </text>
+        </children>
+        <name>fmt</name>
+      </param>
+      <param>
+        <kind>param</kind>
+        <children>
+          <text>
+            <kind>text</kind>
+            <literal>Format arguments.</literal>
+          </text>
+        </children>
+        <name>__VA_ARGS__</name>
+      </param>
+    </params>
+  </doc>
+  <isFunctionLike/>
+  <parameters>
+    <string>fmt</string>
+  </parameters>
+  <isVariadic/>
+</macro>
+<macro>
+  <name>WRONG_PARAM</name>
+  <loc>
+    <defLoc>
+      <shortPath>macros.cpp</shortPath>
+      <sourcePath>macros.cpp</sourcePath>
+      <lineNumber>103</lineNumber>
+      <columnNumber>9</columnNumber>
+      <documented/>
+    </defLoc>
+  </loc>
+  <kind>macro</kind>
+  <id>2DeCzuXQbMbRRHU6BnKV9exULsuV</id>
+  <extraction>regular</extraction>
+  <parent>4ZrjxJnU1LA5xSyrWMNuXTvSYKwt</parent>
+  <doc>
+    <brief>
+      <kind>brief</kind>
+      <children>
+        <text>
+          <kind>text</kind>
+          <literal>Documentation that names a parameter the macro does not actually have.</literal>
+        </text>
+      </children>
+    </brief>
+    <params>
+      <param>
+        <kind>param</kind>
+        <children>
+          <text>
+            <kind>text</kind>
+            <literal>Not actually a parameter of WRONG_PARAM.</literal>
+          </text>
+        </children>
+        <name>y</name>
+      </param>
+    </params>
+  </doc>
+  <isFunctionLike/>
+  <parameters>
+    <string>x</string>
+  </parameters>
 </macro>
 </mrdocs>


### PR DESCRIPTION
Macros showed up in extraction order instead of sorted. The member sort walked a handwritten list of tranches that never got the macros, so macros were skipped. This PR walks the buckets by reflection instead, so macros come out sorted, and any bucket added later is covered without touching the sort.

## Changes

The member sort now covers every tranche of a member group with reflection rather than a fixed list. The macro fixtures were regenerated and now list macros in sorted order.

## Testing

The regenerated macro fixtures cover the ordering and run on every build.

## Documentation

This is a fix. No documentation changes needed.
